### PR TITLE
Tweak LBFGS to allow PyTree inputs

### DIFF
--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -6,8 +6,8 @@ import jax.random
 import jaxopt
 from jax import lax
 from jax.flatten_util import ravel_pytree
-from jaxopt.base import OptStep
 from jaxopt._src.lbfgs import LbfgsState
+from jaxopt.base import OptStep
 
 from blackjax.types import Array, PyTree
 
@@ -79,7 +79,7 @@ def minimize_lbfgs(
     -------
     Optimization results and optimization path
     """
-    
+
     # Ravel pytree into flat array.
     x0_raveled, unravel_fn = ravel_pytree(x0)
     unravel_fn_mapped = jax.vmap(unravel_fn)
@@ -103,16 +103,11 @@ def minimize_lbfgs(
             value=last_step_raveled.state.value,
             stepsize=last_step_raveled.state.stepsize,
             error=last_step_raveled.state.error,
-            s_history=unravel_fn_mapped(
-                last_step_raveled.state.s_history
-            ),
-            y_history=unravel_fn_mapped(
-                last_step_raveled.state.y_history
-            ),
+            s_history=unravel_fn_mapped(last_step_raveled.state.s_history),
+            y_history=unravel_fn_mapped(last_step_raveled.state.y_history),
             rho_history=last_step_raveled.state.rho_history,
-            aux=last_step_raveled.state.aux
-        )
-        
+            aux=last_step_raveled.state.aux,
+        ),
     )
 
     # Unravel optimization path history.
@@ -122,8 +117,8 @@ def minimize_lbfgs(
         g=unravel_fn_mapped(history_raveled.g),
         alpha=unravel_fn_mapped(history_raveled.alpha),
         update_mask=jax.tree_map(
-            lambda x: x.astype(history_raveled.update_mask.dtype), 
-            unravel_fn_mapped(history_raveled.update_mask.astype(x0_raveled.dtype))
+            lambda x: x.astype(history_raveled.update_mask.dtype),
+            unravel_fn_mapped(history_raveled.update_mask.astype(x0_raveled.dtype)),
         ),
     )
 
@@ -139,7 +134,6 @@ def _minimize_lbfgs(
     ftol: float,
     maxls: int,
 ) -> Tuple[OptStep, LBFGSHistory]:
-
     def lbfgs_one_step(carry, i):
         (params, state), previous_history = carry
 

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -5,9 +5,11 @@ import jax.numpy as jnp
 import jax.random
 import jaxopt
 from jax import lax
+from jax.flatten_util import ravel_pytree
 from jaxopt.base import OptStep
+from jaxopt._src.lbfgs import LbfgsState
 
-from blackjax.types import Array
+from blackjax.types import Array, PyTree
 
 __all__ = [
     "LBFGSHistory",
@@ -45,7 +47,7 @@ class LBFGSHistory(NamedTuple):
 
 def minimize_lbfgs(
     fun: Callable,
-    x0: Array,
+    x0: PyTree,
     maxiter: int = 30,
     maxcor: float = 10,
     gtol: float = 1e-08,
@@ -58,7 +60,7 @@ def minimize_lbfgs(
     Parameters
     ----------
     fun:
-        function of the form f(x) where x is a flat ndarray and returns a real scalar.
+        function of the form f(x) where x is a pytree and returns a real scalar.
         The function should be composed of operations with vjp defined.
     x0:
         initial guess
@@ -77,6 +79,65 @@ def minimize_lbfgs(
     -------
     Optimization results and optimization path
     """
+    
+    # Ravel pytree into flat array.
+    x0_raveled, unravel_fn = ravel_pytree(x0)
+    unravel_fn_mapped = jax.vmap(unravel_fn)
+
+    # Run LBFGS optimizer on flat input.
+    last_step_raveled, history_raveled = _minimize_lbfgs(
+        lambda x: fun(unravel_fn(x)),
+        x0_raveled,
+        maxiter,
+        maxcor,
+        gtol,
+        ftol,
+        maxls,
+    )
+
+    # Unravel final optimization step.
+    last_step = OptStep(
+        params=unravel_fn(last_step_raveled.params),
+        state=LbfgsState(
+            iter_num=last_step_raveled.state.iter_num,
+            value=last_step_raveled.state.value,
+            stepsize=last_step_raveled.state.stepsize,
+            error=last_step_raveled.state.error,
+            s_history=unravel_fn_mapped(
+                last_step_raveled.state.s_history
+            ),
+            y_history=unravel_fn_mapped(
+                last_step_raveled.state.y_history
+            ),
+            rho_history=last_step_raveled.state.rho_history,
+            aux=last_step_raveled.state.aux
+        )
+        
+    )
+
+    # Unravel optimization path history.
+    history = LBFGSHistory(
+        x=unravel_fn_mapped(history_raveled.x),
+        f=history_raveled.f,
+        g=unravel_fn_mapped(history_raveled.g),
+        alpha=unravel_fn_mapped(history_raveled.alpha),
+        update_mask=unravel_fn_mapped(
+            history_raveled.update_mask.astype(x0_raveled.dtype)
+        ).astype(history_raveled.update_mask.dtype),
+    )
+
+    return last_step, history
+
+
+def _minimize_lbfgs(
+    fun: Callable,
+    x0: Array,
+    maxiter: int,
+    maxcor: float,
+    gtol: float,
+    ftol: float,
+    maxls: int,
+) -> Tuple[OptStep, LBFGSHistory]:
 
     def lbfgs_one_step(carry, i):
         (params, state), previous_history = carry

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -121,9 +121,10 @@ def minimize_lbfgs(
         f=history_raveled.f,
         g=unravel_fn_mapped(history_raveled.g),
         alpha=unravel_fn_mapped(history_raveled.alpha),
-        update_mask=unravel_fn_mapped(
-            history_raveled.update_mask.astype(x0_raveled.dtype)
-        ).astype(history_raveled.update_mask.dtype),
+        update_mask=jax.tree_map(
+            lambda x: x.astype(history_raveled.update_mask.dtype), 
+            unravel_fn_mapped(history_raveled.update_mask.astype(x0_raveled.dtype))
+        ),
     )
 
     return last_step, history

--- a/blackjax/vi/pathfinder.py
+++ b/blackjax/vi/pathfinder.py
@@ -76,7 +76,7 @@ def init(
         if False output only iteration that maximize ELBO, otherwise output
         all iterations
     lbfgs_kwargs:
-        kwargs passed to the internal call to lbfgs_minimize, avaiable params:
+        kwargs passed to the internal call to lbfgs_minimize, available params:
             maxiter: maximum number of iterations
             maxcor: maximum number of metric corrections ("history size")
             ftol: terminates the minimization when `(f_k - f_{k+1}) < ftol`
@@ -108,11 +108,21 @@ def init(
         # high max line search steps helps optimizing negative log likelihoods
         # that are sums over (large number of) observations' likelihood
         lbfgs_kwargs["maxls"] = 1000
+    if "gtol" not in lbfgs_kwargs:
+        lbfgs_kwargs["gtol"] = 1e-08
+    if "ftol" not in lbfgs_kwargs:
+        lbfgs_kwargs["ftol"] = 1e-05
 
     maxiter = lbfgs_kwargs["maxiter"]
     maxcor = lbfgs_kwargs["maxcor"]
     (_, status), history = _minimize_lbfgs(
-        objective_fn, initial_position_flatten, **lbfgs_kwargs
+        objective_fn,
+        initial_position_flatten,
+        lbfgs_kwargs["maxiter"],
+        lbfgs_kwargs["maxcor"],
+        lbfgs_kwargs["gtol"],
+        lbfgs_kwargs["ftol"],
+        lbfgs_kwargs["maxls"],
     )
 
     # Get postions and gradients of the optimization path (including the starting point).

--- a/blackjax/vi/pathfinder.py
+++ b/blackjax/vi/pathfinder.py
@@ -6,9 +6,9 @@ import jax.random
 from jax.flatten_util import ravel_pytree
 
 from blackjax.optimizers.lbfgs import (
+    _minimize_lbfgs,
     bfgs_sample,
     lbfgs_inverse_hessian_factors,
-    minimize_lbfgs,
 )
 from blackjax.types import Array, PRNGKey, PyTree
 
@@ -111,7 +111,7 @@ def init(
 
     maxiter = lbfgs_kwargs["maxiter"]
     maxcor = lbfgs_kwargs["maxcor"]
-    (_, status), history = minimize_lbfgs(
+    (_, status), history = _minimize_lbfgs(
         objective_fn, initial_position_flatten, **lbfgs_kwargs
     )
 


### PR DESCRIPTION
This addresses https://github.com/blackjax-devs/blackjax/issues/227.

It passes tests locally on my machine, but should probably add an explicit test for a more complex pytree input. Let me know your thoughts.

One thing I'm not sure about is whether you want to count on `LbfgsState` being a stable feature of `jaxopt`. It might make sense to only unravel the fields in `LBFGSHistory`.