### PR TITLE
Skip no-commit-to-branch on github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
     needs: changes
     runs-on: ubuntu-latest
     if: ${{ needs.changes.outputs.changes == 'true' }}
+    env:
+      SKIP: no-commit-to-branch
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2


### PR DESCRIPTION
#192 moved `.github/workflows/check_code_style.yml` to `.github/workflows/test.yml` but did not include the skip of no-commit-to-branch on environment, so checks when pull requests are merged to main fail since they are commits to the main branch. I believe the objective of no-commit-to-branch is to avoid commits to the main branch on local machines, so it must be skipped on actions. Error after merge noticed when merging #195.