### PR TITLE
implement the HMC kernel

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -1,1 +1,5 @@
+from . import inference
+
 __version__ = "0.0.1"
+
+__all__ = ["inference"]

--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -1,5 +1,5 @@
-from . import inference
+from . import hmc, inference
 
 __version__ = "0.0.1"
 
-__all__ = ["inference"]
+__all__ = ["hmc", "inference"]

--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -10,7 +10,7 @@ import blackjax.inference.integrators as integrators
 import blackjax.inference.metrics as metrics
 import blackjax.inference.proposals as proposals
 
-Array = Union[np.array, jnp.DeviceArray]
+Array = Union[np.ndarray, jnp.DeviceArray]
 PyTree = Union[Dict, List, Tuple]
 
 

--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -1,0 +1,101 @@
+"""Public API for the HMC Kernel"""
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax.inference.base as base
+import blackjax.inference.integrators as integrators
+import blackjax.inference.metrics as metrics
+import blackjax.inference.proposals as proposals
+
+Array = Union[np.array, jnp.DeviceArray]
+PyTree = Union[Dict, List, Tuple]
+
+
+class HMCParameters(NamedTuple):
+    step_size: float = 1e-3
+    num_integration_steps: int = 30
+    inv_mass_matrix: Array = None
+    divergence_threshold: int = 1000
+
+
+def new_states(position: PyTree, potential_fn: Callable) -> base.HMCState:
+    """Create chain states from positions.
+
+    The HMC kernel works with states that contain the current chain position
+    and its associated potential energy and derivative of the potential energy.
+    This function computes initial states from an initial position.  While this
+    function is intended to work for one chain, it is possible to use
+    `jax.vmap` to compute the initial state of several chains.
+
+    Example
+    -------
+    Let us assume a model with two random variables. We wish to sample from
+    4 chains with the following initial positions:
+
+        >>> import numpy as np
+        >>> init_positions = (np.random.rand(4, 1000), np.random.rand(4, 300))
+
+    We have a `logpdf` function that returns the log-probability associated with
+    the chain at a given position:
+
+        >>> potential_fn((np.random.rand(1000), np.random.rand(3000)))
+        -3.4
+
+    We can compute the initial state for each of the 4 chain as follows:
+
+        >>> import jax
+        >>> jax.vmap(new_states, in_axes=(0, None))(init_positions, potential_fn)
+
+    Parameters
+    ----------
+    position
+        The current values of the random variables whose posterior we want to
+        sample from. Can be anything from a list, a (named) tuple or a dict of
+        arrays. The arrays can either be Numpy arrays or JAX DeviceArrays.
+    potential_fn
+        A function that returns the value of the potential energy when called
+        with a position.
+
+    Returns
+    -------
+    A HMC state that contains the position, the associated potential energy and gradient of the
+    potential energy.
+    """
+    potential_energy, potential_energy_grad = jax.value_and_grad(potential_fn)(position)
+    return base.HMCState(position, potential_energy, potential_energy_grad)
+
+
+def kernel(potential_fn: Callable, parameters: HMCParameters) -> Callable:
+    """Build a HMC kernel.
+
+    Parameters
+    ----------
+    potential_fn
+        A function that returns the potential energy of a chain at a given position.
+    parameters
+        A NamedTuple that contains the parameters of the kernel to be built.
+    """
+    step_size, num_integration_steps, inv_mass_matrix, divergence_threshold = parameters
+
+    if not inv_mass_matrix:
+        raise ValueError(
+            "Expected a value for `inv_mass_matrix`,"
+            " got None. Please specify a value when initializing"
+            " the parameters or run the window adaptation."
+        )
+
+    momentum_generator, kinetic_energy_fn = metrics.gaussian_euclidean(inv_mass_matrix)
+    integrator = integrators.velocity_verlet(potential_fn, kinetic_energy_fn)
+    proposal = proposals.hmc(integrator, step_size, num_integration_steps)
+    kernel = base.hmc(
+        potential_fn,
+        proposal,
+        momentum_generator,
+        kinetic_energy_fn,
+        divergence_threshold,
+    )
+
+    return kernel

--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -80,7 +80,7 @@ def kernel(potential_fn: Callable, parameters: HMCParameters) -> Callable:
     """
     step_size, num_integration_steps, inv_mass_matrix, divergence_threshold = parameters
 
-    if not inv_mass_matrix:
+    if inv_mass_matrix is None:
         raise ValueError(
             "Expected a value for `inv_mass_matrix`,"
             " got None. Please specify a value when initializing"

--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -91,7 +91,6 @@ def kernel(potential_fn: Callable, parameters: HMCParameters) -> Callable:
     integrator = integrators.velocity_verlet(potential_fn, kinetic_energy_fn)
     proposal = proposals.hmc(integrator, step_size, num_integration_steps)
     kernel = base.hmc(
-        potential_fn,
         proposal,
         momentum_generator,
         kinetic_energy_fn,

--- a/blackjax/inference/__init__.py
+++ b/blackjax/inference/__init__.py
@@ -1,0 +1,3 @@
+from . import integrators
+
+__all__ = ["integrators"]

--- a/blackjax/inference/base.py
+++ b/blackjax/inference/base.py
@@ -145,7 +145,7 @@ def hmc(
 
         position, potential_energy, potential_energy_grad = state
         momentum = momentum_generator(key_momentum, position)
-        energy = potential_energy + kinetic_energy(momentum)
+        energy = potential_energy + kinetic_energy(momentum, position)
 
         proposal, proposal_info = proposal_generator(
             key_integrator, HMCProposalState(position, momentum, potential_energy_grad)
@@ -154,7 +154,9 @@ def hmc(
 
         flipped_momentum = -1.0 * new_momentum
         new_potential_energy = potential_fn(new_position)
-        new_energy = new_potential_energy + kinetic_energy(flipped_momentum)
+        new_energy = new_potential_energy + kinetic_energy(
+            flipped_momentum, new_position
+        )
         new_state = HMCState(
             new_position, new_potential_energy, new_potential_energy_grad
         )

--- a/blackjax/inference/base.py
+++ b/blackjax/inference/base.py
@@ -152,7 +152,7 @@ def hmc(
         )
         new_position, new_momentum, new_potential_energy_grad = proposal
 
-        flipped_momentum = -1.0 * new_momentum
+        flipped_momentum = jax.tree_util.tree_multimap(lambda m: -1.0 * m, new_momentum)
         new_potential_energy = potential_fn(new_position)
         new_energy = new_potential_energy + kinetic_energy(
             flipped_momentum, new_position

--- a/blackjax/inference/base.py
+++ b/blackjax/inference/base.py
@@ -1,0 +1,198 @@
+"""Base kernel for the HMC family."""
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.inference.proposals import HMCProposalInfo, HMCProposalState
+
+__all__ = ["HMCState", "HMCInfo", "hmc"]
+
+PyTree = Union[Dict, List, Tuple]
+
+
+class HMCState(NamedTuple):
+    """State of the HMC algorithm.
+
+    The HMC algorithm takes one position of the chain and returns another
+    position. In order to make computations more efficient, we also store
+    the current potential energy as well as the current gradient of the
+    potential energy.
+    """
+
+    position: PyTree
+    potential_energy: float
+    potential_energy_grad: PyTree
+
+
+class HMCInfo(NamedTuple):
+    """Additional information on the HMC transition.
+
+    This additional information can be used for debugging or computing
+    diagnostics.
+
+    acceptance_probability
+        The acceptance probability of the transition, linked to the energy
+        difference between the original and the proposed states.
+    is_accepted
+        Whether the proposed position was accepted or the original position
+        was returned.
+    is_divergent
+        Whether the difference in energy between the original and the new state
+        exceeded the divergence threshold.
+    energy
+        The total energy that corresponds to the returned state.
+    proposal
+        The state proposed by the proposal. Typically includes the position and
+        momentum.
+    proposal_info
+        Information returned by the proposal. Typically includes the step size,
+        number of integration steps and intermediate states.
+    """
+
+    acceptance_probability: float
+    is_accepted: bool
+    is_divergent: bool
+    energy: float
+    proposal: HMCProposalState
+    proposal_info: HMCProposalInfo
+
+
+def hmc(
+    potential_fn: Callable,
+    proposal_generator: Callable,
+    momentum_generator: Callable,
+    kinetic_energy: Callable,
+    divergence_threshold: float = 1000.0,
+) -> Callable:
+    """Create a Hamiltonian Monte Carlo transition kernel.
+
+    Hamiltonian Monte Carlo (HMC) is known to yield effective Markov
+    transitions and has been a major empirical success, leading to an extensive
+    use in probabilistic programming languages and libraries [1,2,3]_.
+
+    HMC works by augmenting the state space in which the chain evolves with an
+    auxiliary momentum :math:`p`. At each step of the chain we draw a momentum
+    value from the `momentum_generator` function. We then use Hamilton's
+    equations [4]_ to push the state forward; we then compute the new state's
+    energy using the `kinetic_energy` function and `logpdf` (potential energy).
+    While the hamiltonian dynamics is conservative, numerical integration can
+    introduce some discrepancy; we perform a Metropolis acceptance test to
+    compensate for integration errors after having flipped the new state's
+    momentum to make the transition reversible.
+
+    I encourage anyone interested in the theoretical underpinning of the method
+    to read Michael Betancourts' excellent introduction [3]_ and his more
+    technical paper [5]_ on the geometric foundations of the method.
+
+    This implementation is very general and should accomodate most variations
+    on the method.
+
+    Parameters
+    ----------
+    proposal_generator:
+        The function used to propose a new state for the chain. For vanilla HMC this
+        function integrates the trajectory over many steps, but gets more involved
+        with other algorithms such as empirical and dynamical HMC.
+    momentum_generator:
+        A function that returns a new value for the momentum when called.
+    kinetic_energy:
+        A function that computes the current state's kinetic energy.
+    potential:
+        The potential function that is being explored, equal to minus the likelihood.
+    divergence_threshold:
+        The maximum difference in energy between the initial and final state
+        after which we consider the transition to be divergent.
+
+    Returns
+    -------
+    A kernel that moves the chain by one step when called.
+
+    References
+    ----------
+    .. [1]: Duane, Simon, et al. "Hybrid monte carlo." Physics letters B
+            195.2 (1987): 216-222.
+    .. [2]: Neal, Radford M. "An improved acceptance procedure for the
+            hybrid Monte Carlo algorithm." Journal of Computational Physics 111.1
+            (1994): 194-203.
+    .. [3]: Betancourt, Michael. "A conceptual introduction to
+            Hamiltonian Monte Carlo." arXiv preprint arXiv:1701.02434 (2018).
+    .. [4]: "Hamiltonian Mechanics", Wikipedia.
+            https://en.wikipedia.org/wiki/Hamiltonian_mechanics#Deriving_Hamilton's_equations
+    .. [5]: Betancourt, Michael, et al. "The geometric foundations
+            of hamiltonian monte carlo." Bernoulli 23.4A (2017): 2257-2298.
+
+    """
+
+    def kernel(
+        rng_key: jax.random.PRNGKey, state: HMCState
+    ) -> Tuple[HMCState, HMCInfo]:
+        """Moves the chain by one step using the Hamiltonian dynamics.
+
+        Parameters
+        ----------
+        rng_key:
+           The pseudo-random number generator key used to generate random numbers.
+        state:
+            The current state of the chain: position, log-probability and gradient
+            of the log-probability.
+
+        Returns
+        -------
+        The next state of the chain and additional information about the current step.
+        """
+        key_momentum, key_integrator, key_accept = jax.random.split(rng_key, 3)
+
+        position, potential_energy, potential_energy_grad = state
+        momentum = momentum_generator(key_momentum, position)
+        energy = potential_energy + kinetic_energy(momentum)
+
+        proposal, proposal_info = proposal_generator(
+            key_integrator, HMCProposalState(position, momentum, potential_energy_grad)
+        )
+        new_position, new_momentum, new_potential_energy_grad = proposal
+
+        flipped_momentum = -1.0 * new_momentum
+        new_potential_energy = potential_fn(new_position)
+        new_energy = new_potential_energy + kinetic_energy(flipped_momentum)
+        new_state = HMCState(
+            new_position, new_potential_energy, new_potential_energy_grad
+        )
+
+        delta_energy = energy - new_energy
+        delta_energy = jnp.where(jnp.isnan(delta_energy), -jnp.inf, delta_energy)
+        is_divergent = jnp.abs(delta_energy) > divergence_threshold
+
+        p_accept = jnp.clip(jnp.exp(delta_energy), a_max=1)
+        do_accept = jax.random.bernoulli(key_accept, p_accept)
+        accept_state = (
+            new_state,
+            HMCInfo(
+                p_accept,
+                True,
+                is_divergent,
+                new_energy,
+                proposal,
+                proposal_info,
+            ),
+        )
+        reject_state = (
+            state,
+            HMCInfo(
+                p_accept,
+                False,
+                is_divergent,
+                energy,
+                proposal,
+                proposal_info,
+            ),
+        )
+        return jax.lax.cond(
+            do_accept,
+            accept_state,
+            lambda state: state,
+            reject_state,
+            lambda state: state,
+        )
+
+    return kernel

--- a/blackjax/inference/integrators.py
+++ b/blackjax/inference/integrators.py
@@ -1,0 +1,80 @@
+"""Symplectic, time-reversible, integrators for Hamiltonian trajectories."""
+from typing import Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+__all__ = ["velocity_verlet"]
+
+
+class IntegratorState(NamedTuple):
+    position: jnp.DeviceArray
+    momentum: jnp.DeviceArray
+    log_prob_grad: float
+
+
+def velocity_verlet(potential_fn: Callable, kinetic_energy_fn: Callable) -> Callable:
+    """The velocity Verlet (or Verlet-Störmer) integrator.
+
+    The velocity Verlet is a two-stage palindromic integrator [1]_ of the form
+    (a1, b1, a2, b1, a1) with a1 = 0. It is numerically stable for values of
+    the step size that range between 0 and 2 (when the mass matrix is the
+    identity).
+
+    While the position (a1 = 0.5) and velocity Verlet are the most commonly used
+    in samplers, it is known in the numerical computation literature that the value
+    $a1 \approx 0.1932$ leads to a lower integration error [2,3]_. The authors of [1]_
+    show that the value $a1 \approx 0.21132$ leads to an even higher step acceptance
+    rate, up to 3 times higher than with the standard position verlet (p.22, Fig.4).
+
+    By choosing the velocity verlet we avoid two computations of the gradient
+    of the kinetic energy. We are trading accuracy in exchange, and it is not
+    clear whether this is the right tradeoff.
+
+
+    References
+    ----------
+    .. [1]: Bou-Rabee, Nawaf, and Jesús Marıa Sanz-Serna. "Geometric
+            integrators and the Hamiltonian Monte Carlo method." Acta Numerica 27
+            (2018): 113-206.
+    .. [2]: McLachlan, Robert I. "On the numerical integration of ordinary
+            differential equations by symmetric composition methods." SIAM Journal on
+            Scientific Computing 16.1 (1995): 151-168.
+    .. [3]: Schlick, Tamar. Molecular modeling and simulation: an
+            interdisciplinary guide: Vol. 21. Springer
+            Science & Business Media, 2010.
+
+    """
+    a1 = 0
+    b1 = 0.5
+    a2 = 1 - 2 * a1
+
+    potential_grad_fn = jax.jit(jax.grad(potential_fn))
+    kinetic_energy_grad_fn = jax.jit(jax.grad(kinetic_energy_fn))
+
+    def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
+        position, momentum, log_prob_grad = state
+
+        momentum = jax.tree_util.tree_multimap(
+            lambda momentum, log_prob_grad: momentum - b1 * step_size * log_prob_grad,
+            momentum,
+            log_prob_grad,
+        )
+
+        kinetic_grad = kinetic_energy_grad_fn(momentum)
+        position = jax.tree_util.tree_multimap(
+            lambda position, kinetic_grad: position + a2 * step_size * kinetic_grad,
+            position,
+            kinetic_grad,
+        )
+
+        log_prob_grad = potential_grad_fn(position)
+        momentum = jax.tree_util.tree_multimap(
+            lambda momentum, log_prob_grad: momentum - b1 * step_size * log_prob_grad,
+            momentum,
+            log_prob_grad,
+        )
+
+        return IntegratorState(position, momentum, log_prob_grad)
+
+    return one_step

--- a/blackjax/inference/integrators.py
+++ b/blackjax/inference/integrators.py
@@ -54,8 +54,8 @@ def velocity_verlet(
     b1 = 0.5
     a2 = 1 - 2 * a1
 
-    potential_grad_fn = jax.jit(jax.grad(potential_fn))
-    kinetic_energy_grad_fn = jax.jit(jax.grad(kinetic_energy_fn))
+    potential_grad_fn = jax.grad(potential_fn)
+    kinetic_energy_grad_fn = jax.grad(kinetic_energy_fn)
 
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
         position, momentum, log_prob_grad = state

--- a/blackjax/inference/integrators.py
+++ b/blackjax/inference/integrators.py
@@ -1,16 +1,17 @@
 """Symplectic, time-reversible, integrators for Hamiltonian trajectories."""
-from typing import Callable, NamedTuple
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
 
 import jax
-import jax.numpy as jnp
 
 __all__ = ["velocity_verlet"]
 
+PyTree = Union[Dict, List, Tuple]
+
 
 class IntegratorState(NamedTuple):
-    position: jnp.DeviceArray
-    momentum: jnp.DeviceArray
-    log_prob_grad: float
+    position: PyTree
+    momentum: PyTree
+    log_prob_grad: PyTree
 
 
 def velocity_verlet(potential_fn: Callable, kinetic_energy_fn: Callable) -> Callable:

--- a/blackjax/inference/integrators.py
+++ b/blackjax/inference/integrators.py
@@ -3,6 +3,8 @@ from typing import Callable, Dict, List, NamedTuple, Tuple, Union
 
 import jax
 
+from blackjax.inference.metrics import EuclideanKineticEnergy
+
 __all__ = ["velocity_verlet"]
 
 PyTree = Union[Dict, List, Tuple]
@@ -14,7 +16,9 @@ class IntegratorState(NamedTuple):
     log_prob_grad: PyTree
 
 
-def velocity_verlet(potential_fn: Callable, kinetic_energy_fn: Callable) -> Callable:
+def velocity_verlet(
+    potential_fn: Callable, kinetic_energy_fn: EuclideanKineticEnergy
+) -> Callable:
     """The velocity Verlet (or Verlet-Störmer) integrator.
 
     The velocity Verlet is a two-stage palindromic integrator [1]_ of the form

--- a/blackjax/inference/metrics.py
+++ b/blackjax/inference/metrics.py
@@ -27,11 +27,12 @@ from jax.tree_util import tree_flatten
 __all__ = ["gaussian_euclidean"]
 
 PyTree = Union[Dict, List, Tuple]
+EuclideanKineticEnergy = Callable[[PyTree], float]
 
 
 def gaussian_euclidean(
     inverse_mass_matrix: jnp.DeviceArray,
-) -> Tuple[Callable, Callable]:
+) -> Tuple[Callable, EuclideanKineticEnergy]:
     r"""Hamiltonian dynamic on euclidean manifold with normally-distributed momentum.
 
     The gaussian euclidean metric is a euclidean metric further characterized
@@ -65,7 +66,7 @@ def gaussian_euclidean(
             momentum = jnp.multiply(std, mass_matrix_sqrt)
             return treedef.unflatten(momentum)
 
-        def kinetic_energy(momentum: PyTree) -> float:
+        def kinetic_energy(momentum: PyTree, *_) -> float:
             momentum, _ = tree_flatten(momentum)
             velocity = jnp.multiply(inverse_mass_matrix, momentum)
             return 0.5 * jnp.dot(velocity, momentum)
@@ -82,7 +83,7 @@ def gaussian_euclidean(
             momentum = jnp.dot(std, mass_matrix_sqrt)
             return treedef.unflatten(momentum)
 
-        def kinetic_energy(momentum: PyTree) -> float:
+        def kinetic_energy(momentum: PyTree, *_) -> float:
             momentum, _ = tree_flatten(momentum)
             velocity = jnp.matmul(inverse_mass_matrix, momentum)
             return 0.5 * jnp.dot(velocity, momentum)

--- a/blackjax/inference/metrics.py
+++ b/blackjax/inference/metrics.py
@@ -1,0 +1,111 @@
+r"""Metric space in which the Hamiltonian dynamic is embedded.
+
+An important particular case (and the most used in practice) of metric for the
+position space in the Euclidean metric. It is defined by a definite positive
+matrix :math:`M` with fixed value so that the kinetic energy of the hamiltonian
+dynamic is independent of the position and only depends on the momentum
+:math:`p` [1]_.
+
+For a Newtonian hamiltonian dynamic the kinetic energy is given by:
+
+.. math::
+    K(p) = \frac{1}{2} p^T M^{-1} p
+
+References
+----------
+.. [1]: Betancourt, Michael, et al. "The geometric foundations of hamiltonian
+        monte carlo." Bernoulli 23.4A (2017): 2257-2298.
+
+"""
+from typing import Callable, Dict, List, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import jax.scipy as scipy
+from jax.tree_util import tree_flatten
+
+__all__ = ["gaussian_euclidean"]
+
+PyTree = Union[Dict, List, Tuple]
+
+
+def gaussian_euclidean(
+    inverse_mass_matrix: jnp.DeviceArray,
+) -> Tuple[Callable, Callable]:
+    r"""Hamiltonian dynamic on euclidean manifold with normally-distributed momentum.
+
+    The gaussian euclidean metric is a euclidean metric further characterized
+    by setting the conditional probability density :math:`\pi(momentum|position)`
+    to follow a standard gaussian distribution. A Newtonian hamiltonian
+    dynamics is assumed.
+
+    Arguments
+    ---------
+    inverse_mass_matrix
+        One of two-dimensional array corresponding respectively to a diagonal
+        or dense mass matrix.
+
+    References
+    ----------
+    .. [1]: Betancourt, Michael. "A general metric for Riemannian manifold
+            Hamiltonian Monte Carlo." International Conference on Geometric Science of
+            Information. Springer, Berlin, Heidelberg, 2013.
+
+    """
+    ndim = jnp.ndim(inverse_mass_matrix)
+    shape = jnp.shape(inverse_mass_matrix)[:1]
+
+    if ndim == 1:  # diagonal mass matrix
+
+        mass_matrix_sqrt = jnp.sqrt(jnp.reciprocal(inverse_mass_matrix))
+
+        def momentum_generator(rng_key: jax.random.PRNGKey, position: PyTree) -> PyTree:
+            _, treedef = tree_flatten(position)
+            std = jax.random.normal(rng_key, shape)
+            momentum = jnp.multiply(std, mass_matrix_sqrt)
+            return treedef.unflatten(momentum)
+
+        def kinetic_energy(momentum: PyTree) -> float:
+            momentum, _ = tree_flatten(momentum)
+            velocity = jnp.multiply(inverse_mass_matrix, momentum)
+            return 0.5 * jnp.dot(velocity, momentum)
+
+        return momentum_generator, kinetic_energy
+
+    elif ndim == 2:
+
+        mass_matrix_sqrt = cholesky_of_inverse(inverse_mass_matrix)
+
+        def momentum_generator(rng_key: jax.random.PRNGKey, position: PyTree) -> PyTree:
+            _, treedef = tree_flatten(position)
+            std = jax.random.normal(rng_key, shape)
+            momentum = jnp.dot(std, mass_matrix_sqrt)
+            return treedef.unflatten(momentum)
+
+        def kinetic_energy(momentum: PyTree) -> float:
+            momentum, _ = tree_flatten(momentum)
+            velocity = jnp.matmul(inverse_mass_matrix, momentum)
+            return 0.5 * jnp.dot(velocity, momentum)
+
+        return momentum_generator, kinetic_energy
+
+    else:
+        raise ValueError(
+            "The mass matrix has the wrong number of dimensions:"
+            f" expected 1 or 2, got {jnp.dim(inverse_mass_matrix)}."
+        )
+
+
+# Sourced from numpyro.distributions.utils.py
+# Copyright Contributors to the NumPyro project.
+# SPDX-License-Identifier: Apache-2.0
+def cholesky_of_inverse(matrix):
+    # This formulation only takes the inverse of a triangular matrix
+    # which is more numerically stable.
+    # Refer to:
+    # https://nbviewer.jupyter.org/gist/fehiepsi/5ef8e09e61604f10607380467eb82006#Precision-to-scale_tril
+    tril_inv = jnp.swapaxes(
+        jnp.linalg.cholesky(matrix[..., ::-1, ::-1])[..., ::-1, ::-1], -2, -1
+    )
+    identity = jnp.broadcast_to(jnp.identity(matrix.shape[-1]), tril_inv.shape)
+    return scipy.linalg.solve_triangular(tril_inv, identity, lower=True)

--- a/blackjax/inference/metrics.py
+++ b/blackjax/inference/metrics.py
@@ -43,8 +43,15 @@ def gaussian_euclidean(
     Arguments
     ---------
     inverse_mass_matrix
-        One of two-dimensional array corresponding respectively to a diagonal
-        or dense mass matrix.
+        One or two-dimensional array corresponding respectively to a diagonal
+        or dense mass matrix. The inverse mass matrix is multiplied to a
+        flattened version of the Pytree in which the chain position is stored
+        (the current value of the random variables). The order of the variables
+        should thus match JAX's tree flattening order, and more specifically
+        that of `ravel_pytree`.
+        In particular, JAX sorts dictionaries by key when flattening them. The
+        value of each variables will appear in the flattened Pytree following
+        the order given by `sort(keys)`.
 
     References
     ----------

--- a/blackjax/inference/metrics.py
+++ b/blackjax/inference/metrics.py
@@ -68,6 +68,7 @@ def gaussian_euclidean(
 
         def kinetic_energy(momentum: PyTree, *_) -> float:
             momentum, _ = tree_flatten(momentum)
+            momentum = jnp.array(momentum)
             velocity = jnp.multiply(inverse_mass_matrix, momentum)
             return 0.5 * jnp.dot(velocity, momentum)
 
@@ -85,6 +86,7 @@ def gaussian_euclidean(
 
         def kinetic_energy(momentum: PyTree, *_) -> float:
             momentum, _ = tree_flatten(momentum)
+            momentum = jnp.array(momentum)
             velocity = jnp.matmul(inverse_mass_matrix, momentum)
             return 0.5 * jnp.dot(velocity, momentum)
 

--- a/blackjax/inference/proposals.py
+++ b/blackjax/inference/proposals.py
@@ -42,7 +42,6 @@ HMCProposalState = IntegratorState
 class HMCProposalInfo(NamedTuple):
     step_size: float
     num_integration_steps: int
-    trajectory: IntegratorState  # intermediate + last state
 
 
 def hmc(
@@ -57,12 +56,12 @@ def hmc(
 
         def one_step(state, _):
             state = integrator(state, step_size)
-            return state, state
+            return state, ()
 
-        new_state, trajectory = jax.lax.scan(
+        new_state, _ = jax.lax.scan(
             one_step, initial_state, jnp.arange(num_integration_steps)
         )
-        info = HMCProposalInfo(step_size, num_integration_steps, trajectory)
+        info = HMCProposalInfo(step_size, num_integration_steps)
 
         return new_state, info
 

--- a/blackjax/inference/proposals.py
+++ b/blackjax/inference/proposals.py
@@ -42,7 +42,7 @@ HMCProposalState = IntegratorState
 class HMCProposalInfo(NamedTuple):
     step_size: float
     num_integration_steps: int
-    traversed_states: IntegratorState  # intermediate + last state
+    trajectory: IntegratorState  # intermediate + last state
 
 
 def hmc(
@@ -59,10 +59,10 @@ def hmc(
             state = integrator(state, step_size)
             return state, state
 
-        new_state, traversed_states = jax.lax.scan(
+        new_state, trajectory = jax.lax.scan(
             one_step, initial_state, jnp.arange(num_integration_steps)
         )
-        info = HMCProposalInfo(step_size, num_integration_steps, traversed_states)
+        info = HMCProposalInfo(step_size, num_integration_steps, trajectory)
 
         return new_state, info
 

--- a/blackjax/inference/proposals.py
+++ b/blackjax/inference/proposals.py
@@ -1,0 +1,69 @@
+"""Proposals in the HMC family.
+
+Proposals take the current state of the chain, transform it to another state
+that is returned to the base kernel. Proposals can differ from one another on
+two aspects: the way the step size is chosen and the way the number of
+integration steps is chose.
+
+The standard HMC algorithm integrates the same number of times with the same
+step size [1]_. It is also common to draw at each step the number of
+integration steps from a distribution [1,2]_ ; empirical HMC [2]_ for instance
+learns this distribution during the adaptation phase. Other algorithms, like
+NUTS [3, 4, 5]_, determine the number of integration steps dynamically at runtime.
+
+References
+----------
+.. [1]: Duane, Simon, et al. "Hybrid monte carlo." Physics letters B 195.2 (1987): 216-222.
+.. [2]: Wu, Changye, Julien Stoehr, and Christian P. Robert. "Faster
+        Hamiltonian Monte Carlo by learning leapfrog scale." arXiv preprint
+        arXiv:1810.04449 (2018).
+.. [3]: Hoffman, Matthew D., and Andrew Gelman. "The No-U-Turn sampler:
+        adaptively setting path lengths in Hamiltonian Monte Carlo." J. Mach. Learn.
+        Res. 15.1 (2014): 1593-1623.
+.. [4]: Phan, Du, Neeraj Pradhan, and Martin Jankowiak. "Composable effects for
+        flexible and accelerated probabilistic programming in NumPyro." arXiv preprint
+        arXiv:1912.11554 (2019).
+.. [5]: Lao, Junpeng, et al. "tfp. mcmc: Modern Markov Chain Monte Carlo Tools
+        Built for Modern Hardware." arXiv preprint arXiv:2002.01184 (2020).
+
+"""
+from typing import Callable, NamedTuple, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.inference.integrators import IntegratorState
+
+__all__ = ["hmc"]
+
+HMCProposalState = IntegratorState
+
+
+class HMCProposalInfo(NamedTuple):
+    step_size: float
+    num_integration_steps: int
+    traversed_states: IntegratorState  # intermediate + last state
+
+
+def hmc(
+    integrator: Callable, step_size: float, num_integration_steps: int = 1
+) -> Callable:
+    """Vanilla HMC proposal running the integrator for a fixed number of steps"""
+
+    def propose(
+        _, initial_state: HMCProposalState
+    ) -> Tuple[HMCProposalState, HMCProposalInfo]:
+        """Integrate the trajectory  `num_integration_steps` times starting from `initial_state`."""
+
+        def one_step(state, _):
+            state = integrator(state, step_size)
+            return state, state
+
+        new_state, traversed_states = jax.lax.scan(
+            one_step, initial_state, jnp.arange(num_integration_steps)
+        )
+        info = HMCProposalInfo(step_size, num_integration_steps, traversed_states)
+
+        return new_state, info
+
+    return propose

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+
+[mypy-jax.*]
+ignore_missing_imports = True
+
+[mypy-numpy.*]
+ignore_missing_imports = True
+
+[mypy-pytest.*]
+ignore_missing_imports = True

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -31,7 +31,11 @@ def inference_loop(rng_key, kernel, initial_state, num_samples):
     return states
 
 
-def test_hmc():
+inv_mass_matrices = [np.array([1.0, 1.0]), np.array([[1.0, 0.0], [0.0, 1.0]])]
+
+
+@pytest.mark.parametrize("inv_mass_matrix", inv_mass_matrices)
+def test_hmc(inv_mass_matrix):
     """Test the HMC kernel.
 
     This is a very simple sanity-check.
@@ -47,12 +51,12 @@ def test_hmc():
     initial_state = hmc.new_states(initial_position, potential)
 
     params = hmc.HMCParameters(
-        num_integration_steps=90, step_size=1e-3, inv_mass_matrix=np.array([1.0, 1.0])
+        num_integration_steps=90, step_size=1e-3, inv_mass_matrix=inv_mass_matrix
     )
     kernel = hmc.kernel(potential, params)
 
     rng_key = jax.random.PRNGKey(19)
-    states = inference_loop(rng_key, kernel, initial_state, 10_000)
+    states = inference_loop(rng_key, kernel, initial_state, 20_000)
 
     coefs_samples = states.position["coefs"][5000:]
     scale_samples = states.position["scale"][5000:]

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -1,0 +1,61 @@
+"""Test the accuracy of the HMC kernel"""
+import functools as ft
+
+import jax
+import jax.numpy as jnp
+import jax.scipy.stats as stats
+import numpy as np
+import pytest
+
+import blackjax.hmc as hmc
+
+
+def potential_fn(scale, coefs, preds, x):
+    """Linear regression"""
+    logpdf = 0
+    logpdf += stats.expon.logpdf(scale, 1, 1)
+    logpdf += stats.norm.logpdf(coefs, 3 * jnp.ones(x.shape[-1]), 2)
+    y = jnp.dot(x, coefs)
+    logpdf += stats.norm.logpdf(preds, y, scale)
+    return -jnp.sum(logpdf)
+
+
+def inference_loop(rng_key, kernel, initial_state, num_samples):
+    def one_step(state, rng_key):
+        state, _ = kernel(rng_key, state)
+        return state, state
+
+    keys = jax.random.split(rng_key, num_samples)
+    _, states = jax.lax.scan(one_step, initial_state, keys)
+
+    return states
+
+
+def test_hmc():
+    """Test the HMC kernel.
+
+    This is a very simple sanity-check.
+    """
+    x_data = np.random.normal(0, 1, size=(1000, 1))
+    y_data = 3 * x_data + np.random.normal(size=x_data.shape)
+    observations = {"x": x_data, "preds": y_data}
+
+    conditioned_potential = ft.partial(potential_fn, **observations)
+    potential = lambda x: conditioned_potential(**x)
+
+    initial_position = {"scale": 0.5, "coefs": 2.0}
+    initial_state = hmc.new_states(initial_position, potential)
+
+    params = hmc.HMCParameters(
+        num_integration_steps=90, step_size=1e-3, inv_mass_matrix=np.array([1.0, 1.0])
+    )
+    kernel = hmc.kernel(potential, params)
+
+    rng_key = jax.random.PRNGKey(19)
+    states = inference_loop(rng_key, kernel, initial_state, 10_000)
+
+    coefs_samples = states.position["coefs"][5000:]
+    scale_samples = states.position["scale"][5000:]
+
+    assert np.mean(scale_samples) == pytest.approx(1, 1e-1)
+    assert np.mean(coefs_samples) == pytest.approx(3, 1e-1)

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -1,0 +1,123 @@
+import jax
+import jax.numpy as jnp
+import numpy
+import pytest
+
+import blackjax.inference.integrators as integrators
+
+
+def HarmonicOscillator(inv_mass_matrix, k=1.0, m=1.0):
+    """Potential and Kinetic energy of an harmonic oscillator."""
+
+    def potential_energy(q):
+        return jnp.sum(0.5 * k * jnp.square(q["x"]))
+
+    def kinetic_energy(p):
+        v = jnp.multiply(inv_mass_matrix, p["x"])
+        return jnp.sum(0.5 * jnp.dot(v, p["x"]))
+
+    return potential_energy, kinetic_energy
+
+
+def FreeFall(inv_mass_matrix, g=1.0):
+    """Potential and kinetic energy of a free-falling object."""
+
+    def potential_energy(q):
+        return jnp.sum(g * q["x"])
+
+    def kinetic_energy(p):
+        v = jnp.multiply(inv_mass_matrix, p["x"])
+        return jnp.sum(0.5 * jnp.dot(v, p["x"]))
+
+    return potential_energy, kinetic_energy
+
+
+def PlanetaryMotion(inv_mass_matrix):
+    """Potential and kinetic energy for planar planetary motion."""
+
+    def potential_energy(q):
+        return -1.0 / jnp.power(q["x"] ** 2 + q["y"] ** 2, 0.5)
+
+    def kinetic_energy(p):
+        z = jnp.stack([p["x"], p["y"]], axis=-1)
+        return 0.5 * jnp.dot(inv_mass_matrix, z ** 2)
+
+    return potential_energy, kinetic_energy
+
+
+algorithms = [{"integrator": integrators.velocity_verlet, "precision": 1e-4}]
+
+
+examples = [
+    {
+        "model": FreeFall,
+        "num_steps": 100,
+        "step_size": 0.01,
+        "q_init": {"x": 0.0},
+        "p_init": {"x": 1.0},
+        "q_final": {"x": 0.5},
+        "p_final": {"x": 1.0},
+        "inv_mass_matrix": jnp.array([1.0]),
+    },
+    {
+        "model": HarmonicOscillator,
+        "num_steps": 100,
+        "step_size": 0.01,
+        "q_init": {"x": 0.0},
+        "p_init": {"x": 1.0},
+        "q_final": {"x": jnp.sin(1.0)},
+        "p_final": {"x": jnp.cos(1.0)},
+        "inv_mass_matrix": jnp.array([1.0]),
+    },
+    {
+        "model": PlanetaryMotion,
+        "num_steps": 628,
+        "step_size": 0.01,
+        "q_init": {"x": 1.0, "y": 0.0},
+        "p_init": {"x": 0.0, "y": 1.0},
+        "q_final": {"x": 1.0, "y": 0.0},
+        "p_final": {"x": 0.0, "y": 1.0},
+        "inv_mass_matrix": jnp.array([1.0, 1.0]),
+    },
+]
+
+
+@pytest.mark.parametrize("do_jit_compile", [True, False])
+@pytest.mark.parametrize("integrator", algorithms)
+@pytest.mark.parametrize("example", examples)
+def test_integrator(example, integrator, do_jit_compile):
+    """Test the numerical accuracy of trajectory integrators.
+
+    We compare the evolution of the trajectory to analytical integration, and
+    the conservation of energy. JAX's default float precision is 32bit; it is
+    possible to change it to 64bit but only at startup. It is thus impossible
+    to test both in the same run; we run the tests with the lower precision.
+
+    """
+    model = example["model"]
+    potential, kinetic_energy = model(example["inv_mass_matrix"])
+    integrator_step = integrator["integrator"]
+
+    step = integrator_step(potential, kinetic_energy)
+    step = jax.jit(step) if do_jit_compile else step
+
+    step_size = example["step_size"]
+
+    q = example["q_init"]
+    p = example["p_init"]
+    initial_state = integrators.IntegratorState(q, p, jax.grad(potential)(q))
+    final_state = jax.lax.fori_loop(
+        0, example["num_steps"], lambda i, state: step(state, step_size), initial_state
+    )
+
+    # We make sure that the particle moved from its initial position.
+    for dimension in final_state.position:
+        init = final_state.position[dimension]
+        final = example["q_final"][dimension]
+        print(example["q_final"], final_state.position)
+        numpy.testing.assert_allclose(init, final, atol=1e-2)
+
+    # We now check the conservation of energy, the property that matters the most in HMC.
+    energy = potential(q) + kinetic_energy(p)
+    new_energy = potential(final_state.position) + kinetic_energy(final_state.momentum)
+    assert energy == pytest.approx(new_energy.item(), integrator["precision"])

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -105,9 +105,11 @@ def test_integrator(example, integrator, do_jit_compile):
 
     q = example["q_init"]
     p = example["p_init"]
-    initial_state = integrators.IntegratorState(q, p, jax.grad(potential)(q))
+    initial_state = integrators.IntegratorState(
+        q, p, potential(q), jax.grad(potential)(q)
+    )
     final_state = jax.lax.fori_loop(
-        0, example["num_steps"], lambda i, state: step(state, step_size), initial_state
+        0, example["num_steps"], lambda _, state: step(state, step_size), initial_state
     )
 
     # We make sure that the particle moved from its initial position.


### PR DESCRIPTION
## Scope

Implement a HMC kernel that moves one chain for one step, with the following elements:

- [x] Velocity verlet integrator + tests
- [x] Proposal with a fixed number of steps
- [x] Gaussian euclidean metric
- [x] HMC base kernels
- [x] High-level API
- [x] Setup simple integration test

The goal is to get to a concrete implementation quickly to see the design in action.