### PR TITLE
Metropolis Adjusted Langevin algorithm

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -3,6 +3,7 @@ from .diagnostics import potential_scale_reduction as rhat
 from .kernels import (
     adaptive_tempered_smc,
     hmc,
+    mala,
     nuts,
     rmh,
     tempered_smc,
@@ -13,6 +14,7 @@ __version__ = "0.4.0"
 
 __all__ = [
     "hmc",  # mcmc
+    "mala",
     "nuts",
     "rmh",
     "window_adaptation",  # mcmc adaptation

--- a/blackjax/mcmc/__init__.py
+++ b/blackjax/mcmc/__init__.py
@@ -1,3 +1,3 @@
-from . import hmc, nuts, rmh
+from . import hmc, mala, nuts, rmh
 
-__all__ = ["hmc", "nuts", "rmh"]
+__all__ = ["hmc", "mala", "nuts", "rmh"]

--- a/blackjax/mcmc/diffusion.py
+++ b/blackjax/mcmc/diffusion.py
@@ -1,0 +1,39 @@
+"""Solvers for Langevin diffusions."""
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.types import PRNGKey, PyTree
+
+__all__ = ["overdamped_langevin"]
+
+
+class DiffusionState(NamedTuple):
+    position: PyTree
+    logprob_grad: PyTree
+
+
+def generate_gaussian_noise(rng_key: PRNGKey, position):
+    position_flat, unravel_fn = jax.flatten_util.ravel_pytree(position)
+    noise_flat = jax.random.normal(rng_key, shape=jnp.shape(position_flat))
+    return unravel_fn(noise_flat)
+
+
+def overdamped_langevin(logprob_grad_fn):
+    """Euler solver for overdamped Langevin diffusion."""
+
+    def one_step(rng_key, state: DiffusionState, step_size: float, batch: tuple = ()):
+        position, logprob_grad = state
+        noise = generate_gaussian_noise(rng_key, position)
+        position = jax.tree_util.tree_multimap(
+            lambda p, g, n: p + step_size * g + jnp.sqrt(2 * step_size) * n,
+            position,
+            logprob_grad,
+            noise,
+        )
+
+        logprob_grad = logprob_grad_fn(position, *batch)
+        return DiffusionState(position, logprob_grad)
+
+    return one_step

--- a/blackjax/mcmc/mala.py
+++ b/blackjax/mcmc/mala.py
@@ -1,0 +1,103 @@
+"""Public API for Metropolis Adjusted Langevin kernels."""
+from typing import Callable, NamedTuple, Tuple
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.mcmc.diffusion import overdamped_langevin
+from blackjax.types import PRNGKey, PyTree
+
+__all__ = ["MALAState", "MALAInfo", "init", "kernel"]
+
+
+class MALAState(NamedTuple):
+    """State of the MALA algorithm.
+
+    The MALA algorithm takes one position of the chain and returns another
+    position. In order to make computations more efficient, we also store
+    the current log-probability density as well as the current gradient of the
+    log-probability density.
+
+    """
+
+    position: PyTree
+    logprob_grad: PyTree
+
+
+class MALAInfo(NamedTuple):
+    """Additional information on the MALA transition.
+
+    This additional information can be used for debugging or computing
+    diagnostics.
+
+    acceptance_probability
+        The acceptance probability of the transition.
+    is_accepted
+        Whether the proposed position was accepted or the original position
+        was returned.
+
+    """
+
+    acceptance_probability: float
+    is_accepted: bool
+
+
+def init(position: PyTree, logprob_fn: Callable) -> MALAState:
+    grad_fn = jax.grad(logprob_fn)
+    logprob_grad = grad_fn(position)
+    return MALAState(position, logprob_grad)
+
+
+def kernel():
+    """Build a MALA kernel.
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current state
+    of the chain and that returns a new state of the chain along with
+    information about the transition.
+
+    """
+
+    def transition_probability(state, new_state, step_size):
+        """Transition probability to go from `state` to `new_state`"""
+        theta = new_state.position - state.position - step_size * state.logprob_grad
+        return -0.25 * (1.0 / step_size) * jnp.dot(theta, theta)
+
+    def one_step(
+        rng_key: PRNGKey, state: MALAState, logprob_fn: Callable, step_size: float
+    ) -> Tuple[MALAState, MALAInfo]:
+        """Generate a new sample with the MALA kernel.
+
+        TODO expand the docstring.
+
+        """
+        grad_fn = jax.grad(logprob_fn)
+        integrator = overdamped_langevin(grad_fn)
+
+        key_integrator, key_rmh = jax.random.split(rng_key)
+
+        new_state = integrator(key_integrator, state, step_size)
+
+        delta = (
+            logprob_fn(new_state.position)
+            - logprob_fn(state.position)
+            + transition_probability(new_state, state, step_size)
+            - transition_probability(state, new_state, step_size)
+        )
+        delta = jnp.where(jnp.isnan(delta), -jnp.inf, delta)
+        p_accept = jnp.clip(jnp.exp(delta), a_max=1)
+
+        do_accept = jax.random.bernoulli(key_rmh, p_accept)
+
+        new_state = MALAState(*new_state)
+        info = MALAInfo(p_accept, do_accept)
+
+        return jax.lax.cond(
+            do_accept,
+            lambda _: (new_state, info),
+            lambda _: (state, info),
+            operand=None,
+        )
+
+    return one_step

--- a/docs/sampling.rst
+++ b/docs/sampling.rst
@@ -8,6 +8,7 @@ Sampling
 
   hmc
   nuts
+  mala
   rmh
   tempered_smc
   adaptive_tempered_smc
@@ -49,6 +50,11 @@ HMC
 ~~~
 
 .. autoclass:: blackjax.hmc
+
+MALA
+~~~~
+
+.. autoclass:: blackjax.mala
 
 NUTS
 ~~~~

--- a/examples/use_with_pymc.ipynb
+++ b/examples/use_with_pymc.ipynb
@@ -186,6 +186,7 @@
     "init_position_dict = model.compute_initial_point()\n",
     "init_position = [init_position_dict[rv] for rv in rvs]\n",
     "\n",
+    "\n",
     "def get_jaxified_logp(model):\n",
     "\n",
     "    logp_fn = get_jaxified_graph(inputs=model.value_vars, outputs=[model.logpt()])\n",
@@ -194,6 +195,7 @@
     "        return logp_fn(*x)[0]\n",
     "\n",
     "    return logp_fn_wrap\n",
+    "\n",
     "\n",
     "logprob_fn = get_jaxified_logp(model)"
    ]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -42,8 +42,10 @@ class GaussianEuclideanMetricsTest(chex.TestCase):
         velocity = inverse_mass_matrix * momentum_val
         expected_kinetic_energy_val = 0.5 * velocity * momentum_val
 
-        assert momentum_val == expected_momentum_val
-        assert kinetic_energy_val == expected_kinetic_energy_val
+        np.testing.assert_allclose(expected_momentum_val, momentum_val, 1e-6)
+        np.testing.assert_allclose(
+            kinetic_energy_val, expected_kinetic_energy_val, 1e-6
+        )
 
     @chex.all_variants(with_pmap=False)
     def test_gaussian_euclidean_dim_2(self):
@@ -62,8 +64,10 @@ class GaussianEuclideanMetricsTest(chex.TestCase):
         velocity = jnp.dot(inverse_mass_matrix, momentum_val)
         expected_kinetic_energy_val = 0.5 * jnp.matmul(velocity, momentum_val)
 
-        np.testing.assert_allclose(expected_momentum_val, momentum_val)
-        np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
+        np.testing.assert_allclose(expected_momentum_val, momentum_val, 1e-6)
+        np.testing.assert_allclose(
+            kinetic_energy_val, expected_kinetic_energy_val, 1e-6
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -121,6 +121,13 @@ normal_test_cases = [
         "num_sampling_steps": 20_000,
         "burnin": 5_000,
     },
+    {
+        "algorithm": blackjax.mala,
+        "initial_position": 1.0,
+        "parameters": {"step_size": 1e-1},
+        "num_sampling_steps": 20_000,
+        "burnin": 2_000,
+    },
 ]
 
 


### PR DESCRIPTION
Here's a first attempt at merging sgmcmcjax into blackjax. Sorry it took ages to get something done! I've had loads of work and paper deadlines/revisions/etc.. :( 

I added the following:

1. diffusions function:
    - `state` includes `gradient_state`. This is to store stuff that will be needed for fancier gradient estimators (SVRG for example)
    - iteration number i is set to 0. This should be stored in some kind of state
2. Gradient estimators
    - `build_grad_log_post` builds the gradient function that takes in parameters and the data (which might be a minibatch)
    - `build_gradient_estimation_fn`: returns the gradient estimator as well as the function that initialises the gradient state (the gradient at the first iteration will be based on a minibatch of data)
3. Build kernels:
    - Build ULA kernel
    - Build SGLD kernel: same as ULA but you pass in a batch size as well as a random key to initialise the gradient


I did some copy paste from sgmcmcjax, but tried to follow the API that @rlouf suggested. But I'm not sure what the best way is to define state. We need a state for the chain (like for standard mcmc), but we also need state for the gradients (not for this simple gradient estimator, but for SVRG for example). 


Anyways have a look at this is let me know what your thoughts are. I added a notebook that runs boths algorithms in `notebooks/sgld_ula.ipynb`.