### PR TITLE
Allow users to pass a float for constant learning rate

### DIFF
--- a/examples/SGMCMC.md
+++ b/examples/SGMCMC.md
@@ -178,10 +178,9 @@ num_samples = 2000
 rng_key = jax.random.PRNGKey(1)
 batches = batch_data(rng_key, (X_train, y_train), batch_size, data_size)
 
-# Build the SGLD kernel
-schedule_fn = lambda _: step_size  # constant step size
+# Build the SGLD kernel with a constant learning rate
 grad_fn = grad_estimator(logprior_fn, loglikelihood_fn, data_size)
-sgld = blackjax.sgld(grad_fn, schedule_fn)
+sgld = blackjax.sgld(grad_fn, step_size)
 
 # Set the initial state
 init_positions = init_parameters(rng_key, layer_sizes)


### PR DESCRIPTION
The current API requires user to pass a function of the index of the current iteration, even when the learning rate is constant. However, in practice most people use a constant learning rate (even if they shouldn't, but who are we to judge?)  and we should simplify that pattern of use.

This commit thus allows users to pass either a function, either a float as learning rate to the kernel builder. It will raise an exception for any other type.