### PR TITLE
NUTS bug fix

### DIFF
--- a/blackjax/hmc.py
+++ b/blackjax/hmc.py
@@ -171,7 +171,7 @@ def hmc_proposal(
         end_state = build_trajectory(state)
         end_state = flip_momentum(end_state)
         proposal = init_proposal(state)
-        new_proposal, is_diverging = generate_proposal(proposal, end_state)
+        new_proposal, is_diverging = generate_proposal(proposal.energy, end_state)
         sampled_proposal, *info = sample_proposal(rng_key, proposal, new_proposal)
         do_accept, p_accept = info
 

--- a/blackjax/inference/proposal.py
+++ b/blackjax/inference/proposal.py
@@ -30,9 +30,7 @@ def proposal_generator(
         energy = state.potential_energy + kinetic_energy(state.position, state.momentum)
         return Proposal(state, energy, 0.0)
 
-    def update(
-        previous_proposal: Proposal, state: IntegratorState
-    ) -> Tuple[Proposal, bool]:
+    def update(initial_energy: float, state: IntegratorState) -> Tuple[Proposal, bool]:
         """Generate a new proposal from a trajectory state.
 
         The trajectory state records information about the position in the state
@@ -43,18 +41,17 @@ def proposal_generator(
 
         Parameters
         ----------
-        previous_proposal:
-            The previous proposal.
+        initial_energy:
+            The initial energy.
         state:
             The new state.
 
         """
-        energy = previous_proposal.energy
         new_energy = state.potential_energy + kinetic_energy(
             state.position, state.momentum
         )
 
-        delta_energy = energy - new_energy
+        delta_energy = initial_energy - new_energy
         delta_energy = jnp.where(jnp.isnan(delta_energy), -jnp.inf, delta_energy)
         is_transition_divergent = jnp.abs(delta_energy) > divergence_threshold
 

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -179,6 +179,7 @@ def dynamic_progressive_integration(
         termination_state,
         max_num_steps: int,
         step_size,
+        initial_energy,
     ):
         """Integrate the trajectory starting from `initial_state` and update
         the proposal sequentially until the termination criterion is met.
@@ -199,6 +200,8 @@ def dynamic_progressive_integration(
             been met.
         step_size
             The step size of the symplectic integrator.
+        initial_energy
+            Initial energy H0 of the HMC step (not to confused with the initial energy of the subtree)
 
         """
 
@@ -227,7 +230,7 @@ def dynamic_progressive_integration(
                 lambda _: append_to_trajectory(direction, trajectory, new_state),
                 operand=None,
             )
-            new_proposal, is_diverging = generate_proposal(proposal, new_state)
+            new_proposal, is_diverging = generate_proposal(initial_energy, new_state)
             sampled_proposal = sample_proposal(rng_key, proposal, new_proposal)
             new_termination_state = update_termination_state(
                 termination_state, new_trajectory.momentum_sum, new_state.momentum, step
@@ -334,6 +337,7 @@ def dynamic_multiplicative_expansion(
         rng_key,
         initial_proposal: proposal.Proposal,
         criterion_state,
+        initial_energy,
     ):
         def do_keep_expanding(expansion_state) -> bool:
             """Determine whether we need to keep expanding the trajectory."""
@@ -388,6 +392,7 @@ def dynamic_multiplicative_expansion(
                 termination_state,
                 rate ** step,
                 step_size,
+                initial_energy,
             )
 
             left_trajectory, right_trajectory = reorder_trajectories(

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -32,13 +32,13 @@ from typing import Callable, Dict, List, NamedTuple, Tuple, Union
 import jax
 import jax.numpy as jnp
 
+from blackjax.inference.integrators import IntegratorState
 from blackjax.inference.proposal import (
     Proposal,
-    proposal_generator,
     progressive_biased_sampling,
     progressive_uniform_sampling,
+    proposal_generator,
 )
-from blackjax.inference.integrators import IntegratorState
 
 PyTree = Union[Dict, List, Tuple]
 

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -225,7 +225,7 @@ def dynamic_progressive_integration(
                 step == 0,
                 lambda _: Trajectory(new_state, new_state, new_state.momentum, 1),
                 lambda _: append_to_trajectory(direction, trajectory, new_state),
-                operand=None
+                operand=None,
             )
             new_proposal, is_diverging = generate_proposal(proposal, new_state)
             sampled_proposal = sample_proposal(rng_key, proposal, new_proposal)
@@ -235,7 +235,7 @@ def dynamic_progressive_integration(
             has_terminated = is_criterion_met(
                 new_termination_state, new_trajectory.momentum_sum, new_state.momentum
             )
-            
+
             return (
                 rng_key,
                 step + 1,
@@ -263,7 +263,7 @@ def dynamic_progressive_integration(
             _,
             step,
             proposal,
-            _, 
+            _,
             trajectory,
             termination_state,
             is_diverging,

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -585,18 +585,20 @@ def dynamic_multiplicative_expansion(
             # update the proposal
             # we reject proposals coming from diverging or turning subtrajectories,
             # but accumulate average acceptance probabilty across entire trajectory
-            def update_log_p_accept(inputs):
+            def update_cumsum_log_mh_accpet(inputs):
                 _, proposal, new_proposal = inputs
                 return Proposal(
                     proposal.state,
                     proposal.energy,
                     proposal.weight,
-                    jnp.logaddexp(proposal.log_p_accept, new_proposal.log_p_accept),
+                    jnp.logaddexp(
+                        proposal.cumsum_log_mh_accpet, new_proposal.cumsum_log_mh_accpet
+                    ),
                 )
 
             sampled_proposal = jax.lax.cond(
                 is_diverging | is_turning_subtree,
-                update_log_p_accept,
+                update_cumsum_log_mh_accpet,
                 lambda x: proposal_sampler(*x),
                 operand=(proposal_key, proposal, new_proposal),
             )

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -243,7 +243,6 @@ def dynamic_progressive_integration(
             new_state = integrator(previous_state, direction * step_size)
             new_proposal, is_diverging = generate_proposal(initial_energy, new_state)
 
-                    new_proposal,
             new_trajectory = append_to_trajectory(direction, trajectory, new_state)
             sampled_proposal = sample_proposal(proposal_key, proposal, new_proposal)
 

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -184,9 +184,7 @@ def dynamic_progressive_integration(
         Value of the difference of energy between two consecutive states above which we say a transition is divergent.
 
     """
-    _, generate_proposal = proposal_generator(
-        kinetic_energy, divergence_threshold
-    )
+    _, generate_proposal = proposal_generator(kinetic_energy, divergence_threshold)
     sample_proposal = progressive_uniform_sampling
 
     def integrate(
@@ -264,8 +262,8 @@ def dynamic_progressive_integration(
                 has_terminated,
             )
 
-        # Take the first step (step 0) that starts the new trajectory with proposal, 
-        # so that at for step k > 0 in the while loop we can just append the new 
+        # Take the first step (step 0) that starts the new trajectory with proposal,
+        # so that at for step k > 0 in the while loop we can just append the new
         # state to the trajectory and generate new proposal.
         state_step0 = integrator(initial_state, direction * step_size)
         initial_proposal, is_diverging = generate_proposal(initial_energy, state_step0)

--- a/blackjax/inference/trajectory.py
+++ b/blackjax/inference/trajectory.py
@@ -585,20 +585,20 @@ def dynamic_multiplicative_expansion(
             # update the proposal
             # we reject proposals coming from diverging or turning subtrajectories,
             # but accumulate average acceptance probabilty across entire trajectory
-            def update_cumsum_log_mh_accpet(inputs):
+            def update_sum_log_p_accept(inputs):
                 _, proposal, new_proposal = inputs
                 return Proposal(
                     proposal.state,
                     proposal.energy,
                     proposal.weight,
                     jnp.logaddexp(
-                        proposal.cumsum_log_mh_accpet, new_proposal.cumsum_log_mh_accpet
+                        proposal.sum_log_p_accept, new_proposal.sum_log_p_accept
                     ),
                 )
 
             sampled_proposal = jax.lax.cond(
                 is_diverging | is_turning_subtree,
-                update_cumsum_log_mh_accpet,
+                update_sum_log_p_accept,
                 lambda x: proposal_sampler(*x),
                 operand=(proposal_key, proposal, new_proposal),
             )

--- a/blackjax/nuts.py
+++ b/blackjax/nuts.py
@@ -197,7 +197,9 @@ def iterative_nuts_proposal(
         trajectory, num_doublings, is_diverging, is_turning = info
         # Compute average acceptance probabilty across entire trajectory,
         # even over subtrees that may have been rejected
-        avg_accept_prob = jnp.exp(sampled_proposal.log_p_accept) / trajectory.num_states
+        avg_accept_prob = (
+            jnp.exp(sampled_proposal.cumsum_log_mh_accpet) / trajectory.num_states
+        )
 
         info = NUTSInfo(
             initial_state.momentum,

--- a/blackjax/nuts.py
+++ b/blackjax/nuts.py
@@ -47,7 +47,7 @@ class NUTSInfo(NamedTuple):
     integration_steps
         Number of integration steps that were taken. This is also the number of states
         in the full trajectory.
-    avg_accept_prob
+    acceptance_probability
         average acceptance probabilty across entire trajectory
     """
 
@@ -59,7 +59,7 @@ class NUTSInfo(NamedTuple):
     trajectory_rightmost_state: integrators.IntegratorState
     num_trajectory_expansions: int
     integration_steps: int
-    avg_accept_prob: float
+    acceptance_probability: float
 
 
 new_state = blackjax.hmc.new_state
@@ -197,7 +197,7 @@ def iterative_nuts_proposal(
         trajectory, num_doublings, is_diverging, is_turning = info
         # Compute average acceptance probabilty across entire trajectory,
         # even over subtrees that may have been rejected
-        avg_accept_prob = (
+        acceptance_probability = (
             jnp.exp(sampled_proposal.sum_log_p_accept) / trajectory.num_states
         )
 
@@ -210,7 +210,7 @@ def iterative_nuts_proposal(
             trajectory.rightmost_state,
             num_doublings,
             trajectory.num_states,
-            avg_accept_prob,
+            acceptance_probability,
         )
 
         return sampled_proposal.state, info

--- a/blackjax/nuts.py
+++ b/blackjax/nuts.py
@@ -177,14 +177,14 @@ def iterative_nuts_proposal(
 
     def propose(rng_key, initial_state: integrators.IntegratorState):
         criterion_state = new_criterion_state(initial_state, max_num_expansions)
-        initial_proposal = proposal.Proposal(
-            initial_state, _compute_energy(initial_state), 0.0
-        )
+        initial_energy = _compute_energy(initial_state)  # H0 of the HMC step
+        initial_proposal = proposal.Proposal(initial_state, initial_energy, 0.0)
 
         sampled_proposal, *info = expand(
             rng_key,
             initial_proposal,
             criterion_state,
+            initial_energy,
         )
         trajectory, num_doublings, is_diverging, has_terminated, is_turning = info
 

--- a/blackjax/nuts.py
+++ b/blackjax/nuts.py
@@ -198,7 +198,7 @@ def iterative_nuts_proposal(
         # Compute average acceptance probabilty across entire trajectory,
         # even over subtrees that may have been rejected
         avg_accept_prob = (
-            jnp.exp(sampled_proposal.cumsum_log_mh_accpet) / trajectory.num_states
+            jnp.exp(sampled_proposal.sum_log_p_accept) / trajectory.num_states
         )
 
         info = NUTSInfo(

--- a/blackjax/nuts.py
+++ b/blackjax/nuts.py
@@ -44,6 +44,11 @@ class NUTSInfo(NamedTuple):
         The rightmost state of the full trajectory.
     num_trajectory_expansions
         Number of subtrajectory samples that were taken.
+    integration_steps
+        Number of integration steps that were taken. This is also the number of states
+        in the full trajectory.
+    avg_accept_prob
+        average acceptance probabilty across entire trajectory
     """
 
     momentum: PyTree
@@ -54,6 +59,7 @@ class NUTSInfo(NamedTuple):
     trajectory_rightmost_state: integrators.IntegratorState
     num_trajectory_expansions: int
     integration_steps: int
+    avg_accept_prob: float
 
 
 new_state = blackjax.hmc.new_state
@@ -178,7 +184,9 @@ def iterative_nuts_proposal(
     def propose(rng_key, initial_state: integrators.IntegratorState):
         criterion_state = new_criterion_state(initial_state, max_num_expansions)
         initial_energy = _compute_energy(initial_state)  # H0 of the HMC step
-        initial_proposal = proposal.Proposal(initial_state, initial_energy, 0.0)
+        initial_proposal = proposal.Proposal(
+            initial_state, initial_energy, 0.0, -np.inf
+        )
 
         sampled_proposal, *info = expand(
             rng_key,
@@ -186,17 +194,21 @@ def iterative_nuts_proposal(
             criterion_state,
             initial_energy,
         )
-        trajectory, num_doublings, is_diverging, has_terminated, is_turning = info
+        trajectory, num_doublings, is_diverging, is_turning = info
+        # Compute average acceptance probabilty across entire trajectory,
+        # even over subtrees that may have been rejected
+        avg_accept_prob = jnp.exp(sampled_proposal.log_p_accept) / trajectory.num_states
 
         info = NUTSInfo(
             initial_state.momentum,
             is_diverging,
-            has_terminated | is_turning,
+            is_turning,
             sampled_proposal.energy,
             trajectory.leftmost_state,
             trajectory.rightmost_state,
             num_doublings,
             trajectory.num_states,
+            avg_accept_prob,
         )
 
         return sampled_proposal.state, info

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import sys
 
 import setuptools
 
-
 # READ README.md for long description on PyPi.
 try:
     long_description = open("README.md", encoding="utf-8").read()

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -45,4 +45,6 @@ def test_nuts():
         _, rng_key = jax.random.split(rng_key)
         state, _ = kernel(rng_key, state)
 
-    assert GLOBAL["count"] == 1
+    # Potential function was traced twice as we call potential function
+    # at Step 0 when building a new trajectory in tree doubling.
+    assert GLOBAL["count"] == 2

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -56,7 +56,7 @@ def test_hmc(inv_mass_matrix):
     )
     kernel = hmc.kernel(potential, params)
 
-    rng_key = jax.random.PRNGKey(19)
+    rng_key = jax.random.PRNGKey(23)
     states = inference_loop(rng_key, kernel, initial_state, 20_000)
 
     coefs_samples = states.position["coefs"][5000:]

--- a/tests/test_hmc.py
+++ b/tests/test_hmc.py
@@ -56,7 +56,7 @@ def test_hmc(inv_mass_matrix):
     )
     kernel = hmc.kernel(potential, params)
 
-    rng_key = jax.random.PRNGKey(23)
+    rng_key = jax.random.PRNGKey(19)
     states = inference_loop(rng_key, kernel, initial_state, 20_000)
 
     coefs_samples = states.position["coefs"][5000:]

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1,7 +1,9 @@
 """Test the trajectory integration"""
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
+import functools
 
 import blackjax.inference.integrators as integrators
 import blackjax.inference.metrics as metrics
@@ -66,6 +68,124 @@ def test_dynamic_progressive_integration_divergence(case):
     assert is_diverging.item() is should_diverge
 
 
+def test_dynamic_progressive_equal_recursive():
+    rng_key = jax.random.PRNGKey(23132)
+
+    def potential_fn(x):
+        return (1.0 - x[0]) ** 2 + 1.5 * (x[1] - x[0] ** 2) ** 2
+
+    inverse_mass_matrix = jnp.asarray([[1.0, 0.5], [0.5, 1.25]])
+    momentum_generator, kinetic_energy_fn, uturn_check_fn = metrics.gaussian_euclidean(
+        inverse_mass_matrix
+    )
+
+    integrator = integrators.velocity_verlet(potential_fn, kinetic_energy_fn)
+    (
+        new_criterion_state,
+        update_criterion_state,
+        is_criterion_met,
+    ) = termination.iterative_uturn_numpyro(uturn_check_fn)
+    (
+        integrator,
+        kinetic_energy_fn,
+        update_criterion_state,
+        is_criterion_met,
+        uturn_check_fn,
+    ) = [
+        jax.jit(x)
+        for x in (
+            integrator,
+            kinetic_energy_fn,
+            update_criterion_state,
+            is_criterion_met,
+            uturn_check_fn,
+        )
+    ]
+
+    trajectory_integrator = trajectory.dynamic_progressive_integration(
+        integrator,
+        kinetic_energy_fn,
+        update_criterion_state,
+        is_criterion_met,
+        divergence_threshold,
+    )
+    buildtree_integrator = trajectory.dynamic_recursive_integration(
+        integrator,
+        kinetic_energy_fn,
+        uturn_check_fn,
+        divergence_threshold,
+    )
+
+    for _ in range(50):
+        (
+            rng_key,
+            rng_direction,
+            rng_tree_depth,
+            rng_step_size,
+            rng_position,
+            rng_momentum,
+        ) = jax.random.split(rng_key, 6)
+        direction = jax.random.choice(rng_direction, jnp.array([-1, 1]))
+        tree_depth = jax.random.choice(rng_tree_depth, np.arange(2, 5))
+        initial_state = integrators.new_integrator_state(
+            potential_fn,
+            jax.random.normal(rng_position, [2]),
+            jax.random.normal(rng_momentum, [2]),
+        )
+        step_size = jnp.abs(jax.random.normal(rng_step_size, [])) * 0.1
+        initial_energy = initial_state.potential_energy + kinetic_energy_fn(
+            initial_state.position, initial_state.momentum
+        )
+
+        termination_state = new_criterion_state(initial_state, tree_depth)
+        (
+            proposal0,
+            trajectory0,
+            _,
+            is_diverging0,
+            has_terminated0,
+            _,
+        ) = trajectory_integrator(
+            rng_key,
+            initial_state,
+            direction,
+            termination_state,
+            2 ** tree_depth,
+            step_size,
+            initial_energy,
+        )
+
+        (
+            _,
+            proposal1,
+            trajectory1,
+            is_diverging1,
+            has_terminated1,
+        ) = buildtree_integrator(
+            rng_key,
+            initial_state,
+            direction,
+            tree_depth,
+            step_size,
+            initial_energy,
+        )
+        # Assert that the trajectory being built is the same
+        jax.tree_multimap(
+            functools.partial(np.testing.assert_allclose, rtol=1e-5),
+            trajectory0,
+            trajectory1,
+        )
+        assert is_diverging0 == is_diverging1
+        assert has_terminated0 == has_terminated1
+        # We dont expect the proposal to be the same (even with the same PRNGKey
+        # as the order of selection is different). but the property associate
+        # with the full trajectory should be the same.
+        np.testing.assert_allclose(proposal0.weight, proposal1.weight, rtol=1e-5)
+        np.testing.assert_allclose(
+            proposal0.log_p_accept, proposal1.log_p_accept, rtol=1e-5
+        )
+
+
 @pytest.mark.parametrize(
     "case",
     [(0.0000000001, False, False, 10), (1, False, True, 2), (100000, True, True, 1)],
@@ -107,10 +227,10 @@ def test_dynamic_progressive_expansion(case):
         potential_fn, position, momentum_generator(rng_key, position)
     )
     energy = state.potential_energy + kinetic_energy_fn(state.position, state.momentum)
-    initial_proposal = initial_proposal = proposal.Proposal(state, energy, 0.0)
+    initial_proposal = proposal.Proposal(state, energy, 0.0, -np.inf)
     initial_termination_state = new_criterion_state(state, 10)
 
-    _, _, step, is_diverging, has_terminated, is_turning = expand(
+    _, _, step, is_diverging, is_turning = expand(
         rng_key, initial_proposal, initial_termination_state, energy
     )
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -183,7 +183,7 @@ def test_dynamic_progressive_equal_recursive():
         # with the full trajectory should be the same.
         np.testing.assert_allclose(proposal0.weight, proposal1.weight, rtol=1e-5)
         np.testing.assert_allclose(
-            proposal0.cumsum_log_mh_accpet, proposal1.cumsum_log_mh_accpet, rtol=1e-5
+            proposal0.sum_log_p_accept, proposal1.sum_log_p_accept, rtol=1e-5
         )
 
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -183,7 +183,7 @@ def test_dynamic_progressive_equal_recursive():
         # with the full trajectory should be the same.
         np.testing.assert_allclose(proposal0.weight, proposal1.weight, rtol=1e-5)
         np.testing.assert_allclose(
-            proposal0.log_p_accept, proposal1.log_p_accept, rtol=1e-5
+            proposal0.cumsum_log_mh_accpet, proposal1.cumsum_log_mh_accpet, rtol=1e-5
         )
 
 

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1,9 +1,10 @@
 """Test the trajectory integration"""
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import functools
 
 import blackjax.inference.integrators as integrators
 import blackjax.inference.metrics as metrics

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -47,11 +47,12 @@ def test_dynamic_progressive_integration_divergence(case):
     initial_state = integrators.new_integrator_state(
         potential_fn, position, momentum_generator(rng_key, position)
     )
+    initial_energy = initial_state.potential_energy + kinetic_energy_fn(initial_state.position, initial_state.momentum)
     termination_state = new_criterion_state(initial_state, 10)
     max_num_steps = 100
 
     _, _, _, is_diverging, _, _ = trajectory_integrator(
-        rng_key, initial_state, direction, termination_state, max_num_steps, step_size
+        rng_key, initial_state, direction, termination_state, max_num_steps, step_size, initial_energy
     )
 
     assert is_diverging.item() is should_diverge
@@ -102,7 +103,7 @@ def test_dynamic_progressive_expansion(case):
     initial_termination_state = new_criterion_state(state, 10)
 
     _, _, step, is_diverging, has_terminated, is_turning = expand(
-        rng_key, initial_proposal, initial_termination_state
+        rng_key, initial_proposal, initial_termination_state, energy
     )
 
     assert is_diverging == should_diverge

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -47,12 +47,20 @@ def test_dynamic_progressive_integration_divergence(case):
     initial_state = integrators.new_integrator_state(
         potential_fn, position, momentum_generator(rng_key, position)
     )
-    initial_energy = initial_state.potential_energy + kinetic_energy_fn(initial_state.position, initial_state.momentum)
+    initial_energy = initial_state.potential_energy + kinetic_energy_fn(
+        initial_state.position, initial_state.momentum
+    )
     termination_state = new_criterion_state(initial_state, 10)
     max_num_steps = 100
 
     _, _, _, is_diverging, _, _ = trajectory_integrator(
-        rng_key, initial_state, direction, termination_state, max_num_steps, step_size, initial_energy
+        rng_key,
+        initial_state,
+        direction,
+        termination_state,
+        max_num_steps,
+        step_size,
+        initial_energy,
     )
 
     assert is_diverging.item() is should_diverge


### PR DESCRIPTION
This PR fix a few major bugs in NUTS implementation
- Proposal weight need to be accumulated regardless accept or reject
- During tree doubling, the trajectory of a new tree should not include the state that initialise the new tree
- There is a bug that during trajectory building integration was starting from the proposal position instead of the previous position in the trajectory
- Energy differences should be compare with the initial state of the step, not the proposal state or the state that initialise the new tree
- Proposal should comes from a subtree (not including the state that initialise the new tree)