### PR TITLE
Truncate `$GITHUB_REF` at the right level when testing for `pip install` success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,4 @@ jobs:
       run: sleep 240
     - name: Install from PyPI
       run: |
-        pip install blackjax==${GITHUB_REF:11}
+        pip install blackjax==${GITHUB_REF:10}


### PR DESCRIPTION
The workflow that checks that blackjax can be installed from PyPi currently fails because `$GITHUB_REF` is truncated before the leading version number (currently 0). This commit fixes this.