### PR TITLE
Fix math and remove environment information in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ add_module_names = False
 
 source_suffix = {".rst": "restructuredtext", ".ipynb": "myst-nb", ".md": "myst-nb"}
 
-nb_execution_mode = "auto"
+nb_execution_mode = "off"
 nb_execution_timeout = 300
 suppress_warnings = ["mystnb.unknown_mime_type"]
 

--- a/examples/GP_EllipticalSliceSampler.md
+++ b/examples/GP_EllipticalSliceSampler.md
@@ -18,30 +18,30 @@ mystnb:
 
 Given a vector of obervations $ \mathbf{y} $ with known variance $\sigma^2\mathbb{I}$ and Gaussian likelihood, we model the mean parameter of these observations as a Gaussian process given input/feature matrix $\mathbf{X}$
 
-$$
+```{math}
 \begin{align*}
 \mathbf{y}|\mathbf{f} &\sim N(\mathbf{f}, \sigma^2\mathbb{I}) \\
 \mathbf{f} &\sim GP(0, \Sigma),
 \end{align*}
-$$
+```
 
 where $\Sigma$ is a covariance function of the feature vector derived from the squared exponential kenel. Thus, for any pair of observations $i$ and $j$ the covariance of these two observations is given by
 
-$$
+```{math}
 \Sigma_{i,j} = \sigma^2_f \exp\left(-\frac{||\mathbf{X}_{i, \cdot} - \mathbf{X}_{j, \cdot}||^2}{2 l^2}\right)
-$$
+```
 
 for some lengthscale parameter $l$ and signal variance parameter $\sigma_f^2$.
 
 In this example we will limit our analysis to the posterior distribution of the mean parameter $\mathbf{f}$, by conjugacy the posterior is Gaussian with mean and covariance
 
-$$
+```{math}
 \begin{align*}
 \mathbf{f}|\mathbf{y} &\sim N(\mu_f, \Sigma_f) \\
 \Sigma_f^{-1} &= \Sigma^{-1} + \sigma^{-2}\mathbf{I} \\
 \mu_f &= \sigma^{-2} \Sigma_f \mathbf{y}.
 \end{align*}
-$$
+```
 
 Using this analytic result we can check the correct convergence of our sampler towards the posterior distribution. It is important to note, however, that the Elliptical Slice sampler can be used to sample from any vector of parameters so long as these parameters have a prior Multivariate Gaussian distribution.
 
@@ -94,6 +94,10 @@ y = f + jrnd.normal(ky, shape=(n,)) * y_sd
 # conjugate results
 posterior_cov = jnp.linalg.inv(invSigma + 1 / y_sd**2 * jnp.eye(n))
 posterior_mean = jnp.dot(posterior_cov, y) * 1 / y_sd**2
+```
+
+```{code-cell}
+:tags: [hide-input]
 
 plt.figure(figsize=(8, 5))
 plt.hist(np.array(y), bins=50, density=True)
@@ -148,6 +152,10 @@ keys = jrnd.split(rng, 1000)
 predictive = jax.vmap(lambda k, f: f + jrnd.normal(k, (n,)) * y_sd)(
     keys, samples[-1000:]
 )
+```
+
+```{code-cell}
+:tags: [hide-input]
 plt.figure(figsize=(8, 5))
 plt.hist(np.array(y), bins=50, density=True)
 plt.hist(np.array(predictive.reshape(-1)), bins=50, density=True, alpha=0.8)
@@ -167,6 +175,8 @@ Another parameter of interest for diagnostics is the location on the ellipse the
 Since the likelihood's variance is set at 1., it is quite informative. Increasing the likelihood's variance leads to less sub iterations per iteration of the Elliptical Slice sampler and the parameter theta becoming more uniform on its range.
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 plt.figure(figsize=(10, 5))
 plt.hist(np.array(info.subiter), bins=50)
 plt.xlabel("Sub iterations")
@@ -175,6 +185,8 @@ plt.show()
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 plt.figure(figsize=(10, 5))
 plt.hist(np.array(info.theta), bins=100)
 plt.xlabel("theta")

--- a/examples/Introduction.md
+++ b/examples/Introduction.md
@@ -27,15 +27,6 @@ import numpy as np
 import blackjax
 ```
 
-```{code-cell} ipython3
-%load_ext watermark
-%watermark -d -m -v -p jax,jaxlib,blackjax
-```
-
-```{code-cell} ipython3
-jax.devices()
-```
-
 ## The Problem
 
 We'll generate observations from a normal distribution of known `loc` and `scale` to see if we can recover the parameters in sampling. Let's take a decent-size dataset with 1,000 points:

--- a/examples/LogisticRegression.md
+++ b/examples/LogisticRegression.md
@@ -26,15 +26,12 @@ import blackjax
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 %config InlineBackend.figure_format = "retina"
 plt.rcParams["axes.spines.right"] = False
 plt.rcParams["axes.spines.top"] = False
 plt.rcParams["figure.figsize"] = (12, 8)
-```
-
-```{code-cell} ipython3
-%load_ext watermark
-%watermark -d -m -v -p jax,jaxlib,blackjax
 ```
 
 ## The Data
@@ -50,6 +47,8 @@ y = rows[0] * 1.0  # y[i] = whether point i belongs to cluster 1
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 colors = ["tab:red" if el else "tab:blue" for el in rows[0]]
 plt.scatter(*X.T, edgecolors=colors, c="none")
 plt.xlabel(r"$X_0$")
@@ -80,6 +79,8 @@ $$
 And $\Phi$ is the matrix that contains the data, so each row $\Phi_{i,:}$ is the vector $\left[1, X_0^i, X_1^i\right]$
 
 ```{code-cell} ipython3
+:tags: [hide-stderr]
+
 Phi = jnp.c_[jnp.ones(num_points)[:, None], X]
 N, M = Phi.shape
 
@@ -140,7 +141,7 @@ states = inference_loop(rng_key, rmh.step, initial_state, 5_000)
 And display the trace:
 
 ```{code-cell} ipython3
-burnin = 300
+:tags: [hide-input]
 
 fig, ax = plt.subplots(1, 3, figsize=(12, 2))
 for i, axi in enumerate(ax):
@@ -151,6 +152,7 @@ plt.show()
 ```
 
 ```{code-cell} ipython3
+burnin = 300
 chains = states.position[burnin:, :]
 nsamp, _ = chains.shape
 ```
@@ -174,6 +176,8 @@ Z_mcmc = Z_mcmc.mean(axis=0)
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 plt.contourf(*Xspace, Z_mcmc)
 plt.scatter(*X.T, c=colors)
 plt.xlabel(r"$X_0$")

--- a/examples/LogisticRegressionWithLatentGaussianSampler.md
+++ b/examples/LogisticRegressionWithLatentGaussianSampler.md
@@ -26,15 +26,12 @@ import blackjax
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 %config InlineBackend.figure_format = "retina"
 plt.rcParams["axes.spines.right"] = False
 plt.rcParams["axes.spines.top"] = False
 plt.rcParams["figure.figsize"] = (12, 8)
-```
-
-```{code-cell} ipython3
-%load_ext watermark
-%watermark -d -m -v -p jax,jaxlib,blackjax
 ```
 
 ## The data
@@ -50,6 +47,8 @@ y = rows[0] * 1.0  # y[i] = whether point i belongs to cluster 1
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 colors = ["tab:red" if el else "tab:blue" for el in rows[0]]
 plt.scatter(*X.T, edgecolors=colors, c="none")
 plt.xlabel(r"$X_0$")
@@ -80,6 +79,8 @@ $$
 And $\Phi$ is the matrix that contains the data, so each row $\Phi_{i,:}$ is the vector $\left[1, X_0^i, X_1^i\right]$
 
 ```{code-cell} ipython3
+:tags: [hide-stderr]
+
 Phi = jnp.c_[jnp.ones(num_points)[:, None], X]
 N, M = Phi.shape
 alpha = 1.0
@@ -184,6 +185,8 @@ print(f"Percentage of accepted samples (after calibration): {tota_pct_accepted:.
 And display the trace:
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 fig, ax = plt.subplots(1, 3, figsize=(12, 2))
 for i, axi in enumerate(ax):
     axi.plot(states.position[:, i])
@@ -215,6 +218,8 @@ Z_mcmc = Z_mcmc.mean(axis=0)
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 plt.contourf(*Xspace, Z_mcmc)
 plt.scatter(*X.T, c=colors)
 plt.xlabel(r"$X_0$")

--- a/examples/Pathfinder.md
+++ b/examples/Pathfinder.md
@@ -27,15 +27,12 @@ import blackjax
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 %config InlineBackend.figure_format = "retina"
 plt.rcParams["axes.spines.right"] = False
 plt.rcParams["axes.spines.top"] = False
 plt.rcParams["figure.figsize"] = (10, 6)
-```
-
-```{code-cell} ipython3
-%load_ext watermark
-%watermark -d -m -v -p jax,jaxlib,blackjax
 ```
 
 ## The Data
@@ -51,6 +48,8 @@ y = rows[0] * 1.0  # y[i] = whether point i belongs to cluster 1
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 colors = ["tab:red" if el else "tab:blue" for el in rows[0]]
 plt.scatter(*X.T, edgecolors=colors, c="none")
 plt.xlabel(r"$X_0$")
@@ -120,6 +119,8 @@ path = blackjax.vi.pathfinder.init(rng_key, logprob_fn, w0, return_path=True, ft
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 def ellipse_confidence(mu, cov, ax, c, n_std=2.0):
     import numpy as np
 
@@ -202,6 +203,8 @@ _, (_, samples) = inference_loop(rng_key, pathfinder.step, state, 5_000)
 And display the trace:
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 fig, ax = plt.subplots(1, 2, figsize=(8, 2), sharey=True)
 for i, axi in enumerate(ax):
     axi.plot(samples[:, i])
@@ -230,6 +233,8 @@ _, (samples_rmh, _) = inference_loop(rng_key, rmh.step, state_rmh, 5_000)
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 fig, ax = plt.subplots(2, 2, figsize=(10, 4), sharey=True)
 for i in range(2):
     ax[i, 0].plot(samples_rmh.position[:, i])

--- a/examples/RegimeSwitchingModel.md
+++ b/examples/RegimeSwitchingModel.md
@@ -21,16 +21,16 @@ We'll assume that at any given time $t$ the stock's returns will follow one of t
 
 In the whole, our regime-switching model is defined by the likelihood
 
-$$
+```{math}
 \begin{split}
     L(\mathbf{r}|\alpha, \rho, \sigma^2, \mathbf{p}, r_0, \xi_{10}) &= \prod_t \xi_{1t}\eta_{1t} + (1-\xi_{1t})\eta_{2t} \\
     \xi_{1t} &= \frac{\xi_{1t-1}\eta_{1t}}{\xi_{1t-1}\eta_{1t} + (1-\xi_{1t-1})\eta_{2t}},
 \end{split}
-$$
+```
 
 where $\eta_{jt} = p_{j,1}$, $\mathcal{N}(r_t;\alpha_1, \sigma_1^2) + p_{j,2}$, and $\mathcal{N}(r_t; \alpha_2 + \rho r_{t-1}, \sigma_2^2)$ for $j\in\{0, 1\}$. And the priors of the parameters are:
 
-$$
+```{math}
 \begin{split}
     \alpha_1, \alpha_2 &\sim \mathcal{N}(0, 1) \\
     \rho &\sim \mathcal{N}^0(1, 0.1) \\
@@ -39,7 +39,7 @@ $$
     r_0 &\sim \mathcal{N}(0, 1) \\
     \xi_{10} &\sim \mathcal{Beta}(2, 2),
 \end{split}
-$$
+```
 
 where $\mathcal{N}^0$ indicates the truncated at 0 Gaussian distribution and $\mathcal{C}^+$ the half-Cauchy distribution.
 
@@ -202,6 +202,11 @@ print_summary(samples)
 
 ```{code-cell} ipython3
 samples = jax.tree_map(lambda s: s.reshape((-1,) + s.shape[2:]), samples)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
 sam = []
 for name, value in samples.items():
     sam.append(np.asarray(value).T)

--- a/examples/SGMCMC.md
+++ b/examples/SGMCMC.md
@@ -82,10 +82,12 @@ X_test, y_test, N_test = prepare_data(data_test)
 
 We will use a very simple (bayesian) neural network in this example: A MLP with gaussian priors on the weights. We first need a function that computes the model's logposterior density given the data and the current values of the parameters. If we note $X$ the array that represents an image and $y$ the array such that $y_i = 0$  if the image is in category $i$, $y_i=1$ otherwise, the model can be written as:
 
+```{math}
 \begin{align*}
   \boldsymbol{p} &= \operatorname{NN}(X)\\
   \boldsymbol{y} &\sim \operatorname{Categorical}(\boldsymbol{p})
 \end{align*}
+```
 
 ```{code-cell} ipython3
 @jax.jit
@@ -215,6 +217,8 @@ for step in progress_bar(range(num_samples + num_warmup)):
 Let us plot the accuracy at different points in the sampling process:
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 import matplotlib.pylab as plt
 
 fig = plt.figure(figsize=(12, 8))
@@ -230,6 +234,8 @@ plt.plot()
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 print(f"The average accuracy in the sampling phase is {np.mean(accuracies[10:]):.2f}")
 ```
 
@@ -270,12 +276,11 @@ for i in range(10):
 And now compute the average accuracy over all the samples without these uncertain predictions:
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 avg_accuracy = np.mean(
     [compute_accuracy(s, X_test[certain_mask], y_test[certain_mask]) for s in samples]
 )
-```
-
-```{code-cell} ipython3
 print(
     f"The average accuracy removing the samples for which the model is uncertain is {avg_accuracy:.3f}"
 )

--- a/examples/SparseLogisticRegression.md
+++ b/examples/SparseLogisticRegression.md
@@ -17,7 +17,17 @@ mystnb:
 
 This example models a logistic regression with hierarchies on the scale of the independent variable's parameters that function as a proxy for variable selection. We give the independent variable's regressors $\beta$ a prior mean of 0 and global $\tau$ and local $\lambda$ scale parameters with strong prior information around 0, thus allowing these parameters to a posteriori degenerate at 0, hence excluding its independent variable from the model. These type of hierarchies on the prior scale of a parameter create funnel geometries that are hard to efficiently explore without local or global structure of the target.
 
-The model is run on its non-centered parametrization \citep{papaspiliopoulos2007general} with data from the numerical version of the [German credit dataset](https://archive.ics.uci.edu/ml/datasets/statlog+(german+credit+data)). The target posterior is defined by its likelihood $L(\mathbf{y}|\beta, \lambda, \tau) = \prod_i \text{Beta}(y_i;\sigma((\tau \lambda \odot \beta)^T X_i))$, with $\sigma$ the sigmoid function, and prior $\pi_0(\beta, \lambda, \tau) = \text{Gamma}(\tau;1/2, 1/2)\prod_i \mathcal{N}(\beta_i;0, 1)\text{Gamma}(\lambda_i;1/2, 1/2)$.
+The model is run on its non-centered parametrization \citep{papaspiliopoulos2007general} with data from the numerical version of the [German credit dataset](https://archive.ics.uci.edu/ml/datasets/statlog+(german+credit+data)). The target posterior is defined by its likelihood
+
+$$
+L(\mathbf{y}|\beta, \lambda, \tau) = \prod_i \text{Beta}(y_i;\sigma((\tau \lambda \odot \beta)^T X_i))
+$$
+
+with $\sigma$ the sigmoid function, and prior
+
+$$
+\pi_0(\beta, \lambda, \tau) = \text{Gamma}(\tau;1/2, 1/2)\prod_i \mathcal{N}(\beta_i;0, 1)\text{Gamma}(\lambda_i;1/2, 1/2)
+$$
 
 
 ```{code-cell} ipython3

--- a/examples/TemperedSMC.md
+++ b/examples/TemperedSMC.md
@@ -22,7 +22,7 @@ $$
 p_{\lambda_k}(x) \propto p_0(x) \exp(-\lambda_k V(x))
 $$
 
-where the tempering parameter $ \lambda_k $ takes increasing values between $0$ and $1$. Tempered SMC will also particularly shine when the MCMC step
+where the tempering parameter $\lambda_k$ takes increasing values between $0$ and $1$. Tempered SMC will also particularly shine when the MCMC step
 is not well calibrated (too small step size, etc) like in the example below.
 
 ## Imports
@@ -56,7 +56,7 @@ $$
 V(x) = (x^2 - 1)^2
 $$
 
-This corresponds to the following distribution. We plot the resulting tempered density for 5 different values of $$\lambda_k$$ : from $\lambda_k =1$ which correponds to the original density to $\lambda_k=0$. The lower the value of $\lambda_k$ the easier it is to sampler from the posterior density.
+This corresponds to the following distribution. We plot the resulting tempered density for 5 different values of $\lambda_k$ : from $\lambda_k =1$ which correponds to the original density to $\lambda_k=0$. The lower the value of $\lambda_k$ the easier it is for the sampler to jump between the modes of the posterior density.
 
 ```{code-cell} ipython3
 def V(x):
@@ -81,6 +81,11 @@ normalizing_factor = jnp.sum(density, axis=1, keepdims=True) * (
     linspace[1] - linspace[0]
 )
 density /= normalizing_factor
+```
+
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 fig, ax = plt.subplots(figsize=(12, 8))
 ax.plot(linspace.squeeze(), density.T)
@@ -124,6 +129,10 @@ hmc_parameters = dict(
 hmc = blackjax.hmc(full_logprob, **hmc_parameters)
 hmc_state = hmc.init(jnp.ones((1,)))
 hmc_samples = inference_loop(key, hmc.step, hmc_state, n_samples)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 samples = np.array(hmc_samples.position[:, 0])
 _ = plt.hist(samples, bins=100, density=True)
@@ -142,6 +151,10 @@ nuts_parameters = dict(step_size=1e-4, inverse_mass_matrix=inv_mass_matrix)
 nuts = blackjax.nuts(full_logprob, **nuts_parameters)
 nuts_state = nuts.init(jnp.ones((1,)))
 nuts_samples = inference_loop(key, nuts.step, nuts_state, n_samples)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 samples = np.array(nuts_samples.position[:, 0])
 _ = plt.hist(samples, bins=100, density=True)
@@ -204,6 +217,10 @@ initial_smc_state = tempered.init(initial_smc_state)
 
 n_iter, smc_samples = smc_inference_loop(key, tempered.step, initial_smc_state)
 print("Number of steps in the adaptive algorithm: ", n_iter.item())
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 samples = np.array(smc_samples.particles[:, 0])
 _ = plt.hist(samples, bins=100, density=True)
@@ -240,6 +257,10 @@ normalizing_factor = jnp.sum(density, axis=1, keepdims=True) * (
     linspace[1] - linspace[0]
 )
 density /= normalizing_factor
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 fig, ax = plt.subplots(figsize=(12, 8))
 ax.semilogy(linspace.squeeze(), density.T)
@@ -280,6 +301,10 @@ hmc_parameters = dict(
 hmc = blackjax.hmc(full_logprob, **hmc_parameters)
 hmc_state = hmc.init(jnp.ones((1,)))
 hmc_samples = inference_loop(key, hmc.step, hmc_state, n_samples)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 samples = np.array(hmc_samples.position[:, 0])
 _ = plt.hist(samples, bins=100, density=True)
@@ -299,6 +324,10 @@ nuts_parameters = dict(step_size=1e-2, inverse_mass_matrix=inv_mass_matrix)
 nuts = blackjax.nuts(full_logprob, **nuts_parameters)
 nuts_state = nuts.init(jnp.ones((1,)))
 nuts_samples = inference_loop(key, nuts.step, nuts_state, n_samples)
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 samples = np.array(nuts_samples.position[:, 0])
 _ = plt.hist(samples, bins=100, density=True)
@@ -337,6 +366,10 @@ initial_smc_state = tempered.init(initial_smc_state)
 
 n_iter, smc_samples = smc_inference_loop(key, tempered.step, initial_smc_state)
 print("Number of steps in the adaptive algorithm: ", n_iter.item())
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
 
 samples = np.array(smc_samples.particles[:, 0])
 _ = plt.hist(samples, bins=100, density=True)

--- a/examples/change_of_variable_hmc.md
+++ b/examples/change_of_variable_hmc.md
@@ -20,29 +20,18 @@ mystnb:
 
 In particular we use following binomial hierarchical model where $y_{j}$ and $N_{j}$ are observed variables.
 
-
-<table>
-<tr>
-</tr>
-<tr>
-<td>
-
-![image.png](https://github.com/karm-patel/karm-patel.github.io/blob/master/images/binomial_hierarchichal.png?raw=True)
-
-</td>
-<td>
-
+```{math}
 \begin{align}
     y_{j} &\sim \text{Binom}(N_{j}, \theta_{j}) \label{eq:1} \\
     \theta_{j} &\sim \text{Beta}(a, b) \label{eq:2} \\
     p(a, b) &\propto (a+b)^{-5/2}
 \end{align}
+```
 
-</td>
-</tr>
-</table>
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 import arviz as az
 import jax
 import jax.numpy as jnp
@@ -62,9 +51,9 @@ plt.rc("xtick", labelsize=12)  # fontsize of the xtick labels
 plt.rc("ytick", labelsize=12)  # fontsize of the tyick labels
 ```
 
-## Data
-
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 # index of array is type of tumor and value shows number of total people tested.
 group_size = jnp.array(
     [
@@ -226,6 +215,8 @@ n_rat_tumors = len(group_size)
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 plt.figure(figsize=(12, 3))
 plt.bar(range(n_rat_tumors), n_of_positives)
 plt.title("No. of positives for each tumor type", fontsize=14)
@@ -234,6 +225,8 @@ sns.despine()
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 plt.figure(figsize=(14, 4))
 plt.bar(range(n_rat_tumors), group_size)
 plt.title("Group size for each tumor type", fontsize=14)
@@ -337,9 +330,11 @@ states, infos = inference_loop_multiple_chains(
 
 ## Arviz Plots
 
-We have all our posterior samples stored in `states.position` dictionary and `infos` store additional information like acceptance probability, divergence, etc. Now, we can use certain diagnostics to judge if our MCMC samples are converged on stationary distribution. Some of widely diagnostics are trace plots, potential scale reduction factor (R hat), divergences, etc. `Arviz` library provides quicker ways to anaylze these diagnostics. We can use `arviz.summary()` and `arviz_plot_trace()`, but these functions take specific format (arviz's trace) as a input. So now first we will convert `states` and `infos` into `trace`.
+We have all our posterior samples stored in `states.position` dictionary and `infos` store additional information like acceptance probability, divergence, etc. Now, we can use certain diagnostics to judge if our MCMC samples are converged on stationary distribution. Some of widely diagnostics are trace plots, potential scale reduction factor (R hat), divergences, etc. `Arviz` library provides quicker ways to anaylze these diagnostics. We can use `arviz.summary()` and `arviz_plot_trace()`, but these functions take specific format (arviz's trace) as a input.
 
 ```{code-cell} ipython3
+:tags: [hide-cell]
+
 def arviz_trace_from_states(states, info, burn_in=0):
     position = states.position
     if isinstance(position, jnp.DeviceArray):  # if states.position is array of samples
@@ -381,6 +376,8 @@ summ_df
 **r_hat** is showing measure of each chain is converged to stationary distribution. **r_hat** should be less than or equal to 1.01, here we get r_hat far from 1.01 for each latent sample.
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 az.plot_trace(trace)
 plt.tight_layout()
 ```
@@ -490,6 +487,8 @@ summ_df
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 az.plot_trace(trace)
 plt.tight_layout()
 ```
@@ -584,6 +583,8 @@ summ_df
 ```
 
 ```{code-cell} ipython3
+:tags: [hide-input]
+
 az.plot_trace(trace)
 plt.tight_layout()
 ```

--- a/examples/howto_use_aesara.md
+++ b/examples/howto_use_aesara.md
@@ -40,7 +40,7 @@ n_of_positives = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1,
 n_rat_tumors = len(group_size)
 ```
 
-Let us know implement the model in Aesara/AePPL. We start with implementing the generative model in two part, the improper prior on `a` and `b` and then the response model:
+Let us now implement the model in Aesara/AePPL. We start with implementing the generative model in two part, the improper prior on `a` and `b` and then the response model:
 
 ```{code-cell} ipython3
 import aesara

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,6 @@
 -e ./
-aesara>=2.8.5
 aeppl
+aesara>=2.8.5
 arviz
 distrax
 jax


### PR DESCRIPTION
Reminding here that environment information is not necessary since this can be found in the CI process that generated the doc.

Closes #308 and #309 