### PR TITLE
Expose `target_accept` arguments to `stan_warmup.run`

### DIFF
--- a/blackjax/adaptation/step_size.py
+++ b/blackjax/adaptation/step_size.py
@@ -89,6 +89,8 @@ def dual_averaging_adaptation(
         Controls the weights of past steps in the current update. The scheme will
         quickly forget earlier step for a small value of `kappa`. Introduced
         in [2]_, with a recommended value of .75
+    target:
+        Target acceptance rate.
 
     Returns
     -------
@@ -181,7 +183,7 @@ def find_reasonable_step_size(
     value for the step size starting from any value, choosing a good first
     value can speed up the convergence. This heuristics doubles and halves the
     step size until the acceptance probability of the HMC proposal crosses the
-    .5 value.
+    target value.
 
     Parameters
     ----------

--- a/blackjax/stan_warmup.py
+++ b/blackjax/stan_warmup.py
@@ -31,7 +31,9 @@ def run(
     num_steps: int = 1000,
     *,
     is_mass_matrix_diagonal: bool = True,
-    initial_step_size: float = 1.0
+    initial_step_size: float = 1.0,
+    target_accept_initial: float = 0.65,
+    target_accept: float = 0.65,
 ) -> Tuple[HMCState, Tuple[float, Array], NamedTuple]:
     """Loop for the Stan warmup.
 
@@ -50,6 +52,10 @@ def run(
         Indicates whether we should adapt a diagonal or full mass matrix.
     initial_step_size:
         The fist step size to use.
+    target_accept_initial:
+        Target acceptance rate for initial step size adaptation.
+    target_accept:
+        Target acceptance rate for main step size adaptation using dual averaging.
 
     Returns
     -------
@@ -83,7 +89,12 @@ def run(
     return last_chain_state, (step_size, inverse_mass_matrix), warmup_chain
 
 
-def stan_warmup(kernel_factory: Callable, is_mass_matrix_diagonal: bool):
+def stan_warmup(
+    kernel_factory: Callable,
+    is_mass_matrix_diagonal: bool,
+    target_accept_initial: float = 0.65,
+    target_accept: float = 0.65,
+):
     """Warmup scheme for sampling procedures based on euclidean manifold HMC.
     The schedule and algorithms used match Stan's [1]_ as closely as possible.
 
@@ -124,6 +135,10 @@ def stan_warmup(kernel_factory: Callable, is_mass_matrix_diagonal: bool):
         mass matrix.
     is_mass_matrix_diagonal
         Create and adapt a diagonal mass matrix if True, a dense matrix otherwise.
+    target_accept_initial:
+        Target acceptance rate for initial step size adaptation.
+    target_accept:
+        Target acceptance rate for main step size adaptation using dual averaging.
 
     Returns
     -------
@@ -135,7 +150,7 @@ def stan_warmup(kernel_factory: Callable, is_mass_matrix_diagonal: bool):
         Function that returns the step size and mass matrix given a warmup state.
 
     """
-    fast_init, fast_update = fast_window()
+    fast_init, fast_update = fast_window(target_accept)
     slow_init, slow_update, slow_final = slow_window(is_mass_matrix_diagonal)
 
     def init(
@@ -158,6 +173,7 @@ def stan_warmup(kernel_factory: Callable, is_mass_matrix_diagonal: bool):
             kernel,
             initial_state,
             initial_step_size,
+            target_accept_initial,
         )
         da_state = fast_init(step_size)
 
@@ -229,15 +245,16 @@ def stan_warmup(kernel_factory: Callable, is_mass_matrix_diagonal: bool):
     return init, update, final
 
 
-def fast_window() -> Tuple[Callable, Callable]:
+def fast_window(
+    target_accept: float = 0.65,
+) -> Tuple[Callable, Callable]:
     """First stage of the Stan warmup. The step size is adapted using
     Nesterov's dual averaging algorithms while the mass matrix stays the same.
 
     Parameters
     ----------
-    kernel_factory
-        A function that takes the kernel's parameters as an input
-        and returns the corresponding transition kernel.
+    target_accept:
+        Target acceptance rate for step size adaptation using dual averaging.
 
     Returns
     -------
@@ -246,7 +263,7 @@ def fast_window() -> Tuple[Callable, Callable]:
     window.
 
     """
-    da_init, da_update, _ = dual_averaging_adaptation()
+    da_init, da_update, _ = dual_averaging_adaptation(target=target_accept)
 
     def init(initial_step_size: float) -> DualAveragingAdaptationState:
         da_state = da_init(initial_step_size)
@@ -267,6 +284,7 @@ def fast_window() -> Tuple[Callable, Callable]:
 
 def slow_window(
     is_mass_matrix_diagonal: bool = True,
+    target_accept: float = 0.65,
 ) -> Tuple[Callable, Callable, Callable]:
     """Slow stage of the Stan warmup.
 
@@ -279,6 +297,8 @@ def slow_window(
     is_mass_matrix_diagonal
         Whether we want a diagonal mass matrix. Passed to the mass matrix adapation
         algorithm.
+    target_accept:
+        Target acceptance rate for step size adaptation using dual averaging.
 
     Returns
     -------
@@ -288,7 +308,7 @@ def slow_window(
 
     """
     mm_init, mm_update, mm_final = mass_matrix_adaptation(is_mass_matrix_diagonal)
-    da_init, da_update, da_final = dual_averaging_adaptation()
+    da_init, da_update, da_final = dual_averaging_adaptation(target=target_accept)
 
     def init(state: HMCState) -> MassMatrixAdaptationState:
         """Initialize the mass matrix adaptation algorithm."""

--- a/blackjax/stan_warmup.py
+++ b/blackjax/stan_warmup.py
@@ -67,7 +67,8 @@ def run(
         kernel_factory,
         is_mass_matrix_diagonal,
         target_accept_initial=target_accept_initial,
-        target_accept=target_accept)
+        target_accept=target_accept,
+    )
 
     def one_step(carry, interval):
         rng_key, state, warmup_state = carry

--- a/blackjax/stan_warmup.py
+++ b/blackjax/stan_warmup.py
@@ -32,7 +32,7 @@ def run(
     *,
     is_mass_matrix_diagonal: bool = True,
     initial_step_size: float = 1.0,
-    target_accept: float = 0.65,
+    target_acceptance_rate: float = 0.65,
 ) -> Tuple[HMCState, Tuple[float, Array], NamedTuple]:
     """Loop for the Stan warmup.
 
@@ -51,7 +51,7 @@ def run(
         Indicates whether we should adapt a diagonal or full mass matrix.
     initial_step_size:
         The fist step size to use.
-    target_accept:
+    target_acceptance_rate:
         Target acceptance rate for step size adaptation.
 
     Returns
@@ -63,7 +63,7 @@ def run(
     init, update, final = stan_warmup(
         kernel_factory,
         is_mass_matrix_diagonal,
-        target_accept=target_accept,
+        target_acceptance_rate=target_acceptance_rate,
     )
 
     def one_step(carry, interval):
@@ -93,7 +93,7 @@ def run(
 def stan_warmup(
     kernel_factory: Callable,
     is_mass_matrix_diagonal: bool,
-    target_accept: float = 0.65,
+    target_acceptance_rate: float = 0.65,
 ):
     """Warmup scheme for sampling procedures based on euclidean manifold HMC.
     The schedule and algorithms used match Stan's [1]_ as closely as possible.
@@ -135,7 +135,7 @@ def stan_warmup(
         mass matrix.
     is_mass_matrix_diagonal
         Create and adapt a diagonal mass matrix if True, a dense matrix otherwise.
-    target_accept:
+    target_acceptance_rate:
         Target acceptance rate for step size adaptation.
 
     Returns
@@ -148,7 +148,7 @@ def stan_warmup(
         Function that returns the step size and mass matrix given a warmup state.
 
     """
-    fast_init, fast_update = fast_window(target_accept)
+    fast_init, fast_update = fast_window(target_acceptance_rate)
     slow_init, slow_update, slow_final = slow_window(is_mass_matrix_diagonal)
 
     def init(
@@ -171,7 +171,7 @@ def stan_warmup(
             kernel,
             initial_state,
             initial_step_size,
-            target_accept,
+            target_acceptance_rate,
         )
         da_state = fast_init(step_size)
 

--- a/blackjax/stan_warmup.py
+++ b/blackjax/stan_warmup.py
@@ -63,7 +63,11 @@ def run(
         that contains the whole adaptation chain.
 
     """
-    init, update, final = stan_warmup(kernel_factory, is_mass_matrix_diagonal)
+    init, update, final = stan_warmup(
+        kernel_factory,
+        is_mass_matrix_diagonal,
+        target_accept_initial=target_accept_initial,
+        target_accept=target_accept)
 
     def one_step(carry, interval):
         rng_key, state, warmup_state = carry

--- a/blackjax/stan_warmup.py
+++ b/blackjax/stan_warmup.py
@@ -32,7 +32,6 @@ def run(
     *,
     is_mass_matrix_diagonal: bool = True,
     initial_step_size: float = 1.0,
-    target_accept_initial: float = 0.65,
     target_accept: float = 0.65,
 ) -> Tuple[HMCState, Tuple[float, Array], NamedTuple]:
     """Loop for the Stan warmup.
@@ -52,10 +51,8 @@ def run(
         Indicates whether we should adapt a diagonal or full mass matrix.
     initial_step_size:
         The fist step size to use.
-    target_accept_initial:
-        Target acceptance rate for initial step size adaptation.
     target_accept:
-        Target acceptance rate for main step size adaptation using dual averaging.
+        Target acceptance rate for step size adaptation.
 
     Returns
     -------
@@ -66,7 +63,6 @@ def run(
     init, update, final = stan_warmup(
         kernel_factory,
         is_mass_matrix_diagonal,
-        target_accept_initial=target_accept_initial,
         target_accept=target_accept,
     )
 
@@ -97,7 +93,6 @@ def run(
 def stan_warmup(
     kernel_factory: Callable,
     is_mass_matrix_diagonal: bool,
-    target_accept_initial: float = 0.65,
     target_accept: float = 0.65,
 ):
     """Warmup scheme for sampling procedures based on euclidean manifold HMC.
@@ -140,10 +135,8 @@ def stan_warmup(
         mass matrix.
     is_mass_matrix_diagonal
         Create and adapt a diagonal mass matrix if True, a dense matrix otherwise.
-    target_accept_initial:
-        Target acceptance rate for initial step size adaptation.
     target_accept:
-        Target acceptance rate for main step size adaptation using dual averaging.
+        Target acceptance rate for step size adaptation.
 
     Returns
     -------
@@ -178,7 +171,7 @@ def stan_warmup(
             kernel,
             initial_state,
             initial_step_size,
-            target_accept_initial,
+            target_accept,
         )
         da_state = fast_init(step_size)
 


### PR DESCRIPTION
This PR exposes two arguments for step size adaptation to the function `stan_warmup.run`:
- `target_accept_initial` for initial step size adaptation i.e. passed to `find_reasonable_step_size`,
- `target_accept` for step size adaptation using dual averaging i.e. passed to `dual_averaging_adaptation`

Closes #109