### PR TITLE
Design of the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # BlackJAX
 
+# Build a NUTS sampler in 3 lines of code
+
+```python
+from blackjax import nuts
+from jax import random
+
+init_position, inv_mass_matrix = get_position()
+
+parameters = nuts.new_parameters(inv_mass_matrix)  # has default value of step_size and num_integration_steps
+init_state = nuts.new_state(init_position, logpdf)
+nuts_kernel = nuts.kernel(logpdf, parameters)
+
+rng_key = jax.random.PRNGKey(2020)
+new_state, info = nuts_kernel(rng_key, init_state)
+```
+
 # How to contribute?
 
 1. `pip install -r requirements-dev.txt`

--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -1,0 +1,117 @@
+"""Public API for the HMC Kernel"""
+from typing import Callable, NamedTuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax.inference.base as base
+import blackjax.inference.integrators as integrators
+import blackjax.inference.metrics as metrics
+import blackjax.inference.proposals as proposals
+
+Array = Union[np.array, jnp.DeviceArray]
+
+
+class HMCParameters(NamedTuple):
+    step_size: float
+    inv_mass_matrix: Array
+    num_integration_steps: int
+
+
+def new_states(position: jax.pytree, logpdf: Callable):
+    """Create chain states from positions.
+
+    The HMC kernel works with states that contain the current chain position
+    and its associated potential energy and derivative of the potential energy.
+    This function computes initial states from an initial position.
+
+    While this function is intended to work for one chain, it is possible to
+    use `jax.vmap` to compute the initial state of several chains.
+
+    Example
+    -------
+    Let us assume a model with two random variables. We wish to sample from
+    4 chains with the following initial positions:
+
+        >>> import numpy as np
+        >>> init_positions = (np.random.rand(4, 1000), np.random.rand(4, 300))
+
+    We have a `logpdf` function that returns the log-probability associated with
+    the chain at a given position:
+
+        >>> logpdf((np.random.rand(1000), np.random.rand(3000)))
+        -3.4
+
+    We can compute the initial state for each of the 4 chain as follows:
+
+        >>> import jax
+        >>> jax.vmap(new_states, in_axes=(0, None))(init_positions, logpdf)
+
+    Parameters
+    ----------
+    position
+        The current values of the random variables whose posterior we want to
+        sample from. Can be anything from a list, a (named) tuple or a dict of
+        arrays. The arrays can either be Numpy arrays or JAX DeviceArrays.
+    logpdf
+        The joint log-probability function of the model.
+
+    Returns
+    -------
+    A HMC state that contains the position, the associated potential energy and gradient of the
+    potential energy.
+
+    """
+    potential_fn = lambda x: -logpdf(x)
+    potential_energy, potential_energy_grad = jax.value_and_grad(potential_fn)(position)
+    return base.HMCState(position, potential_energy, potential_energy_grad)
+
+
+def new_parameters(
+    inv_mass_matrix: Array,
+    step_size: float = 1e-3,
+    num_integration_steps: int = 30,
+) -> HMCParameters:
+    """Create a new set of parameters.
+
+    Wrapping this in a function is convenient. It gives us more leeway on the
+    parameters' internal representation, allows us to provide defaults and to
+    perform some checks.
+
+    """
+    try:
+        step_size = float(step_size)
+    except ValueError:
+        raise ValueError(f"Could not convert `step_size` to float: {step_size}")
+
+    try:
+        num_integration_steps = int(num_integration_steps)
+    except ValueError:
+        raise ValueError(
+            f"Could not convert `num_integration_steps` to int {num_integration_steps}"
+        )
+
+    return HMCParameters(step_size, inv_mass_matrix, num_integration_steps)
+
+
+def kernel(logpdf: Callable, parameters: HMCParameters) -> Callable:
+    """Build a HMC kernel.
+
+    The details won't probably speak to you now, and we will dicuss the internals soon.
+    The most important for now is that users do not need to be aware of these internals
+    to have a good HMC or NUTS kernel.
+
+    This clear separation means that we can provide easy-to-use tools at the same time as
+    modular and re-usable building blocks.
+
+    """
+    potential_fn = lambda x: -logpdf(x)
+    step_size, inv_mass_matrix, num_integration_steps = parameters
+
+    momentum_generator, kinetic_energy_fn = metrics.gaussian_euclidean(inv_mass_matrix)
+    integrator = integrators.velocity_verlet(potential_fn, kinetic_energy_fn)
+    proposal = proposals.hmc(integrator, step_size, num_integration_steps)
+    kernel = base.hmc(proposal, momentum_generator, kinetic_energy_fn, potential_fn)
+
+    return kernel

--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -14,7 +14,17 @@ Array = Union[np.array, jnp.DeviceArray]
 
 
 class HMCParameters(NamedTuple):
-    """This could also be a dataclass that checks type with __post_init__"""
+    """This could also be a dataclass that checks type with __post_init__
+
+    The only issue with this is that dataclasses are not registered as
+    pytrees automatically (https://github.com/google/jax/issues/2371), which
+    means you would not be able to vmap through parameters, which is useful
+    when sampling from chains that have been independently warmed up.
+
+    I believe the best solution is still to initialize the parameters with
+    a function that checks for the values.
+
+    """
     step_size: float = 1e-3
     num_integration_steps: int = 30
     inv_mass_matrix: Array = None
@@ -81,7 +91,7 @@ def kernel(logpdf: Callable, parameters: HMCParameters) -> Callable:
 
     """
     potential_fn = lambda x: -logpdf(x)
-    step_size, inv_mass_matrix, num_integration_steps = parameters
+    step_size, num_integration_steps, inv_mass_matrix = parameters
 
     if not inv_mass_matrix:
         raise ValueError(

--- a/blackjax/nuts.py
+++ b/blackjax/nuts.py
@@ -1,0 +1,63 @@
+"""Public API for the NUTS kernel
+
+My only question here is: do we expose both recursive and iterative NUTS?
+
+"""
+from typing import Callable, NamedTuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax.hmc
+import blackjax.inference.base as base
+import blackjax.inference.integrators as integrators
+import blackjax.inference.metrics as metrics
+import blackjax.inference.proposals as proposals
+
+Array = Union[np.array, jnp.DeviceArray]
+
+
+class NUTSParameters(NamedTuple):
+    step_size: float
+    inv_mass_matrix: Array
+    max_tree_depth: int
+
+
+new_states = blackjax.hmc.new_states
+
+
+def new_parameters(
+    inv_mass_matrix: Array, step_size: float = 1e-3, max_tree_depth=10
+) -> NUTSParameters:
+    try:
+        step_size = float(step_size)
+    except ValueError:
+        raise ValueError(f"Could not convert `step_size` to float: {step_size}")
+
+    try:
+        max_tree_depth = int(max_tree_depth)
+    except ValueError:
+        raise ValueError(
+            f"Could not convert `num_integration_steps` to int {max_tree_depth}"
+        )
+
+    return NUTSParameters(step_size, inv_mass_matrix, max_tree_depth)
+
+
+def kernel(logpdf: Callable, parameters: NUTSParameters) -> Callable:
+    """Build an iterative NUTS kernel.
+
+    Note that only the line corresponding to the proposal differs from the HMC
+    kernel defined in `hmc.py`.
+
+    """
+    potential_fn = lambda x: -logpdf(x)
+    step_size, inv_mass_matrix, max_tree_depth = parameters
+
+    momentum_generator, kinetic_energy_fn = metrics.gaussian_euclidean(inv_mass_matrix)
+    integrator = integrators.velocity_verlet(potential_fn, kinetic_energy_fn)
+    proposal = proposals.nuts(integrator, step_size, max_tree_depth)
+    kernel = base.hmc(proposal, momentum_generator, kinetic_energy_fn, potential_fn)
+
+    return kernel

--- a/blackjax/window_adaptation.py
+++ b/blackjax/window_adaptation.py
@@ -1,0 +1,211 @@
+"""Public API for the window adaptation.
+
+Exposing a public API for the window adaptation is slightly trickier as there
+are more moving pieces than in the kernel.
+"""
+from typing import Callable, List, NamedTuple, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+
+import blackjax.adaptation.mass_matrix as adapt_mass_matrix
+import blackjax.adaptation.schedules as schedules
+import blackjax.adaptation.step_size as adapt_step_size
+import blackjax.hmc as hmc
+import blackjax.inference.base as base
+import blackjax.nuts as nuts
+
+
+class WindowAdaptationState(NamedTuple):
+    dual_averaging_state: adapt_step_size.DualAveragingState
+    inv_covariance_state: adapt_mass_matrix.InverseCovarianceState
+
+
+def window_adaptation(
+    rng_key: jax.random.PRNGKey,
+    kernel_factory: Callable[[Callable, Union[hmc.HMCParameters, nuts.NUTSParameters]], Callable],
+    logpdf: Callable,
+    init_state: base.HMCState,
+    init_parameters: Union[hmc.HMCParameters, nuts.NUTSParameters],
+    num_warmup_steps: int = 500,
+    is_mass_matrix_diagonal: bool = True,
+):
+    """Warmup scheme for sampling procedures based on euclidean manifold HMC.
+    The schedule and algorithms used match Stan's [1]_ as closely as possible.
+
+    Unlike several other libraries, we separate the warmup and sampling phases
+    explicitly. This ensure a better modularity; a change in the warmup does
+    not affect the sampling. It also allows users to run their own warmup
+    should they want to.
+
+    Stan's warmup consists in the three following phases:
+
+    1. A fast adaptation window where only the step size is adapted using
+    Nesterov's dual averaging scheme to match a target acceptance rate.
+    2. A succession of slow adapation windows (where the size of a window
+    is double that of the previous window) where both the mass matrix and the step size
+    are adapted. The mass matrix is recomputed at the end of each window; the step
+    size is re-initialized to a "reasonable" value.
+    3. A last fast adaptation window where only the step size is adapted.
+
+    Schematically:
+
+    ```
+    +---------+---+------+------------+------------------------+------+
+    |  fast   | s | slow |   slow     |        slow            | fast |
+    +---------+---+------+------------+------------------------+------+
+    1         2   3      3            3                        3
+    ```
+
+    Step (1) consists in find a "reasonable" first step size that is used to
+    initialize the dual averaging scheme. In (2) we initialize the mass matrix
+    to the matrix. In (3) we compute the mass matrix to use in the kernel and
+    re-initialize the mass matrix adaptation. The step size is still adapated
+    in slow adaptation windows, and is not re-initialized between windows.
+
+    Parameters
+    ----------
+    rng_key
+        Key for the pseudo-random number generator.
+    kernel_factory:
+        A function which returns a transition kernel given a logpdf and a HMCParameters or
+        NUTSParameters tuple. It can return an HMC kernel, a NUTS kernel and it does not
+        matter which kernel will be used later. You can use NUTS to adapt HMC's parameters.
+    logpdf
+        Fuction that returns the log-probability of a given chain position.
+    init_state
+        Initial state of the chain.
+    init_parameters:
+        Initial parameters for the kernel.
+    num_warmup_steps:
+        Number of warmup steps to run.
+    is_mass_matrix_diagonal
+        Create and adapt a diagonal mass matrix if True, a dense matrix otherwise.
+
+    Returns
+    -------
+    init
+        Function that initializes the warmup.
+    update
+        Function that moves the warmup one step.
+    final
+        Function that returns the step size and mass matrix given a warmup state.
+    """
+    potential = lambda x: -logpdf(x)
+    kernel_from_params = jax.partial(kernel_factory, potential)
+
+    dual_averaging_init, dual_averaging_update = adapt_step_size.dual_averagin()
+    (
+        inv_covariance_init,  # wow that's black gone wild here
+        inv_covariance_update,
+        inv_covariance_final,
+    ) = adapt_mass_matrix.inv_covariance(is_mass_matrix_diagonal)
+
+    def adapt_init(
+        rng_key: jax.random.PRNGKey,
+        initial_state: base.HMCState,
+        initial_parameters,
+    ):
+        mm_state = inv_covariance_init(initial_state)
+
+        step_size = adapt_step_size.find_reasonable_step_size(
+            rng_key,
+            kernel_factory,
+            initial_state,
+            init_parameters,
+        )
+        da_state = dual_averaging_init(step_size)
+
+        warmup_state = WindowAdaptationState(da_state, mm_state)
+
+        return warmup_state
+
+    def adapt_update(
+        rng_key: jax.random.PRNGKey,
+        chain_state: base.HMCState,
+        warmup_state: WindowAdaptationState,
+        warmup_stage: Tuple[int, bool],
+    ) -> Tuple[base.HMCState, WindowAdaptationState, base.HMCInfo]:
+        """Move the warmup by one step.
+        We first create a new kernel with the current values of the step size
+        and mass matrix and move the chain one step. Then, depending on the
+        stage passed as an argument we execute either the fast or slow interval
+        update. Finally we execute the final update of the slow interval depending
+        on whether we are at the end of the window.
+        Parameters
+        ----------
+        rng_key
+            The key used in JAX's random number generator.
+        stage
+            The current stage of the warmup. 0 for the fast interval, 1 for the
+            slow interval.
+        is_middle_window_end
+            True if this step is the last of a slow adaptation interval.
+        chain_state
+            Current state of the chain.
+        warmup
+            Current warmup state.
+        Returns
+        -------
+        The updated states of the chain and the warmup.
+        """
+        stage, is_middle_window_end = warmup_stage
+        dual_averaging_state, inv_covariance_state = warmup_state
+
+        step_size = jnp.exp(dual_averaging_state.log_step_size)
+        inv_mass_matrix = inv_covariance_state.inverse_mass_matrix
+        kernel = kernel_from_params(
+            init_parameters._replace(
+                step_size=step_size, inv_mass_matrix=inv_mass_matrix
+            )
+        )
+
+        chain_state, chain_info = kernel(rng_key, chain_state)
+
+        warmup_state = jax.lax.switch(
+            stage,
+            (dual_averaging_update, inv_covariance_update),
+            (rng_key, chain_state, chain_info, warmup_state),
+        )
+
+        warmup_state = jax.lax.cond(
+            is_middle_window_end,
+            inv_covariance_final,  # this is not exactly true, but a small detail here
+            lambda x: x,
+            warmup_state,
+        )
+
+        return chain_state, warmup_state, chain_info
+
+    def adapt_final(
+        warmup_state: WindowAdaptationState,
+    ) -> Union[hmc.HMCParameters, nuts.NUTSParameters]:
+        """Return the initial parameters with updated mass matrix and step size."""
+        dual_averaging_state, inv_covariance_state = warmup_state
+        step_size = jnp.exp(dual_averaging_state.log_step_size_avg)
+        inv_mass_matrix = inv_covariance_state.inv_mass_matrix
+        return init_parameters._replace(
+            step_size=step_size, inv_mass_matrix=inv_mass_matrix
+        )
+
+    # Separating the code this way makes the flow more obvious.
+
+    schedule = jnp.array(schedules.stan_window_adaptation)
+    state, warmup_state = adapt_init(rng_key, init_state, init_parameters)
+
+    def one_step(carry, warmup_stage):
+        rng_key, state, warmup_state = carry
+        _, rng_key = jax.random.split(rng_key)
+        state, warmup_state, info = adapt_update(
+            rng_key, state, warmup_state, warmup_stage
+        )
+        return (rng_key, state, warmup_state), (state, warmup_state, info)
+
+    last_carry, warmup_chain = jax.lax.scan(
+        one_step, (rng_key, state, warmup_state), schedule
+    )
+    _, last_state, last_warmup_state = last_carry
+
+    parameters = adapt_final(warmup_state)
+
+    return last_state, parameters, warmup_chain

--- a/blackjax/window_adaptation.py
+++ b/blackjax/window_adaptation.py
@@ -112,7 +112,7 @@ def window_adaptation(
             rng_key,
             kernel_factory,
             initial_state,
-            init_parameters,
+            initial_parameters,
         )
         da_state = dual_averaging_init(step_size)
 

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,6 @@ setuptools.setup(
     install_requires=[
         "jax==0.2.7",
         "jaxlib==0.1.57",
+        "numpy==1.19.4",
     ],
 )


### PR DESCRIPTION
We choose to start working on the library by defining the public interface. Defining pre-built kernels has several advantages:

- It forces us to settle on a reasonable interface with which the internals will need to work;
- They are a good entry points in the library. Probably what people would like to try first, for most of them these pre-built algorithms will be enough;
- Since their behavior is known, these are a good target for integration tests and benchmarking. As a result they will come with some guarantees of robustness and performance.

BlackJAX will expose two objects publicly: kernels (NUTS and HMC) as well as Stan's window adaptation scheme. In this PR we define these objects' public API. You can look at the code in this PR for the proposed implementation. I discuss some of the points I judged important below.

# Example use

One would create and run a (HMC) kernel as in:

```python
from blackjax import hmc
from jax import random

rng_key = jax.random.PRNGKey(2020)
init_position, inv_mass_matrix = get_position()

parameters = hmc.new_parameters(inv_mass_matrix)  # has default value of step_size and num_integration_steps
init_state = hmc.new_state(init_position, logpdf)
hmc_kernel = hmc.kernel(logpdf, parameters)

new_state, info = hmc_kernel(rng_key, init_state)
```

Note that I said *a* kernel. BlackJAX returns one kernel, that runs one chain. The execution loop and batching is done user-side. While everyone more or less agrees on what should go in a general-purpose NUTS or HMC kernel, I don't want to force my opinionated choice on the users for batching and looping. And I suspect users who do not want to bother with this mechanic would use their favorite modeling language.

*The choice to JIT-compile or not the kernel is left to the user.*

# Interface

## logpdf or potential

Do we require a logpdf or a potential_fn to create the kernel? I used `logpdf` in the example above in the code because this a potentially confusing one. I am not opposed to `potential_fn` since it simplifies the code a little. Maybe someone with more experience could chime in?

## I/O

A crucial point is the I/O: how should the initial values of the random variables be passed? What do we get as an output? This is where JAX and its pytrees shine, really. Users would have to respect the following constraints:

- The state of the chain needs to be contained in either a list, a (named) tuple or a dictionary of arrays. The arrays can indifferently be Numpy arrays or JAX DeviceArrays;
- If the state is called `x` then `logpdf(x)` must return the value of the log-probability at position `x`.

These constraints are rather loose, and suit most existing application with little to no modifications. As an output, `state.position` returns the current values of random variables in the same format they were passed in.

 Let's do a tour of 3 of the PPLs involved in this project, see if they would have do change anything (correct me if I'm wrong).

### Numpyro

Numpyro's potential takes a dictionary as an argument; the state of the chain is passed around in a dictionary. It would work as is.

### PyMC3

PyMC3's potential is a function of the random variables; the state of the chain is passed around as a list. It would have to pass the function `lambda x: logpdf_pymc3(*x)` to BlackJAX's kernels if it wanted to keep the same format for the state of its chains.

### MCX

MCX's potential is a function of the random variables; the state of the chain is passed around as a dictionary. I would have to pass the function `lambda x: logpdf_mcx(**x)` to BlackJAX's kernel if it wanted to keep the same format for the state of its chains.

## state, info

We separate the state of the chain from additional information about the transition. This allows user to choose whether they want to keep it or discard it at each step. This is the pattern followed in MCX.

The state in a NamedTuple with fields `position`, `potential_energy`, `potential_energy_grad`. The last 2 avoid wasteful computations. The arrays in `position` are JAX DeviceArrays.

The info is a nested NamedTuple. For instance in MCX:

```python
class HMCInfo(NamedTuple):
	proposed_state: HMCProposedState
    acceptance_probability: float
    is_accepted: bool
    is_divergent: bool
    energy: float
    proposal_info: HMCProposalInfo
```
`proposal_info` is where info about the NUTS transition would be stored (number of leapfrog steps taken, etc.). Some of the info is used internally, some is included in the trace and everything else is discarded.

Everything else is in this PR's code.

# Adaptation

Exposing a simple API for Stan's window adaptation is no small feat. Here is the simplest example possible where the user has full control over the looping/batching:

```python
import jax

from blackjax import window_adaptation
import blackjax.hmc as hmc


rng_key = jax.random.PRNGKey(2020)
num_warmup_steps = 1_000
init_position = get_position()

init_parameters = hmc.new_parameters()
init_state = hmc.new_state(init_position, logpdf)

init, update, final = window_adaptation(logpdf, hmc.kernel, num_warmup_steps)
state, warmup_state = init(rng_key, init_parameters, init_state)

for _ in range(num_warmup_steps):
    _, rng_key = jax.random.split(rng_key)
    state, warmup_state = update(rng_key, state, warmup_state)

parameters = final(warmup_state)
```

However I am not sure that even to adapt multiple chains the user needs to have control over the inner loop. We could thus take care of the updating loop ourselves, thus simplifying the API a lot. `window_adaptation` becomes a big function so the previous example would look like:

```python
import jax

from blackjax import window_adaptation
import blackjax.hmc as hmc


rng_key = jax.random.PRNGKey(2020)
num_warmup_steps = 1_000

init_position = get_position()
init_state = hmc.new_state(init_position, logpdf)

init_parameters = hmc.new_parameters()
state, parameters, warmup_chain = window_adaptation(rng_key, hmc.kernel, logpdf, init_state, init_parameters, num_warmup_steps)
```

Users can adapt the parameters of several chains by vmap-ing over the `rng_key`, `init_state` and `init_parameters`. The current code implements this design. It is shown with no guarantee of actually working, but it gives the general idea of what needs to be implemented, how it relates to the core, and how complex it is.

_With hindsight this does not allow users to add a progress bar so we should probably go with the first solution._

# Misc questions

- Do we expose both recursive and iterative NUTS?

# Next steps

Once we've agreed on the API I suggest to take HMC and run with it, open a discussion on the internals and get something running quickly. Tests can be set up simultaneously, targeting the publicly exposed HMC.