### PR TITLE
Fix install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ We value the following contributions:
 
 ### How to contribute?
 
-1. Run `pip install -r requirements-dev.txt` to install all the dev
+1. Run `pip install -r requirements.txt` to install all the dev
    dependencies.
 2. Run `pre-commit run --all-files` and `make test` before pushing on the repo; CI should pass if
    these pass locally.

--- a/examples/Introduction.ipynb
+++ b/examples/Introduction.ipynb
@@ -328,7 +328,7 @@
     "\n",
     "ax1.plot(scale_samples)\n",
     "ax1.set_xlabel(\"Samples\")\n",
-    "ax.set_ylabel(\"scale\")"
+    "ax1.set_ylabel(\"scale\")"
    ]
   },
   {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e ./
+chex
 pre-commit
 pytest
 pytest-benchmark
 pytest-cov
 pytest-xdist
-chex


### PR DESCRIPTION
Very small change, was going through the `contributing` setup page (I'd like to add SMC ABC to this) and noticed that `requirements-dev.txt` does not exist anymore. 