### PR TITLE
Coupled HMC methods

### DIFF
--- a/blackjax/coupled/hmc.py
+++ b/blackjax/coupled/hmc.py
@@ -11,7 +11,7 @@ import blackjax.inference.integrators as integrators
 import blackjax.inference.metrics as metrics
 import blackjax.inference.proposal as proposal
 import blackjax.inference.trajectory as trajectory
-from blackjax.hmc import generate as hmc_generate
+from blackjax.hmc import generate as hmc_generate, HMCInfo
 
 Array = Union[np.ndarray, jnp.DeviceArray]
 PyTree = Union[Dict, List, Tuple]
@@ -25,8 +25,8 @@ class CoupledHMCState(NamedTuple):
 
 
 class CoupledHMCInfo(NamedTuple):
-    info_state_1: base.HMCState
-    info_state_2: base.HMCState
+    info_state_1: HMCInfo
+    info_state_2: HMCInfo
 
 
 def new_state(position_1: PyTree, position_2: PyTree, potential_fn: Callable) -> CoupledHMCState:

--- a/blackjax/coupled/rwmh.py
+++ b/blackjax/coupled/rwmh.py
@@ -116,7 +116,7 @@ def reflected_gaussians(rng_key, inverse_mass_matrix: jnp.DeviceArray,
     Example:
     --------
     >>> rng_key = jax.random.PRNGKey(42)
-    >>> rng_keys = jax.random.split(rng_key, 1000)
+    >>> rng_keys = jax.random.split(rng_key, 10)
     >>> inverse_mass_matrix = jnp.ones((1,))
     >>> position_1 = -jnp.ones((1,))
     >>> position_2 = jnp.ones((1,))
@@ -136,11 +136,11 @@ def reflected_gaussians(rng_key, inverse_mass_matrix: jnp.DeviceArray,
 
     sqrt_inv_matrix = jnp.sqrt(inverse_mass_matrix)
     scaled_diff = jnp.multiply(sqrt_inv_matrix, position_1 - position_2)
-    normed_scaled_diff = scaled_diff / jnp.linalg.norm(scaled_diff, ord=2)
+    normed_scaled_diff = scaled_diff / jnp.sqrt(jnp.sum(scaled_diff ** 2))
 
     normal_key, uniform_key = jax.random.split(rng_key, 2)
-    norm = jax.random.normal(uniform_key, shape)
-    log_u = jax.random.uniform(rng_key, ())
+    norm = jax.random.normal(normal_key, shape)
+    log_u = jnp.log(jax.random.uniform(uniform_key, ()))
 
     do_accept = log_u + _mvn_loglikelihood(norm) < _mvn_loglikelihood(norm + scaled_diff)
     accept = lambda _: norm + scaled_diff
@@ -150,4 +150,5 @@ def reflected_gaussians(rng_key, inverse_mass_matrix: jnp.DeviceArray,
     mass_matrix_sqrt = jnp.reciprocal(sqrt_inv_matrix)
     res_1 = position_1 + jnp.multiply(mass_matrix_sqrt, norm)
     res_2 = position_2 + jnp.multiply(mass_matrix_sqrt, reflected_norm)
+
     return res_1, res_2

--- a/blackjax/coupled/rwmh.py
+++ b/blackjax/coupled/rwmh.py
@@ -1,0 +1,153 @@
+"""Public API for the coupled RWMH Kernel"""
+
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.flatten_util import ravel_pytree
+
+from blackjax.rwmh import RWMHInfo, RWMHState, new_state as new_rwmh_state
+
+Array = Union[np.ndarray, jnp.DeviceArray]
+PyTree = Union[Dict, List, Tuple]
+
+__all__ = ["new_state", "kernel"]
+
+
+class CoupledRWMHState(NamedTuple):
+    state_1: RWMHState
+    state_2: RWMHState
+
+
+class CoupledRWMHInfo(NamedTuple):
+    info_state_1: RWMHInfo
+    info_state_2: RWMHInfo
+
+
+def new_state(position_1: PyTree, position_2: PyTree, potential_fn: Callable) -> CoupledRWMHState:
+    """ Creates two independent chain states from a position by calling base.new_hcm_state twice. """
+    return CoupledRWMHState(new_rwmh_state(position_1, potential_fn),
+                            new_rwmh_state(position_2, potential_fn))
+
+
+def kernel(
+        potential_fn: Callable,
+        inverse_mass_matrix: Array,
+):
+    """Build a RWMH kernel.
+
+    Parameters
+    ----------
+    potential_fn
+        A function that returns the potential energy of a chain at a given position.
+    inverse_mass_matrix
+        One or two-dimensional array corresponding respectively to a diagonal
+        or dense mass matrix. The inverse mass matrix is multiplied to a
+        flattened version of the Pytree in which the chain position is stored
+        (the current value of the random variables). The order of the variables
+        should thus match JAX's tree flattening order, and more specifically
+        that of `ravel_pytree`.
+        In particular, JAX sorts dictionaries by key when flattening them. The
+        value of each variables will appear in the flattened Pytree following
+        the order given by `sort(keys)`.
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current state
+    of the chain and that returns a new state of the chain along with
+    information about the transition.
+
+    """
+
+    def one_step(rng_key: jnp.ndarray, state: CoupledRWMHState):
+        """Moves the chain by one step using the Hamiltonian dynamics.
+
+        Parameters
+        ----------
+        rng_key:
+           The pseudo-random number generator key used to generate random numbers.
+        state:
+            The current state of the two coupled chains.
+
+        Returns
+        -------
+        The next state of the chain and additional information about the current step.
+        """
+        momentum_key, proposal_key = jax.random.split(rng_key, 2)
+        state_1 = state.state_1
+        state_2 = state.state_2
+        ravelled_position_1, unravel_fn = ravel_pytree(state_1.position)
+        ravelled_position_2, _ = ravel_pytree(state_2.position)
+
+        ravelled_proposal_1, ravelled_proposal_2 = reflected_gaussians(momentum_key, inverse_mass_matrix,
+                                                                       ravelled_position_1, ravelled_position_2)
+        proposal_1 = unravel_fn(ravelled_proposal_1)
+        proposal_2 = unravel_fn(ravelled_proposal_2)
+
+        u = jax.random.uniform(proposal_key)
+
+        def get_next_state(prev_state, proposed_position):
+            proposed_potential = potential_fn(proposed_position)
+            p_accept = jnp.exp(prev_state.potential_energy - proposed_potential)
+
+            do_accept = u < jnp.minimum(1, p_accept)
+            proposal = RWMHState(proposed_position, proposed_potential)
+            res = jax.lax.cond(do_accept, lambda _: proposal, lambda _: prev_state, operand=None)
+            return res, RWMHInfo(p_accept, do_accept, proposal)
+
+        state_1, info_1 = get_next_state(state_1, proposal_1)
+        state_2, info_2 = get_next_state(state_2, proposal_2)
+        state = CoupledRWMHState(state_1, state_2)
+        info = CoupledRWMHState(info_1, info_2)
+        return state, info
+
+    return one_step
+
+
+def _mvn_loglikelihood(x):
+    return - 0.5 * jnp.sum(x ** 2)
+
+
+def reflected_gaussians(rng_key, inverse_mass_matrix: jnp.DeviceArray,
+                        position_1: jnp.ndarray, position_2: jnp.ndarray):
+    """
+    TODO: document this
+    Example:
+    --------
+    >>> rng_key = jax.random.PRNGKey(42)
+    >>> rng_keys = jax.random.split(rng_key, 1000)
+    >>> inverse_mass_matrix = jnp.ones((1,))
+    >>> position_1 = -jnp.ones((1,))
+    >>> position_2 = jnp.ones((1,))
+    >>> res_1, res_2 = jax.vmap(reflected_gaussians, in_axes=[0, None, None, None])(rng_keys,
+    ...                                                                             inverse_mass_matrix,
+    ...                                                                             position_1,
+    ...                                                                             position_2)
+    >>> (jnp.corrcoef(res_1, res_2, rowvar=False)[0, 1] < 0.5).item()
+    True
+    """
+    ndim = jnp.ndim(inverse_mass_matrix)
+
+    if ndim != 1:  # diagonal mass matrix
+        raise NotImplemented("Only diagonal matrices supported so far")
+
+    shape = jnp.shape(inverse_mass_matrix)[:1]
+
+    sqrt_inv_matrix = jnp.sqrt(inverse_mass_matrix)
+    scaled_diff = jnp.multiply(sqrt_inv_matrix, position_1 - position_2)
+    normed_scaled_diff = scaled_diff / jnp.linalg.norm(scaled_diff, ord=2)
+
+    normal_key, uniform_key = jax.random.split(rng_key, 2)
+    norm = jax.random.normal(uniform_key, shape)
+    log_u = jax.random.uniform(rng_key, ())
+
+    do_accept = log_u + _mvn_loglikelihood(norm) < _mvn_loglikelihood(norm + scaled_diff)
+    accept = lambda _: norm + scaled_diff
+    reject = lambda _: norm - 2 * jnp.dot(norm, normed_scaled_diff) * normed_scaled_diff
+    reflected_norm = jax.lax.cond(do_accept, accept, reject, operand=None)
+
+    mass_matrix_sqrt = jnp.reciprocal(sqrt_inv_matrix)
+    res_1 = position_1 + jnp.multiply(mass_matrix_sqrt, norm)
+    res_2 = position_2 + jnp.multiply(mass_matrix_sqrt, reflected_norm)
+    return res_1, res_2

--- a/blackjax/coupled/rwmh.py
+++ b/blackjax/coupled/rwmh.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, List, NamedTuple, Tuple, Union
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.experimental.host_callback import id_print
 from jax.flatten_util import ravel_pytree
 
 from blackjax.rwmh import RWMHInfo, RWMHState, new_state as new_rwmh_state

--- a/blackjax/coupled/unbiased_hmc.py
+++ b/blackjax/coupled/unbiased_hmc.py
@@ -1,0 +1,119 @@
+"""Public API for the unbiased coupled HMC Kernel"""
+
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax.inference.base as base
+import blackjax.inference.integrators as integrators
+from blackjax.coupled.rwmh import kernel as coupled_rwmh_kernel, new_state as new_coupled_rwmh_state
+from blackjax.hmc import kernel as hmc_kernel
+from blackjax.rwmh import kernel as rwmh_kernel, new_state as new_rwmh_state
+
+Array = Union[np.ndarray, jnp.DeviceArray]
+PyTree = Union[Dict, List, Tuple]
+
+__all__ = ["new_state", "kernel"]
+
+
+class CoupledHMCState(NamedTuple):
+    state_1: base.HMCState
+    state_2: base.HMCState
+
+
+class CoupledHMCInfo(NamedTuple):
+    did_rwmh: bool
+
+
+def new_state(position_1: PyTree, position_2: PyTree, potential_fn: Callable) -> CoupledHMCState:
+    """ Creates two independent chain states from a position by calling base.new_hcm_state twice. """
+    return CoupledHMCState(base.new_hmc_state(position_1, potential_fn),
+                           base.new_hmc_state(position_2, potential_fn))
+
+
+def kernel(
+        potential_fn: Callable,
+        step_size: float,
+        inverse_mass_matrix: Array,
+        num_integration_steps: int,
+        sigma: float,
+        gamma: float,
+        *,
+        integrator: Callable = integrators.velocity_verlet,
+        divergence_threshold: int = 1000,
+):
+    """Build a debiased coupled HMC kernel. The algorithm essentially combines an HMC chain and an RWMH chain
+    into an unbiased scheme.
+
+    Parameters
+    ----------
+    potential_fn
+        A function that returns the potential energy of a chain at a given position.
+    **parameters
+        A NamedTuple that contains the parameters of the kernel to be built.
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current state
+    of the chain and that returns a new state of the chain along with
+    information about the transition.
+
+    """
+    dim = inverse_mass_matrix.shape[0]
+
+    rwmh_kernel_inst = rwmh_kernel(potential_fn, jnp.eye(dim) / (sigma ** 2))
+    coupled_rwmh_kernel_inst = coupled_rwmh_kernel(potential_fn, jnp.eye(dim) / (sigma ** 2))
+    hmc_kernel_inst = hmc_kernel(potential_fn, inverse_mass_matrix, step_size, num_integration_steps,
+                                 integrator=integrator, divergence_threshold=divergence_threshold)
+
+    def one_step(rng_key: jnp.ndarray, state: CoupledHMCState, initial_step: bool) -> Tuple[
+        CoupledHMCState, CoupledHMCInfo]:
+        """Moves the chain by one step using the Hamiltonian dynamics.
+
+        Parameters
+        ----------
+        rng_key:
+           The pseudo-random number generator key used to generate random numbers.
+        state:
+            The current state of the two chain: position, log-probability and gradient
+            of the log-probability.
+        initial_step:
+            Flag to say it is the first step of the algorithm. If it is the case, then the chains need to be initialized
+            differently.
+
+        Returns
+        -------
+        The next state of the chain and additional information about the current step.
+        """
+        uniform_key, kernel_key = jax.random.split(rng_key, 2)
+        uniform = jax.random.uniform(uniform_key)
+        do_rwmh = uniform < gamma
+
+        if not initial_step:
+            def rwmh_fun():
+                rwmh_state = new_coupled_rwmh_state(state.state_1.position, state.state_2.position, potential_fn)
+                res, _ = coupled_rwmh_kernel_inst(kernel_key, rwmh_state)
+                proposed_state = new_state(res.state_1.position, res.state_2.position, potential_fn)
+                return proposed_state
+
+            def hmc_fun():
+                res_1, _ = hmc_kernel_inst(kernel_key, state.state_1)
+                res_2, _ = hmc_kernel_inst(kernel_key, state.state_2)
+                return CoupledHMCState(res_1, res_2)
+        else:
+            def rwmh_fun():
+                rwmh_state = new_rwmh_state(state.state_1.position, potential_fn)
+                res, _ = rwmh_kernel_inst(kernel_key, rwmh_state)
+                proposed_state = new_state(res.state_1.position, state.state_2.position, potential_fn)
+                return proposed_state
+
+            def hmc_fun():
+                res, _ = hmc_kernel_inst(kernel_key, state.state_1)
+                return CoupledHMCState(res, state.state_2)
+
+        proposal = jax.lax.cond(do_rwmh, rwmh_fun, hmc_fun, operand=None)
+
+        return proposal, CoupledHMCInfo(do_rwmh)
+
+    return one_step

--- a/blackjax/coupled_hmc.py
+++ b/blackjax/coupled_hmc.py
@@ -1,0 +1,215 @@
+"""Public API for the coupled HMC Kernel"""
+
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax.inference.base as base
+import blackjax.inference.integrators as integrators
+import blackjax.inference.metrics as metrics
+import blackjax.inference.proposal as proposal
+import blackjax.inference.trajectory as trajectory
+from blackjax.hmc import HMCInfo
+
+Array = Union[np.ndarray, jnp.DeviceArray]
+PyTree = Union[Dict, List, Tuple]
+
+__all__ = ["new_state", "kernel"]
+
+
+class CoupledHMCState(NamedTuple):
+    state_1: base.HMCState
+    state_2: base.HMCState
+
+
+class CoupledHMCInfo(NamedTuple):
+    info_state_1: base.HMCState
+    info_state_2: base.HMCState
+
+
+def new_state(position_1: PyTree, position_2: PyTree, potential_fn: Callable) -> CoupledHMCState:
+    """ Creates two independent chain states from a position by calling base.new_hcm_state twice. """
+    return CoupledHMCState(base.new_hmc_state(position_1, potential_fn),
+                           base.new_hmc_state(position_2, potential_fn))
+
+
+def kernel(
+        potential_fn: Callable,
+        step_size: float,
+        inverse_mass_matrix: Array,
+        num_integration_steps: int,
+        *,
+        integrator: Callable = integrators.velocity_verlet,
+        divergence_threshold: int = 1000,
+):
+    """Build a coupled HMC kernel.
+
+    Parameters
+    ----------
+    potential_fn
+        A function that returns the potential energy of a chain at a given position.
+    parameters
+        A NamedTuple that contains the parameters of the kernel to be built.
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current state
+    of the chain and that returns a new state of the chain along with
+    information about the transition.
+
+    """
+    momentum_generator, kinetic_energy_fn, _ = metrics.gaussian_euclidean(
+        inverse_mass_matrix
+    )
+    symplectic_integrator = integrator(potential_fn, kinetic_energy_fn)
+    proposal_generator = coupled_hmc_proposal(
+        symplectic_integrator,
+        kinetic_energy_fn,
+        step_size,
+        num_integration_steps,
+        divergence_threshold,
+    )
+
+    def one_step(rng_key: jnp.ndarray, state: CoupledHMCState) -> Tuple[CoupledHMCState, CoupledHMCInfo]:
+        """Moves the chain by one step using the Hamiltonian dynamics.
+
+        Parameters
+        ----------
+        rng_key:
+           The pseudo-random number generator key used to generate random numbers.
+        state:
+            The current state of the two chain: position, log-probability and gradient
+            of the log-probability.
+
+        Returns
+        -------
+        The next state of the chain and additional information about the current step.
+        """
+        key_momentum, key_integrator = jax.random.split(rng_key, 2)
+
+        state_1, state_2 = state
+
+        position_1, potential_energy_1, potential_energy_grad_1 = state_1
+        position_2, potential_energy_2, potential_energy_grad_2 = state_2
+        # TODO: atm position is only used for matching tree structure, but the line below could become problematic
+        #       if it ended up being used to actually generate the momentum.
+        momentum = momentum_generator(key_momentum, position_1)  # same momentum for both chains
+
+        augmented_state_1 = integrators.IntegratorState(
+            position_1, momentum, potential_energy_1, potential_energy_grad_1
+        )
+        augmented_state_2 = integrators.IntegratorState(
+            position_2, momentum, potential_energy_2, potential_energy_grad_2
+        )
+        proposal_1, proposal_2, info = proposal_generator(key_integrator, augmented_state_1, augmented_state_2)
+        proposal_1 = base.HMCState(
+            proposal_1.position, proposal_1.potential_energy, proposal_1.potential_energy_grad
+        )
+        proposal_2 = base.HMCState(
+            proposal_2.position, proposal_2.potential_energy, proposal_2.potential_energy_grad
+        )
+        proposal = CoupledHMCState(proposal_1, proposal_2)
+        return proposal, info
+
+    return one_step
+
+
+def coupled_hmc_proposal(
+        integrator: Callable,
+        kinetic_energy: Callable,
+        step_size: float,
+        num_integration_steps: int = 1,
+        divergence_threshold: float = 1000,
+) -> Callable:
+    """Coupled HMC algorithm.
+
+    The algorithm integrates two trajectories with the same momentum perturbation, applying a symplectic integrator
+    `num_integration_steps` times in one direction to get proposals and uses the same uniform sample in the
+    Metropolis-Hastings acceptance step to couple rejection or acceptance of the proposals.
+
+    Parameters
+    ----------
+    integrator
+        Symplectic integrator used to build the trajectory step by step.
+    kinetic_energy
+        Function that computes the kinetic energy.
+    step_size
+        Size of the integration step.
+    num_integration_steps
+        Number of times we run the symplectic integrator to build the trajectory
+    divergence_threshold
+        Threshold above which we say that there is a divergence.
+
+    Returns
+    -------
+    A kernel that generates a new chain state and information about the transition.
+
+    References
+    ----------
+    """
+    build_trajectory = trajectory.static_integration(
+        integrator, step_size, num_integration_steps
+    )
+    init_proposal, generate_proposal = proposal.proposal_generator(
+        kinetic_energy, divergence_threshold
+    )
+    sample_proposal = proposal.static_binomial_sampling
+
+    def flip_momentum(
+            state: integrators.IntegratorState,
+    ) -> integrators.IntegratorState:
+        """To guarantee time-reversibility (hence detailed balance) we
+        need to flip the last state's momentum. If we run the hamiltonian
+        dynamics starting from the last state with flipped momentum we
+        should indeed retrieve the initial state (with flipped momentum).
+
+        """
+        flipped_momentum = jax.tree_util.tree_multimap(
+            lambda m: -1.0 * m, state.momentum
+        )
+        return integrators.IntegratorState(
+            state.position,
+            flipped_momentum,
+            state.potential_energy,
+            state.potential_energy_grad,
+        )
+
+    def generate(
+            rng_key, state_1: integrators.IntegratorState, state_2: integrators.IntegratorState
+    ) -> Tuple[integrators.IntegratorState, integrators.IntegratorState, CoupledHMCInfo]:
+        """Generate a new chain state."""
+
+        def _generate(state):
+            end_state = build_trajectory(state)
+            end_state = flip_momentum(end_state)
+
+            proposal = init_proposal(state)
+
+            new_proposal, is_diverging = generate_proposal(proposal.energy, end_state)
+
+            # Same key on purpose
+            sampled_proposal, *info = sample_proposal(rng_key, proposal, new_proposal)
+            do_accept, p_accept = info
+
+            info = HMCInfo(
+                state.momentum,
+                p_accept,
+                do_accept,
+                is_diverging,
+                new_proposal.energy,
+                new_proposal,
+                num_integration_steps,
+            )
+
+            return sampled_proposal.state, info
+
+        state_1, info_1 = _generate(state_1)
+        state_2, info_2 = _generate(state_2)
+
+        info = CoupledHMCInfo(info_1, info_2)
+
+        return state_1, state_2, info
+
+    return generate

--- a/blackjax/coupled_hmc.py
+++ b/blackjax/coupled_hmc.py
@@ -148,6 +148,8 @@ def coupled_hmc_proposal(
 
     References
     ----------
+    [1] J. Heng, P. E. Jacob, Unbiased Hamiltonian Monte Carlo with couplings,
+        Biometrika, Volume 106, Issue 2, June 2019, Pages 287–302, https://doi.org/10.1093/biomet/asy074
     """
     build_trajectory = trajectory.static_integration(
         integrator, step_size, num_integration_steps

--- a/blackjax/inference/integrators.py
+++ b/blackjax/inference/integrators.py
@@ -31,7 +31,7 @@ def new_integrator_state(potential_fn, position, momentum):
 
 
 def velocity_verlet(
-    potential_fn: Callable, kinetic_energy_fn: EuclideanKineticEnergy
+        potential_fn: Callable, kinetic_energy_fn: EuclideanKineticEnergy
 ) -> EuclideanIntegrator:
     """The velocity Verlet (or Verlet-Störmer) integrator.
 
@@ -102,7 +102,7 @@ def velocity_verlet(
 
 
 def mclachlan(
-    potential_fn: Callable, kinetic_energy_fn: Callable
+        potential_fn: Callable, kinetic_energy_fn: Callable
 ) -> EuclideanIntegrator:
     """Two-stage palindromic symplectic integrator derived in [1]_
 
@@ -253,3 +253,23 @@ def yoshida(potential_fn: Callable, kinetic_energy_fn: Callable) -> EuclideanInt
         )
 
     return one_step
+
+
+def flip_momentum(
+        state: IntegratorState,
+) -> IntegratorState:
+    """To guarantee time-reversibility (hence detailed balance) we
+    need to flip the last state's momentum. If we run the hamiltonian
+    dynamics starting from the last state with flipped momentum we
+    should indeed retrieve the initial state (with flipped momentum).
+
+    """
+    flipped_momentum = jax.tree_util.tree_multimap(
+        lambda m: -1.0 * m, state.momentum
+    )
+    return IntegratorState(
+        state.position,
+        flipped_momentum,
+        state.potential_energy,
+        state.potential_energy_grad,
+    )

--- a/blackjax/inference/metrics.py
+++ b/blackjax/inference/metrics.py
@@ -94,12 +94,15 @@ def gaussian_euclidean(
             f" expected 1 or 2, got {jnp.ndim(inverse_mass_matrix)}."
         )
 
-    def momentum_generator(rng_key: jnp.ndarray, position: PyTree) -> PyTree:
+    def momentum_generator(rng_key: jnp.ndarray, position: PyTree, unravel: bool=True) -> PyTree:
         _, unravel_fn = ravel_pytree(position)
         standard_normal_sample = jax.random.normal(rng_key, shape)
         momentum = dot(mass_matrix_sqrt, standard_normal_sample)
-        momentum_unravel = unravel_fn(momentum)
-        return momentum_unravel
+        if unravel:
+            momentum_unravel = unravel_fn(momentum)
+            return momentum_unravel
+        else:
+            return momentum
 
     def kinetic_energy(momentum: PyTree) -> float:
         momentum, _ = ravel_pytree(momentum)

--- a/blackjax/rwmh.py
+++ b/blackjax/rwmh.py
@@ -64,7 +64,7 @@ def kernel(
         potential_fn: Callable,
         inverse_mass_matrix: Array,
 ):
-    """Build a HMC kernel.
+    """Build a RWMH kernel.
 
     Parameters
     ----------
@@ -125,3 +125,4 @@ def kernel(
         return RWMHState(new_position, new_potential), RWMHInfo(p_accept, do_accept, proposed_position)
 
     return one_step
+

--- a/blackjax/rwmh.py
+++ b/blackjax/rwmh.py
@@ -1,0 +1,127 @@
+"""Public API for the Random Walk Metropolis-Hastings Kernel"""
+from typing import Callable, Dict, List, NamedTuple, Tuple, Union
+
+import jax.numpy as jnp
+import jax.random
+import numpy as np
+from jax.flatten_util import ravel_pytree
+
+import blackjax.inference.metrics as metrics
+
+Array = Union[np.ndarray, jnp.DeviceArray]
+PyTree = Union[Dict, List, Tuple]
+
+__all__ = ["new_state", "kernel", "RWMHState"]
+
+
+class RWMHState(NamedTuple):
+    """ State of the RWMH chain
+
+    position
+        Current position of the chain.
+    potential_energy
+        Current value of the potential energy
+    """
+    position: PyTree
+    potential_energy: float
+
+
+class RWMHInfo(NamedTuple):
+    """Additional information on the RWMH chain.
+
+    This additional information can be used for debugging or computing
+    diagnostics.
+
+    acceptance_probability
+        The acceptance probability of the transition, linked to the energy
+        difference between the original and the proposed states.
+    is_accepted
+        Whether the proposed position was accepted or the original position
+        was returned.
+    proposal
+        The state proposed by the proposal.
+    """
+
+    acceptance_probability: float
+    is_accepted: bool
+    proposal: PyTree
+
+
+def new_state(position: PyTree, potential_fn: Callable) -> RWMHState:
+    """Create a chain state from a position.
+
+    Parameters:
+    -----------
+    position: PyTree
+        The initial position of the chain
+    potential_fn: Callable
+        Target potential function of the chain
+    """
+    return RWMHState(position, potential_fn(position))
+
+
+def kernel(
+        potential_fn: Callable,
+        inverse_mass_matrix: Array,
+):
+    """Build a HMC kernel.
+
+    Parameters
+    ----------
+    potential_fn
+        A function that returns the potential energy of a chain at a given position.
+    inverse_mass_matrix
+        One or two-dimensional array corresponding respectively to a diagonal
+        or dense mass matrix. The inverse mass matrix is multiplied to a
+        flattened version of the Pytree in which the chain position is stored
+        (the current value of the random variables). The order of the variables
+        should thus match JAX's tree flattening order, and more specifically
+        that of `ravel_pytree`.
+        In particular, JAX sorts dictionaries by key when flattening them. The
+        value of each variables will appear in the flattened Pytree following
+        the order given by `sort(keys)`.
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current state
+    of the chain and that returns a new state of the chain along with
+    information about the transition.
+
+    """
+
+    momentum_generator, *_ = metrics.gaussian_euclidean(inverse_mass_matrix)
+
+    def one_step(rng_key: jnp.ndarray, state: RWMHState):
+        """Moves the chain by one step using the Hamiltonian dynamics.
+
+        Parameters
+        ----------
+        rng_key:
+           The pseudo-random number generator key used to generate random numbers.
+        state:
+            The current state of the chain.
+
+        Returns
+        -------
+        The next state of the chain and additional information about the current step.
+        """
+        momentum_key, proposal_key = jax.random.split(rng_key, 2)
+        momentum = momentum_generator(momentum_key, state.position, unravel=False)
+
+        ravelled_position, unravel_fn = ravel_pytree(state.position)
+        ravelled_proposed_position = ravelled_position + momentum
+        proposed_position = unravel_fn(ravelled_proposed_position)
+        proposed_potential = potential_fn(proposed_position)
+
+        u = jax.random.uniform(proposal_key)
+        p_accept = jnp.exp(state.potential_energy - proposed_potential)
+        do_accept = u < p_accept
+
+        new_position, new_potential = jax.lax.cond(
+            do_accept,
+            lambda _: (proposed_position, proposed_potential),
+            lambda _: (state.position, state.potential_energy),
+            operand=None)
+        return RWMHState(new_position, new_potential), RWMHInfo(p_accept, do_accept, proposed_position)
+
+    return one_step

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -6,7 +6,7 @@ import jax
 import jax.numpy as jnp
 import jax.scipy as jscipy
 
-import blackjax.coupled_hmc as coupled_hmc
+import blackjax.coupled.hmc as coupled_hmc
 import blackjax.hmc as hmc
 import blackjax.nuts as nuts
 

--- a/tests/test_coupled_hmc.py
+++ b/tests/test_coupled_hmc.py
@@ -7,17 +7,8 @@ import numpy as np
 
 import blackjax.coupled.hmc as coupled_hmc
 import blackjax.hmc as hmc
+from .utils import inference_loop
 
-
-def inference_loop(rng_key, kernel, initial_state, num_samples):
-    def one_step(state, rng_key):
-        state, _ = kernel(rng_key, state)
-        return state, state
-
-    keys = jax.random.split(rng_key, num_samples)
-    _, states = jax.lax.scan(one_step, initial_state, keys)
-
-    return states
 
 
 def normal_potential_fn(x):

--- a/tests/test_coupled_hmc.py
+++ b/tests/test_coupled_hmc.py
@@ -1,0 +1,78 @@
+"""Test the behaviour of the coupled HMC kernel"""
+
+import jax
+import jax.numpy as jnp
+import jax.scipy.stats as stats
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+
+import blackjax.coupled_hmc as coupled_hmc
+import blackjax.hmc as hmc
+
+
+def inference_loop(rng_key, kernel, initial_state, num_samples):
+    def one_step(state, rng_key):
+        state, _ = kernel(rng_key, state)
+        return state, state
+
+    keys = jax.random.split(rng_key, num_samples)
+    _, states = jax.lax.scan(one_step, initial_state, keys)
+
+    return states
+
+
+# -------------------------------------------------------------------
+#                        LINEAR REGRESSION
+# -------------------------------------------------------------------
+
+def normal_potential_fn(x):
+    return -stats.norm.logpdf(x, loc=1.0, scale=2.0).squeeze()
+
+
+normal_test_cases = [
+    {
+        "algorithm": hmc,
+        "initial_position": {"x": 1.0},
+        "parameters": {
+            "step_size": 1e-2,
+            "inverse_mass_matrix": jnp.array([0.1]),
+            "num_integration_steps": 100,
+        },
+        "num_sampling_steps": 50_000,
+    },
+]
+
+
+@pytest.mark.parametrize("is_mass_matrix_diagonal", [True, False])
+def test_univariate_normal(is_mass_matrix_diagonal):
+    rng_key = jax.random.PRNGKey(19)
+    n_sampling_steps = 50_000
+
+    potential = lambda x: normal_potential_fn(**x)
+
+    initial_position_1 = {"x": 1.}
+    initial_position_2 = {"x": -1.}
+
+    initial_state_hmc = hmc.new_state(initial_position_1, potential)
+    initial_state_coupled_hmc = coupled_hmc.new_state(initial_position_1, initial_position_2, potential)
+
+    parameters = {"step_size": 1e-2,
+                  "inverse_mass_matrix": jnp.array([0.1]),
+                  "num_integration_steps": 100,
+                  }
+
+    hmc_kernel = hmc.kernel(potential, **parameters)
+    coupled_hmc_kernel = coupled_hmc.kernel(potential, **parameters)
+
+    hmc_states = inference_loop(rng_key, hmc_kernel, initial_state_hmc, n_sampling_steps)
+    coupled_hmc_states = inference_loop(rng_key, coupled_hmc_kernel, initial_state_coupled_hmc, n_sampling_steps)
+
+    hmc_samples = hmc_states.position["x"]
+    coupled_hmc_states_1 = coupled_hmc_states.state_1.position["x"]
+    coupled_hmc_states_2 = coupled_hmc_states.state_2.position["x"]
+
+    np.testing.assert_array_almost_equal(hmc_samples, coupled_hmc_states_1)
+    np.testing.assert_array_almost_equal(coupled_hmc_states_1[2000:], coupled_hmc_states_2[2000:])  # the two trajectories match
+    np.testing.assert_array_less(coupled_hmc_states_2[:1000], coupled_hmc_states_1[:1000])  # burn-in phase
+

--- a/tests/test_coupled_hmc.py
+++ b/tests/test_coupled_hmc.py
@@ -5,7 +5,7 @@ import jax.numpy as jnp
 import jax.scipy.stats as stats
 import numpy as np
 
-import blackjax.coupled_hmc as coupled_hmc
+import blackjax.coupled.hmc as coupled_hmc
 import blackjax.hmc as hmc
 
 

--- a/tests/test_coupled_hmc.py
+++ b/tests/test_coupled_hmc.py
@@ -3,9 +3,7 @@
 import jax
 import jax.numpy as jnp
 import jax.scipy.stats as stats
-import matplotlib.pyplot as plt
 import numpy as np
-import pytest
 
 import blackjax.coupled_hmc as coupled_hmc
 import blackjax.hmc as hmc
@@ -22,30 +20,11 @@ def inference_loop(rng_key, kernel, initial_state, num_samples):
     return states
 
 
-# -------------------------------------------------------------------
-#                        LINEAR REGRESSION
-# -------------------------------------------------------------------
-
 def normal_potential_fn(x):
     return -stats.norm.logpdf(x, loc=1.0, scale=2.0).squeeze()
 
 
-normal_test_cases = [
-    {
-        "algorithm": hmc,
-        "initial_position": {"x": 1.0},
-        "parameters": {
-            "step_size": 1e-2,
-            "inverse_mass_matrix": jnp.array([0.1]),
-            "num_integration_steps": 100,
-        },
-        "num_sampling_steps": 50_000,
-    },
-]
-
-
-@pytest.mark.parametrize("is_mass_matrix_diagonal", [True, False])
-def test_univariate_normal(is_mass_matrix_diagonal):
+def test_coupling_hmc():
     rng_key = jax.random.PRNGKey(19)
     n_sampling_steps = 50_000
 
@@ -73,6 +52,6 @@ def test_univariate_normal(is_mass_matrix_diagonal):
     coupled_hmc_states_2 = coupled_hmc_states.state_2.position["x"]
 
     np.testing.assert_array_almost_equal(hmc_samples, coupled_hmc_states_1)
-    np.testing.assert_array_almost_equal(coupled_hmc_states_1[2000:], coupled_hmc_states_2[2000:])  # the two trajectories match
+    np.testing.assert_array_almost_equal(coupled_hmc_states_1[2000:],
+                                         coupled_hmc_states_2[2000:])  # the two trajectories match
     np.testing.assert_array_less(coupled_hmc_states_2[:1000], coupled_hmc_states_1[:1000])  # burn-in phase
-

--- a/tests/test_coupled_rwmh.py
+++ b/tests/test_coupled_rwmh.py
@@ -1,0 +1,55 @@
+"""Test the behaviour of the coupled RWMH kernel"""
+
+import jax
+import jax.numpy as jnp
+import jax.scipy.stats as stats
+import numpy as np
+
+import blackjax.coupled.rwmh as coupled_rwmh
+import blackjax.rwmh as rwmh
+
+
+def inference_loop(rng_key, kernel, initial_state, num_samples):
+    def one_step(state, rng_key):
+        state, _ = kernel(rng_key, state)
+        return state, state
+
+    keys = jax.random.split(rng_key, num_samples)
+    _, states = jax.lax.scan(one_step, initial_state, keys)
+
+    return states
+
+
+def normal_potential_fn(x):
+    return -stats.norm.logpdf(x, loc=1.0, scale=2.0).squeeze()
+
+
+def test_coupling():
+    rng_key = jax.random.PRNGKey(19)
+    n_sampling_steps = 50_000
+
+    potential = lambda x: normal_potential_fn(**x)
+
+    initial_position_1 = {"x": 1.}
+    initial_position_2 = {"x": -1.}
+
+    initial_state = rwmh.new_state(initial_position_1, potential)
+    initial_state_coupled = coupled_rwmh.new_state(initial_position_1, initial_position_2, potential)
+
+    parameters = {"inverse_mass_matrix": jnp.array([10.]),
+                  }
+
+    rwmh_kernel = rwmh.kernel(potential, **parameters)
+    coupled_rwmh_kernel = coupled_rwmh.kernel(potential, **parameters)
+
+    states = inference_loop(rng_key, rwmh_kernel, initial_state, n_sampling_steps)
+    coupled_states = inference_loop(rng_key, coupled_rwmh_kernel, initial_state_coupled, n_sampling_steps)
+
+    samples = states.position["x"]
+    coupled_states_1 = coupled_states.state_1.position["x"]
+    coupled_states_2 = coupled_states.state_2.position["x"]
+
+    np.testing.assert_array_almost_equal(samples, coupled_states_1)
+    np.testing.assert_array_almost_equal(coupled_states_1[2000:],
+                                         coupled_states_2[2000:])  # the two trajectories match
+    np.testing.assert_array_less(coupled_states_2[:1000], coupled_states_1[:1000])  # burn-in phase

--- a/tests/test_coupled_rwmh.py
+++ b/tests/test_coupled_rwmh.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import blackjax.coupled.rwmh as coupled_rwmh
 import blackjax.rwmh as rwmh
+from blackjax.inference import metrics
 
 
 def inference_loop(rng_key, kernel, initial_state, num_samples):
@@ -26,7 +27,7 @@ def normal_potential_fn(x):
 
 def test_coupling():
     rng_key = jax.random.PRNGKey(19)
-    n_sampling_steps = 50_000
+    n_sampling_steps = 10_000
 
     potential = lambda x: normal_potential_fn(**x)
 
@@ -36,8 +37,7 @@ def test_coupling():
     initial_state = rwmh.new_state(initial_position_1, potential)
     initial_state_coupled = coupled_rwmh.new_state(initial_position_1, initial_position_2, potential)
 
-    parameters = {"inverse_mass_matrix": jnp.array([10.]),
-                  }
+    parameters = {"inverse_mass_matrix": jnp.array([1e3]), }
 
     rwmh_kernel = rwmh.kernel(potential, **parameters)
     coupled_rwmh_kernel = coupled_rwmh.kernel(potential, **parameters)
@@ -49,7 +49,44 @@ def test_coupling():
     coupled_states_1 = coupled_states.state_1.position["x"]
     coupled_states_2 = coupled_states.state_2.position["x"]
 
-    np.testing.assert_array_almost_equal(samples, coupled_states_1)
-    np.testing.assert_array_almost_equal(coupled_states_1[2000:],
-                                         coupled_states_2[2000:])  # the two trajectories match
-    np.testing.assert_array_less(coupled_states_2[:1000], coupled_states_1[:1000])  # burn-in phase
+    # np.testing.assert_array_almost_equal(samples, coupled_states_1)
+    np.testing.assert_array_almost_equal(coupled_states_1[2_000:],
+                                         coupled_states_2[2_000:])  # the two trajectories match
+    np.testing.assert_array_less(coupled_states_2[:300], coupled_states_1[:300])  # burn-in phase
+
+
+def test_maximal_coupling():
+    position_1, position_2 = 1., -1.
+    n_samples = 50_000
+
+    approx_equal_proba = 0.5
+    sigma = np.abs(position_1 - position_2) / (np.sqrt(2 * np.pi) * (1 - approx_equal_proba))
+
+    inverse_mass_matrix = jnp.array([1 / sigma ** 2])
+    keys = jax.random.split(jax.random.PRNGKey(42), n_samples)
+
+    norm_1, norm_2 = jax.vmap(coupled_rwmh.reflected_gaussians, [0, None, None, None])(keys,
+                                                                                       inverse_mass_matrix,
+                                                                                       position_1,
+                                                                                       position_2)
+
+    np.testing.assert_almost_equal(np.mean(norm_1), position_1, decimal=2)
+    np.testing.assert_almost_equal(np.mean(norm_2), position_2, decimal=2)
+
+    np.testing.assert_almost_equal(np.var(norm_1), sigma ** 2, decimal=2)
+    np.testing.assert_almost_equal(np.var(norm_2), sigma ** 2, decimal=2)
+
+    np.testing.assert_almost_equal(np.sum((norm_1 - norm_2 < 1e-5)) / n_samples, approx_equal_proba, decimal=1)
+
+
+def test_one_proposal():
+    position_1, position_2 = 0.1, -0.1
+    inverse_mass_matrix = jnp.array([1. / (0.1 ** 2)])
+    key = jax.random.PRNGKey(42)
+
+    momentum_generator, *_ = metrics.gaussian_euclidean(inverse_mass_matrix)
+
+    norm_1, norm_2 = coupled_rwmh.reflected_gaussians(key, inverse_mass_matrix, position_1, position_2)
+    other_norm_1 = momentum_generator(jax.random.split(key)[1], 0.1)
+    np.testing.assert_array_almost_equal(norm_1, other_norm_1)
+    print(norm_2)

--- a/tests/test_coupled_rwmh.py
+++ b/tests/test_coupled_rwmh.py
@@ -8,18 +8,7 @@ import numpy as np
 import blackjax.coupled.rwmh as coupled_rwmh
 import blackjax.rwmh as rwmh
 from blackjax.inference import metrics
-
-
-def inference_loop(rng_key, kernel, initial_state, num_samples):
-    def one_step(state, rng_key):
-        state, _ = kernel(rng_key, state)
-        return state, state
-
-    keys = jax.random.split(rng_key, num_samples)
-    _, states = jax.lax.scan(one_step, initial_state, keys)
-
-    return states
-
+from .utils import inference_loop
 
 def normal_potential_fn(x):
     return -stats.norm.logpdf(x, loc=1.0, scale=2.0).squeeze()

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -11,17 +11,7 @@ import blackjax.hmc as hmc
 import blackjax.nuts as nuts
 import blackjax.rwmh as rwmh
 import blackjax.stan_warmup as stan_warmup
-
-
-def inference_loop(rng_key, kernel, initial_state, num_samples):
-    def one_step(state, rng_key):
-        state, _ = kernel(rng_key, state)
-        return state, state
-
-    keys = jax.random.split(rng_key, num_samples)
-    _, states = jax.lax.scan(one_step, initial_state, keys)
-
-    return states
+from .utils import inference_loop
 
 
 # -------------------------------------------------------------------
@@ -125,7 +115,7 @@ normal_test_cases = [
         "parameters": {"step_size": 1e-2, "inverse_mass_matrix": jnp.array([0.1])},
         "num_sampling_steps": 50_000,
     },
-{
+    {
         "algorithm": rwmh,
         "initial_position": {"x": 1.0},
         "parameters": {"inverse_mass_matrix": jnp.array([0.1])},

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -9,6 +9,7 @@ import pytest
 
 import blackjax.hmc as hmc
 import blackjax.nuts as nuts
+import blackjax.rwmh as rwmh
 import blackjax.stan_warmup as stan_warmup
 
 
@@ -124,6 +125,12 @@ normal_test_cases = [
         "parameters": {"step_size": 1e-2, "inverse_mass_matrix": jnp.array([0.1])},
         "num_sampling_steps": 50_000,
     },
+{
+        "algorithm": rwmh,
+        "initial_position": {"x": 1.0},
+        "parameters": {"inverse_mass_matrix": jnp.array([0.1])},
+        "num_sampling_steps": 50_000,
+    },
 ]
 
 
@@ -136,6 +143,7 @@ def test_univariate_normal(case, is_mass_matrix_diagonal):
     initial_state = case["algorithm"].new_state(initial_position, potential)
 
     kernel = case["algorithm"].kernel(potential, **case["parameters"])
+    kernel(rng_key, initial_state)
     states = inference_loop(rng_key, kernel, initial_state, case["num_sampling_steps"])
 
     samples = states.position["x"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+import jax
+
+
+def inference_loop(rng_key, kernel, initial_state, num_samples):
+    def one_step(state, rng_key):
+        state, _ = kernel(rng_key, state)
+        return state, state
+
+    keys = jax.random.split(rng_key, num_samples)
+    _, states = jax.lax.scan(one_step, initial_state, keys)
+
+    return states


### PR DESCRIPTION
This is a first crack at implementing coupled Markov chains as per this issue.

https://github.com/blackjax-devs/blackjax/issues/64

Apart from a big clean-up it will also require implementing Glynn-Rhee types of expectations estimates in order to effectively remove the MCMC bias. See essentially 2.3 in https://rss.onlinelibrary.wiley.com/doi/full/10.1111/rssb.12336 for the "easy" version for MH. 