### PR TITLE
Fix broken link to introduction notebook in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ for _ in range(100):
 ```
 
 See [this
-notebook](https://github.com/blackjax-devs/blackjax/blob/master/examples/Introduction.ipynb) for more examples of how to use the library: how to write inference loops for one or several chains, how to use the Stan warmup, etc.
+notebook](https://github.com/blackjax-devs/blackjax/blob/main/examples/Introduction.md) for more examples of how to use the library: how to write inference loops for one or several chains, how to use the Stan warmup, etc.
 
 ## Philosophy
 


### PR DESCRIPTION
Updated the link to the [introductory notebook](https://github.com/blackjax-devs/blackjax/blob/main/examples/Introduction.md). Let me know if that's the correct one.

Looking forward to learning more about BlackJAX. Keep up the good work!