### PR TITLE
Bug fix in NUTS sampler

### DIFF
--- a/blackjax/inference/metrics.py
+++ b/blackjax/inference/metrics.py
@@ -133,6 +133,7 @@ def gaussian_euclidean(
         velocity_left = matmul(inverse_mass_matrix, m_left)
         velocity_right = matmul(inverse_mass_matrix, m_right)
 
+        # rho = m_sum
         rho = m_sum - (m_right + m_left) / 2
         turning_at_left = jnp.dot(velocity_left, rho) <= 0
         turning_at_right = jnp.dot(velocity_right, rho) <= 0

--- a/blackjax/inference/termination.py
+++ b/blackjax/inference/termination.py
@@ -50,10 +50,7 @@ def iterative_uturn_numpyro(is_turning):
         r_ckpts, r_sum_ckpts = jax.lax.cond(
             step % 2 == 0,
             (r_ckpts, r_sum_ckpts),
-            lambda x: (
-                x[0].at[ckpt_idx_max].set(r),
-                x[1].at[ckpt_idx_max].set(r_sum)
-            ),
+            lambda x: (x[0].at[ckpt_idx_max].set(r), x[1].at[ckpt_idx_max].set(r_sum)),
             (r_ckpts, r_sum_ckpts),
             lambda x: x,
         )

--- a/blackjax/inference/termination.py
+++ b/blackjax/inference/termination.py
@@ -51,8 +51,8 @@ def iterative_uturn_numpyro(is_turning):
             step % 2 == 0,
             (r_ckpts, r_sum_ckpts),
             lambda x: (
-                jax.ops.index_update(x[0], ckpt_idx_max, r),
-                jax.ops.index_update(x[1], ckpt_idx_max, r_sum),
+                x[0].at[ckpt_idx_max].set(r),
+                x[1].at[ckpt_idx_max].set(r_sum)
             ),
             (r_ckpts, r_sum_ckpts),
             lambda x: x,

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -388,7 +388,9 @@ def dynamic_multiplicative_expansion(
             )
 
             # merge the freshly integrated trajectory to the current trajectory
-            merged_trajectory = merge_trajectories(direction, trajectory, new_trajectory)
+            merged_trajectory = merge_trajectories(
+                direction, trajectory, new_trajectory
+            )
 
             # update the proposal
             # we reject proposals coming from diverging or turning subtrajectories

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -373,7 +373,7 @@ def dynamic_multiplicative_expansion(
             left_trajectory, right_trajectory = reorder_trajectories(
                 direction, trajectory, new_trajectory
             )
-            
+
             # robust u-turn check when merging the two trajectory
             # note this is different from the robust u-turn check done during
             # trajectory building.
@@ -432,7 +432,7 @@ def dynamic_multiplicative_expansion(
                 termination_state,
                 is_diverging,
                 has_terminated,
-                is_turning | is_turning_left | is_turning_right,
+                is_turning,  # | is_turning_left | is_turning_right,
             )
 
         initial_state = initial_proposal.state

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -369,32 +369,34 @@ def dynamic_multiplicative_expansion(
                 rate ** step,
                 step_size,
             )
-            # robust u-turn check when merging the two trajectory
-            # note this is different from the robust u-turn check done during
-            # trajectory building.
+
             left_trajectory, right_trajectory = reorder_trajectories(
                 direction, trajectory, new_trajectory
             )
-            momentum_sum_left = jax.tree_util.tree_multimap(
-                jnp.add,
-                left_trajectory.momentum_sum,
-                right_trajectory.leftmost_state.momentum,
-            )
-            is_turning_left = uturn_check_fn(
-                left_trajectory.leftmost_state.momentum,
-                right_trajectory.leftmost_state.momentum,
-                momentum_sum_left,
-            )
-            momentum_sum_right = jax.tree_util.tree_multimap(
-                jnp.add,
-                left_trajectory.rightmost_state.momentum,
-                right_trajectory.momentum_sum,
-            )
-            is_turning_right = uturn_check_fn(
-                left_trajectory.rightmost_state.momentum,
-                right_trajectory.rightmost_state.momentum,
-                momentum_sum_right,
-            )
+            
+            # robust u-turn check when merging the two trajectory
+            # note this is different from the robust u-turn check done during
+            # trajectory building.
+            # momentum_sum_left = jax.tree_util.tree_multimap(
+            #     jnp.add,
+            #     left_trajectory.momentum_sum,
+            #     right_trajectory.leftmost_state.momentum,
+            # )
+            # is_turning_left = uturn_check_fn(
+            #     left_trajectory.leftmost_state.momentum,
+            #     right_trajectory.leftmost_state.momentum,
+            #     momentum_sum_left,
+            # )
+            # momentum_sum_right = jax.tree_util.tree_multimap(
+            #     jnp.add,
+            #     left_trajectory.rightmost_state.momentum,
+            #     right_trajectory.momentum_sum,
+            # )
+            # is_turning_right = uturn_check_fn(
+            #     left_trajectory.rightmost_state.momentum,
+            #     right_trajectory.rightmost_state.momentum,
+            #     momentum_sum_right,
+            # )
 
             # merge the freshly integrated trajectory to the current trajectory
             momentum_sum = jax.tree_util.tree_multimap(

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -376,15 +376,23 @@ def dynamic_multiplicative_expansion(
             # robust u-turn check when merging the two trajectory
             # note this is different from the robust u-turn check done during
             # trajectory building.
+            momentum_sum_left = jax.tree_util.tree_multimap(
+                jnp.add, trajectory.momentum_sum, new_trajectory.leftmost_state.momentum
+            )
             is_turning_left = uturn_check_fn(
                 trajectory.leftmost_state.momentum,
                 new_trajectory.leftmost_state.momentum,
-                trajectory.momentum_sum + new_trajectory.leftmost_state.momentum,
+                momentum_sum_left,
+            )
+            momentum_sum_right = jax.tree_util.tree_multimap(
+                jnp.add,
+                trajectory.rightmost_state.momentum,
+                new_trajectory.momentum_sum,
             )
             is_turning_right = uturn_check_fn(
                 trajectory.rightmost_state.momentum,
                 new_trajectory.rightmost_state.momentum,
-                trajectory.rightmost_state.momentum + new_trajectory.momentum_sum,
+                momentum_sum_right,
             )
 
             # merge the freshly integrated trajectory to the current trajectory

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -59,7 +59,7 @@ def test_dynamic_progressive_integration_divergence(case):
 
 @pytest.mark.parametrize(
     "case",
-    [(0.0000000001, False, False, 10), (1, False, True, 3), (100000, True, False, 1)],
+    [(0.0000000001, False, False, 10), (1, False, True, 2), (100000, True, True, 1)],
 )
 def test_dynamic_progressive_expansion(case):
     rng_key = jax.random.PRNGKey(0)


### PR DESCRIPTION
- change deprecated index_update ops (https://jax.readthedocs.io/en/latest/jax.ops.html#indexed-update-functions-deprecated)
- bug fix of u turn check (it was not checking on the resulting merged trajectory)
- refactored the merging of 2 trajectory so it is easier to add robust u-turn check