### PR TITLE
Remove the `no-commit-to-branch` check in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,8 +7,6 @@ repos:
     -   id: check-yaml
     -   id: debug-statements
     -   id: end-of-file-fixer
-    -   id: no-commit-to-branch
-        args: [--branch, main]
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
 - repo: https://github.com/PyCQA/isort


### PR DESCRIPTION
This is not useful since the master branch is protected.