### PR TITLE
Better residual resampling

### DIFF
--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -24,7 +24,7 @@ def integrand(x):
     return np.cos(x)
 
 
-@pytest.mark.parametrize("N", [100, 500, 1000])
+@pytest.mark.parametrize("N", [100, 500, 1_000, 100_000])
 @pytest.mark.parametrize("resampling_method", resampling_methods_to_test)
 def test_resampling_methods(N, resampling_method):
     np.random.seed(42)


### PR DESCRIPTION
This reuses our previous implementation of multinomial instead of the high memory footprint implementation of categorical sampling. The difference now lies in the use of a permutation of the multinomial indices to make sure that the sorted uniforms don't mess with the exchangeability properties.

It is probably best to merge this prior to the Waste-free SMC.