### PR TITLE
Add diagnostics

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -2,4 +2,4 @@ from . import hmc, inference
 
 __version__ = "0.2.1"
 
-__all__ = ["hmc", "nuts", "stan_warmup", "inference", "adaptation"]
+__all__ = ["hmc", "nuts", "stan_warmup", "inference", "adaptation", "diagnostics"]

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -34,9 +34,9 @@ def potential_scale_reduction(
     -----
     The diagnostic is computed by:
 
-      .. math:: \hat{R} = \frac{\hat{V}}{W}
+      .. math:: \\hat{R} = \\frac{\\hat{V}}{W}
 
-    where :math:`W` is the within-chain variance and :math:`\hat{V}` is the posterior variance
+    where :math:`W` is the within-chain variance and :math:`\\hat{V}` is the posterior variance
     estimate for the pooled traces. This is the potential scale reduction factor, which
     converges to unity when each of the traces is a sample from the target posterior. Values
     greater than one indicate that one or more chains have not yet converged.
@@ -86,16 +86,16 @@ def effective_sample_size(
 
     Notes
     -----
-    The basic ess (:math:`N_{\mathit{eff}}`) diagnostic is computed by:
+    The basic ess (:math:`N_{\\mathit{eff}}`) diagnostic is computed by:
 
-    .. math:: \hat{N}_{\mathit{eff}} = \frac{MN}{\hat{\tau}}
+    .. math:: \\hat{N}_{\\mathit{eff}} = \\frac{MN}{\\hat{\\tau}}
 
-    .. math:: \hat{\tau} = -1 + 2 \sum_{t'=0}^K \hat{P}_{t'}
+    .. math:: \\hat{\\tau} = -1 + 2 \\sum_{t'=0}^K \\hat{P}_{t'}
 
     where :math:`M` is the number of chains, :math:`N` the number of draws,
-    :math:`\hat{\rho}_t` is the estimated _autocorrelation at lag :math:`t`, and
-    :math:`K` is the last integer for which :math:`\hat{P}_{K} = \hat{\rho}_{2K} +
-    \hat{\rho}_{2K+1}` is still positive.
+    :math:`\\hat{\rho}_t` is the estimated _autocorrelation at lag :math:`t`, and
+    :math:`K` is the last integer for which :math:`\\hat{P}_{K} = \\hat{\rho}_{2K} +
+    \\hat{\rho}_{2K+1}` is still positive.
 
     The current implementation is similar to Stan, which uses Geyer's initial monotone sequence
     criterion (Geyer, 1992; Geyer, 2011).
@@ -103,9 +103,10 @@ def effective_sample_size(
     References
     ----------
     .. [1]: https://mc-stan.org/docs/2_27/reference-manual/effective-sample-size-section.html
-    .. [2]: Gelman, Andrew, J. B. Carlin, Hal S. Stern, David B. Dunson, Aki Vehtari, and Donald B. Rubin. (2013). Bayesian Data Analysis. Third Edition. London: Chapman & Hall / CRC Press.
+    .. [2]: Gelman, Andrew, J. B. Carlin, Hal S. Stern, David B. Dunson, Aki Vehtari, and Donald B. Rubin. (2013). Bayesian Data Analysis. Third Edition. Chapman; Hall/CRC.
     .. [3]: Geyer, Charles J. (1992). “Practical Markov Chain Monte Carlo.” Statistical Science, 473–83.
     .. [4]: Geyer, Charles J. (2011). “Introduction to Markov Chain Monte Carlo.” In Handbook of Markov Chain Monte Carlo, edited by Steve Brooks, Andrew Gelman, Galin L. Jones, and Xiao-Li Meng, 3–48. Chapman; Hall/CRC.
+
     """
     input_shape = input_array.shape
     sample_axis = sample_axis if sample_axis >= 0 else len(input_shape) + sample_axis

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -102,7 +102,7 @@ def effective_sample_size(
 
     References
     ----------
-    .. [1]: https://mc-stan.org/docs/2_27/reference-manual/effective-sample-size-section.html   
+    .. [1]: https://mc-stan.org/docs/2_27/reference-manual/effective-sample-size-section.html
     .. [2]: Gelman, Andrew, J. B. Carlin, Hal S. Stern, David B. Dunson, Aki Vehtari, and Donald B. Rubin. (2013). Bayesian Data Analysis. Third Edition. London: Chapman & Hall / CRC Press.
     .. [3]: Geyer, Charles J. (1992). “Practical Markov Chain Monte Carlo.” Statistical Science, 473–83.
     .. [4]: Geyer, Charles J. (2011). “Introduction to Markov Chain Monte Carlo.” In Handbook of Markov Chain Monte Carlo, edited by Steve Brooks, Andrew Gelman, Galin L. Jones, and Xiao-Li Meng, 3–48. Chapman; Hall/CRC.

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -1,4 +1,4 @@
-"""MCMC diagnoistics."""
+"""MCMC diagnostics."""
 from typing import Union
 
 import jax
@@ -29,6 +29,22 @@ def potential_scale_reduction(
     Returns
     -------
     NDArray of the resulting statistics (r-hat), with the chain and sample dimensions squeezed.
+
+    Notes
+    -----
+    The diagnostic is computed by:
+
+      .. math:: \hat{R} = \frac{\hat{V}}{W}
+
+    where :math:`W` is the within-chain variance and :math:`\hat{V}` is the posterior variance
+    estimate for the pooled traces. This is the potential scale reduction factor, which
+    converges to unity when each of the traces is a sample from the target posterior. Values
+    greater than one indicate that one or more chains have not yet converged.
+
+    References
+    ----------
+    .. [1]: https://mc-stan.org/docs/2_27/reference-manual/notation-for-samples-chains-and-draws.html#potential-scale-reduction
+    .. [2]: Gelman, Andrew, and Donald B. Rubin. (1992) “Inference from Iterative Simulation Using Multiple Sequences.” Statistical Science 7 (4): 457–72.
 
     """
     num_samples = input_array.shape[sample_axis]
@@ -68,6 +84,28 @@ def effective_sample_size(
     -------
     NDArray of the resulting statistics (ess), with the chain and sample dimensions squeezed.
 
+    Notes
+    -----
+    The basic ess (:math:`N_{\mathit{eff}}`) diagnostic is computed by:
+
+    .. math:: \hat{N}_{\mathit{eff}} = \frac{MN}{\hat{\tau}}
+
+    .. math:: \hat{\tau} = -1 + 2 \sum_{t'=0}^K \hat{P}_{t'}
+
+    where :math:`M` is the number of chains, :math:`N` the number of draws,
+    :math:`\hat{\rho}_t` is the estimated _autocorrelation at lag :math:`t`, and
+    :math:`K` is the last integer for which :math:`\hat{P}_{K} = \hat{\rho}_{2K} +
+    \hat{\rho}_{2K+1}` is still positive.
+
+    The current implementation is similar to Stan, which uses Geyer's initial monotone sequence
+    criterion (Geyer, 1992; Geyer, 2011).
+
+    References
+    ----------
+    .. [1]: https://mc-stan.org/docs/2_27/reference-manual/effective-sample-size-section.html   
+    .. [2]: Gelman, Andrew, J. B. Carlin, Hal S. Stern, David B. Dunson, Aki Vehtari, and Donald B. Rubin. (2013). Bayesian Data Analysis. Third Edition. London: Chapman & Hall / CRC Press.
+    .. [3]: Geyer, Charles J. (1992). “Practical Markov Chain Monte Carlo.” Statistical Science, 473–83.
+    .. [4]: Geyer, Charles J. (2011). “Introduction to Markov Chain Monte Carlo.” In Handbook of Markov Chain Monte Carlo, edited by Steve Brooks, Andrew Gelman, Galin L. Jones, and Xiao-Li Meng, 3–48. Chapman; Hall/CRC.
     """
     input_shape = input_array.shape
     sample_axis = sample_axis if sample_axis >= 0 else len(input_shape) + sample_axis

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,4 +1,4 @@
-"""Test MCMC diagnoistics."""
+"""Test MCMC diagnostics."""
 import jax
 import numpy as np
 import pytest
@@ -34,18 +34,18 @@ def insert_list(input_list, loc, elem):
 
 
 @pytest.mark.parametrize("case", test_cases)
-@pytest.mark.parametrize("nchain", [2, 10])
+@pytest.mark.parametrize("num_chains", [2, 10])
 @pytest.mark.parametrize("event_shape", [(), (3,), (5, 7)])
-def test_rhat_ess(case, nchain, event_shape):
+def test_rhat_ess(case, num_chains, event_shape):
     rng_key = jax.random.PRNGKey(32)
-    n_samples = 5000
+    num_samples = 5000
     sample_shape = list(event_shape)
     if case["chain_axis"] < case["sample_axis"]:
-        sample_shape = insert_list(sample_shape, case["chain_axis"], nchain)
-        sample_shape = insert_list(sample_shape, case["sample_axis"], n_samples)
+        sample_shape = insert_list(sample_shape, case["chain_axis"], num_chains)
+        sample_shape = insert_list(sample_shape, case["sample_axis"], num_samples)
     else:
-        sample_shape = insert_list(sample_shape, case["sample_axis"], n_samples)
-        sample_shape = insert_list(sample_shape, case["chain_axis"], nchain)
+        sample_shape = insert_list(sample_shape, case["sample_axis"], num_samples)
+        sample_shape = insert_list(sample_shape, case["chain_axis"], num_chains)
     mc_samples = jax.random.normal(rng_key, shape=sample_shape)
 
     rhat_val = diagnostics.potential_scale_reduction(mc_samples, **case)
@@ -55,4 +55,4 @@ def test_rhat_ess(case, nchain, event_shape):
     # With iid samples we should get ess close to number of samples.
     ess_val = diagnostics.effective_sample_size(mc_samples, **case)
     np.testing.assert_array_equal(ess_val.shape, event_shape)
-    np.testing.assert_allclose(ess_val, nchain * n_samples, rtol=10)
+    np.testing.assert_allclose(ess_val, num_chains * num_samples, rtol=10)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,58 @@
+"""Test MCMC diagnoistics."""
+import jax
+import numpy as np
+import pytest
+
+import blackjax.diagnostics as diagnostics
+
+test_cases = [
+    {
+        "chain_axis": 0,
+        "sample_axis": 1,
+    },
+    {
+        "chain_axis": 1,
+        "sample_axis": 0,
+    },
+    {
+        "chain_axis": 0,
+        "sample_axis": -1,
+    },
+    {
+        "chain_axis": -1,
+        "sample_axis": 0,
+    },
+]
+
+
+def insert_list(input_list, loc, elem):
+    if loc == -1:
+        input_list.append(elem)
+    else:
+        input_list.insert(loc, elem)
+    return input_list
+
+
+@pytest.mark.parametrize("case", test_cases)
+@pytest.mark.parametrize("nchain", [2, 10])
+@pytest.mark.parametrize("event_shape", [(), (3,), (5, 7)])
+def test_rhat_ess(case, nchain, event_shape):
+    rng_key = jax.random.PRNGKey(32)
+    n_samples = 5000
+    sample_shape = list(event_shape)
+    if case["chain_axis"] < case["sample_axis"]:
+        sample_shape = insert_list(sample_shape, case["chain_axis"], nchain)
+        sample_shape = insert_list(sample_shape, case["sample_axis"], n_samples)
+    else:
+        sample_shape = insert_list(sample_shape, case["sample_axis"], n_samples)
+        sample_shape = insert_list(sample_shape, case["chain_axis"], nchain)
+    mc_samples = jax.random.normal(rng_key, shape=sample_shape)
+
+    rhat_val = diagnostics.potential_scale_reduction(mc_samples, **case)
+    np.testing.assert_array_equal(rhat_val.shape, event_shape)
+    np.testing.assert_allclose(rhat_val, 1.0, rtol=1e-03)
+
+    # With iid samples we should get ess close to number of samples.
+    ess_val = diagnostics.effective_sample_size(mc_samples, **case)
+    np.testing.assert_array_equal(ess_val.shape, event_shape)
+    np.testing.assert_allclose(ess_val, nchain * n_samples, rtol=10)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -187,10 +187,8 @@ def generate_multivariate_target(rng=None):
 def mcse_test(samples, true_param, p_val=0.01):
     posterior_mean = jnp.mean(samples, axis=[0, 1])
     ess = diagnostics.effective_sample_size(samples, chain_axis=1, sample_axis=0)
-    posterior_sd = jnp.std(samples, axis=[0, 1], ddof=1)
-    avg_monte_carlo_standard_error = jnp.mean(
-        jnp.std(samples, axis=0), axis=0
-    ) / jnp.sqrt(ess)
+    posterior_sd = jnp.std(samples, axis=0, ddof=1)
+    avg_monte_carlo_standard_error = jnp.mean(posterior_sd, axis=0) / jnp.sqrt(ess)
     scaled_error = jnp.abs(posterior_mean - true_param) / avg_monte_carlo_standard_error
     np.testing.assert_array_less(scaled_error, stats.norm.ppf(1 - p_val))
     return scaled_error

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -7,6 +7,7 @@ import jax.scipy.stats as stats
 import numpy as np
 import pytest
 
+import blackjax.diagnostics as diagnostics
 import blackjax.hmc as hmc
 import blackjax.nuts as nuts
 import blackjax.stan_warmup as stan_warmup
@@ -21,6 +22,20 @@ def inference_loop(rng_key, kernel, initial_state, num_samples):
     _, states = jax.lax.scan(one_step, initial_state, keys)
 
     return states
+
+
+def inference_loop_multiple_chains(
+    rng_key, kernel, initial_state, num_samples, num_chains
+):
+    def one_step(states, rng_key):
+        keys = jax.random.split(rng_key, num_chains)
+        states, info = jax.vmap(kernel)(keys, states)
+        return states, (states, info)
+
+    keys = jax.random.split(rng_key, num_samples)
+    _, (states, info) = jax.lax.scan(one_step, initial_state, keys)
+
+    return states, info
 
 
 # -------------------------------------------------------------------
@@ -110,26 +125,25 @@ def normal_potential_fn(x):
 normal_test_cases = [
     {
         "algorithm": hmc,
-        "initial_position": {"x": 1.0},
+        "initial_position": {"x": jnp.array(100.0)},
         "parameters": {
-            "step_size": 1e-2,
+            "step_size": 0.1,
             "inverse_mass_matrix": jnp.array([0.1]),
             "num_integration_steps": 100,
         },
-        "num_sampling_steps": 50_000,
+        "num_sampling_steps": 6000,
     },
     {
         "algorithm": nuts,
-        "initial_position": {"x": 1.0},
-        "parameters": {"step_size": 1e-2, "inverse_mass_matrix": jnp.array([0.1])},
-        "num_sampling_steps": 50_000,
+        "initial_position": {"x": jnp.array(100.0)},
+        "parameters": {"step_size": 0.1, "inverse_mass_matrix": jnp.array([0.1])},
+        "num_sampling_steps": 6000,
     },
 ]
 
 
 @pytest.mark.parametrize("case", normal_test_cases)
-@pytest.mark.parametrize("is_mass_matrix_diagonal", [True, False])
-def test_univariate_normal(case, is_mass_matrix_diagonal):
+def test_univariate_normal(case):
     rng_key = jax.random.PRNGKey(19)
     potential = lambda x: normal_potential_fn(**x)
     initial_position = case["initial_position"]
@@ -138,7 +152,96 @@ def test_univariate_normal(case, is_mass_matrix_diagonal):
     kernel = case["algorithm"].kernel(potential, **case["parameters"])
     states = inference_loop(rng_key, kernel, initial_state, case["num_sampling_steps"])
 
-    samples = states.position["x"]
+    samples = states.position["x"][-1000:]
 
-    assert np.var(samples).item() == pytest.approx(4.0, 1e-1)
-    assert np.mean(samples).item() == pytest.approx(1.0, 1e-1)
+    assert np.var(samples) == pytest.approx(4.0, 1e-1)
+    assert np.mean(samples) == pytest.approx(1.0, 1e-1)
+
+
+# -------------------------------------------------------------------
+#                MULTIVARIATE NORMAL DISTRIBUTION
+# -------------------------------------------------------------------
+
+
+def generate_multivariate_target(rng=None):
+    if rng is None:
+        loc = jnp.array([0.0, 3])
+        scale = jnp.array([1.0, 2.0])
+        rho = jnp.array(0.75)
+    else:
+        rng, loc_rng, scale_rng, rho_rng = jax.random.split(rng, 4)
+        loc = jax.random.normal(loc_rng, [2]) * 10.0
+        scale = jnp.abs(jax.random.normal(scale_rng, [2])) * 2.5
+        rho = jax.random.uniform(rho_rng, [], minval=-1.0, maxval=1.0)
+
+    cov = jnp.diag(scale ** 2)
+    cov = cov.at[0, 1].set(rho * scale[0] * scale[1])
+    cov = cov.at[1, 0].set(rho * scale[0] * scale[1])
+
+    def potential_fn(x):
+        return -stats.multivariate_normal.logpdf(x, loc, cov).sum()
+
+    return potential_fn, loc, scale, rho
+
+
+def mcse_test(samples, true_param, p_val=0.01):
+    posterior_mean = jnp.mean(samples, axis=[0, 1])
+    ess = diagnostics.effective_sample_size(samples, chain_axis=1, sample_axis=0)
+    posterior_sd = jnp.std(samples, axis=[0, 1], ddof=1)
+    avg_monte_carlo_standard_error = jnp.mean(
+        jnp.std(samples, axis=0), axis=0
+    ) / jnp.sqrt(ess)
+    scaled_error = jnp.abs(posterior_mean - true_param) / avg_monte_carlo_standard_error
+    np.testing.assert_array_less(scaled_error, stats.norm.ppf(1 - p_val))
+    return scaled_error
+
+
+mcse_test_cases = [
+    {
+        "algorithm": hmc,
+        "parameters": {
+            "step_size": 0.1,
+            "num_integration_steps": 32,
+        },
+    },
+    {
+        "algorithm": nuts,
+        "parameters": {"step_size": 0.07},
+    },
+]
+
+
+@pytest.mark.parametrize("case", mcse_test_cases)
+def test_mcse(case):
+    """Test convergence using Monte Carlo central limit theorem."""
+    rng_key = jax.random.PRNGKey(2351235)
+    rng_key, init_fn_key, pos_init_key, sample_key = jax.random.split(rng_key, 4)
+    potential_fn, true_loc, true_scale, true_rho = generate_multivariate_target(
+        init_fn_key
+    )
+    num_chains = 10
+    initial_positions = jax.random.normal(pos_init_key, [num_chains, 2])
+    kernel = jax.jit(
+        case["algorithm"].kernel(
+            potential_fn, inverse_mass_matrix=true_scale, **case["parameters"]
+        )
+    )
+    initial_states = jax.vmap(case["algorithm"].new_state, in_axes=(0, None))(
+        initial_positions, potential_fn
+    )
+    states, _ = inference_loop_multiple_chains(
+        sample_key, kernel, initial_states, 2_000, num_chains=num_chains
+    )
+
+    posterior_samples = states.position[-1000:]
+    posterior_delta = posterior_samples - true_loc
+    posterior_variance = posterior_delta ** 2.0
+    posterior_correlation = jnp.prod(posterior_delta, axis=-1, keepdims=True) / (
+        true_scale[0] * true_scale[1]
+    )
+
+    _ = jax.tree_multimap(
+        mcse_test,
+        [posterior_samples, posterior_variance, posterior_correlation],
+        [true_loc, true_scale ** 2, true_rho],
+    )


### PR DESCRIPTION
Add basic diagnostics
- computation of r-hat
- computation of effective sample size (not based on rank, but easy to add)
- add test to validate sampler accuracy base on monte carlo CLT.

It handles shape flexibly as chain dimension and sample dimension is arbitrary. For example, arviz requires the input array to be [chain, sample, dim0], here we can do [chain, sample, dim0, dim1, ...] or [sample, chain, dim0, dim1, ...], which works both for vmap and pmap output (or even [sample, dim0, dim1, dim2, ..., chain]) 
The diagnostics can be jitted so we can potentially put it in a larger sampling/tuning routine.