### PR TITLE
Use jax.tree_map in place of jax.tree_multimap

### DIFF
--- a/blackjax/sgmcmc/diffusion.py
+++ b/blackjax/sgmcmc/diffusion.py
@@ -63,8 +63,8 @@ def sghmc(logprob_grad_fn, alpha: float = 0.01, beta: float = 0):
     ) -> SGHMCState:
         position, momentum, logprob_grad = state
         noise = generate_gaussian_noise(rng_key, position)
-        position = jax.tree_util.tree_multimap(lambda x, p: x + p, position, momentum)
-        momentum = jax.tree_util.tree_multimap(
+        position = jax.tree_util.tree_map(lambda x, p: x + p, position, momentum)
+        momentum = jax.tree_util.tree_map(
             lambda p, g, n: (1.0 - alpha) * p
             + step_size * g
             + jnp.sqrt(2 * step_size * (alpha - beta)) * n,


### PR DESCRIPTION
The latter is deprecated in jax and will be removed in https://github.com/google/jax/pull/11382

Note that in the last several JAX releases, `tree_multimap` is a direct alias of `tree_map`, so this substitution will not result in any change of behavior aside from silencing the deprecation warning (see https://github.com/google/jax/blob/5b576cb03e85f2e4d8d99f314cf5d87981ef5d42/jax/_src/tree_util.py#L198-L202).