### PR TITLE
Adding progress bars to window adaptation

### DIFF
--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -1,0 +1,91 @@
+"""Progress bar decorators for use with step functions.
+Adapted from Jeremie Coullon's blog post [1]
+.. [1]: "How to add a progress bar to JAX scans and loops"
+        https://www.jeremiecoullon.com/2021/01/29/jax_progress_bar/
+"""
+from fastprogress.fastprogress import progress_bar
+from jax import lax
+from jax.experimental import host_callback
+
+
+def progress_bar_scan(num_samples, print_rate=None):
+    "Progress bar for a JAX scan"
+    progress_bars = {}
+
+    if print_rate is None:
+        if num_samples > 20:
+            print_rate = int(num_samples / 20)
+        else:
+            print_rate = 1  # if you run the sampler for less than 20 iterations
+
+    def _define_bar(arg, transform, device):
+        progress_bars[0] = progress_bar(range(num_samples))
+        progress_bars[0].update(0)
+
+    def _update_bar(arg, transform, device):
+        progress_bars[0].update_bar(arg)
+
+    def _update_progress_bar(iter_num):
+        "Updates progress bar of a JAX scan or loop"
+        _ = lax.cond(
+            iter_num == 0,
+            lambda _: host_callback.id_tap(
+                _define_bar, iter_num, result=iter_num, tap_with_device=True
+            ),
+            lambda _: iter_num,
+            operand=None,
+        )
+
+        _ = lax.cond(
+            # update every multiple of `print_rate` except at the end
+            (iter_num % print_rate == 0),
+            lambda _: host_callback.id_tap(
+                _update_bar, iter_num, result=iter_num, tap_with_device=True
+            ),
+            lambda _: iter_num,
+            operand=None,
+        )
+
+        _ = lax.cond(
+            # update by `remainder`
+            iter_num == num_samples - 1,
+            lambda _: host_callback.id_tap(
+                _update_bar, num_samples, result=iter_num, tap_with_device=True
+            ),
+            lambda _: iter_num,
+            operand=None,
+        )
+
+    def _close_bar(arg, transform, device):
+        progress_bars[0].on_iter_end()
+        print()
+
+    def close_bar(result, iter_num):
+        return lax.cond(
+            iter_num == num_samples - 1,
+            lambda _: host_callback.id_tap(
+                _close_bar, None, result=result, tap_with_device=True
+            ),
+            lambda _: result,
+            operand=None,
+        )
+
+    def _progress_bar_scan(func):
+        """Decorator that adds a progress bar to `body_fun` used in `lax.scan`.
+        Note that `body_fun` must either be looping over `np.arange(num_samples)`,
+        or be looping over a tuple who's first element is `np.arange(num_samples)`
+        This means that `iter_num` is the current iteration number
+        """
+
+        def wrapper_progress_bar(carry, x):
+            if type(x) is tuple:
+                iter_num, *_ = x
+            else:
+                iter_num = x
+            _update_progress_bar(iter_num)
+            result = func(carry, x)
+            return close_bar(result, iter_num)
+
+        return wrapper_progress_bar
+
+    return _progress_bar_scan

--- a/examples/use_with_pymc.ipynb
+++ b/examples/use_with_pymc.ipynb
@@ -180,22 +180,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from pymc.sampling_jax import get_jaxified_graph\n",
+    "from pymc.sampling_jax import get_jaxified_logp\n",
     "\n",
     "rvs = [rv.name for rv in model.value_vars]\n",
     "init_position_dict = model.compute_initial_point()\n",
     "init_position = [init_position_dict[rv] for rv in rvs]\n",
-    "\n",
-    "\n",
-    "def get_jaxified_logp(model):\n",
-    "\n",
-    "    logp_fn = get_jaxified_graph(inputs=model.value_vars, outputs=[model.logpt()])\n",
-    "\n",
-    "    def logp_fn_wrap(x):\n",
-    "        return logp_fn(*x)[0]\n",
-    "\n",
-    "    return logp_fn_wrap\n",
-    "\n",
     "\n",
     "logprob_fn = get_jaxified_logp(model)"
    ]
@@ -243,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa558fa7-d323-4b4e-813c-a4e8ab8f519a",
+   "id": "97d2dd91-b8ef-43b4-a2a2-087be44a66e5",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -e ./
 chex
+fastprogress>=0.2.0
 pre-commit
 pytest
 pytest-benchmark

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuptools.setup(
     description="Flexible and fast inference in Python",
     long_description=long_description,
     packages=setuptools.find_packages(),
-    install_requires=[],
+    install_requires=["fastprogress>=0.2.0"],
     long_description_content_type="text/markdown",
     keywords="probabilistic machine learning bayesian statistics sampling algorithms",
     license="Apache License 2.0",

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -77,6 +77,7 @@ class LinearRegressionTest(chex.TestCase):
             logposterior_fn,
             case["num_warmup_steps"],
             is_mass_matrix_diagonal,
+            progress_bar=True,
             **case["parameters"],
         )
         state, kernel, _ = warmup.run(


### PR DESCRIPTION
This adapts @jeremiecoullon progress bar code to allow progress bars to be displayed during adaptation. Like in numpyro they can have an adverse effect on sampling time so should be disabled for benchmarking.

If we think progress bars are out of scope for blackjax this can be refactored to take `progress_bar_scan` shaped callback instead.