### PR TITLE
Update examples

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -16,7 +16,7 @@ sphinx
 sphinx-autobuild
 sphinx-book-theme
 sphinx-math-dollar
-tensorflow
+tensorflow-cpu
 tensorflow-datasets
 tfp-nightly[jax]
 watermark


### PR DESCRIPTION
I updated the SGMCMC example, which now runs in no time:
- Evaluation now happens on test set
- `jax.jit` the step function

I also updated the Aesara example; Aesara has a much simpler JAX transpilation pipeline since `aesara=2.8.5`.

Finally I changed the tensorflow requirement to `tensorflow-cpu`. I leave #303 as a good first issue.