### PR TITLE
Remove `logprob_grad_fn` kwargs in favor of `jax.custom_vjp`

### DIFF
--- a/blackjax/mcmc/diffusion.py
+++ b/blackjax/mcmc/diffusion.py
@@ -21,7 +21,7 @@ def generate_gaussian_noise(rng_key: PRNGKey, position):
     return unravel_fn(noise_flat)
 
 
-def overdamped_langevin(logprob_grad_fn):
+def overdamped_langevin(logprob_and_grad_fn):
     """Euler solver for overdamped Langevin diffusion."""
 
     def one_step(rng_key, state: DiffusionState, step_size: float, batch: tuple = ()):
@@ -34,7 +34,7 @@ def overdamped_langevin(logprob_grad_fn):
             noise,
         )
 
-        logprob, logprob_grad = logprob_grad_fn(position, *batch)
+        logprob, logprob_grad = logprob_and_grad_fn(position, *batch)
         return DiffusionState(position, logprob, logprob_grad)
 
     return one_step

--- a/blackjax/mcmc/integrators.py
+++ b/blackjax/mcmc/integrators.py
@@ -1,5 +1,5 @@
 """Symplectic, time-reversible, integrators for Hamiltonian trajectories."""
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, NamedTuple
 
 import jax
 
@@ -32,7 +32,6 @@ def new_integrator_state(potential_fn, position, momentum):
 def velocity_verlet(
     potential_fn: Callable,
     kinetic_energy_fn: EuclideanKineticEnergy,
-    potential_grad_fn: Optional[Callable] = None,
 ) -> EuclideanIntegrator:
     """The velocity Verlet (or Verlet-Störmer) integrator.
 
@@ -69,10 +68,7 @@ def velocity_verlet(
     b1 = 0.5
     a2 = 1 - 2 * a1
 
-    if potential_grad_fn:
-        potential_and_grad_fn = lambda x: (potential_fn(x), potential_grad_fn(x))
-    else:
-        potential_and_grad_fn = jax.value_and_grad(potential_fn)
+    potential_and_grad_fn = jax.value_and_grad(potential_fn)
     kinetic_energy_grad_fn = jax.grad(kinetic_energy_fn)
 
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
@@ -108,7 +104,6 @@ def velocity_verlet(
 def mclachlan(
     potential_fn: Callable,
     kinetic_energy_fn: Callable,
-    potential_grad_fn: Optional[Callable] = None,
 ) -> EuclideanIntegrator:
     """Two-stage palindromic symplectic integrator derived in [1]_
 
@@ -132,11 +127,7 @@ def mclachlan(
     a1 = 0.5
     b2 = 1 - 2 * b1
 
-    if potential_grad_fn:
-        potential_and_grad_fn = lambda x: (potential_fn(x), potential_grad_fn(x))
-
-    else:
-        potential_and_grad_fn = jax.value_and_grad(potential_fn)
+    potential_and_grad_fn = jax.value_and_grad(potential_fn)
     kinetic_energy_grad_fn = jax.grad(kinetic_energy_fn)
 
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:
@@ -186,7 +177,6 @@ def mclachlan(
 def yoshida(
     potential_fn: Callable,
     kinetic_energy_fn: Callable,
-    potential_grad_fn: Optional[Callable] = None,
 ) -> EuclideanIntegrator:
     """Three stages palindromic symplectic integrator derived in [1]_
 
@@ -208,11 +198,7 @@ def yoshida(
     b2 = 0.5 - b1
     a2 = 1 - 2 * a1
 
-    if potential_grad_fn:
-        potential_and_grad_fn = lambda x: (potential_fn(x), potential_grad_fn(x))
-
-    else:
-        potential_and_grad_fn = jax.value_and_grad(potential_fn)
+    potential_and_grad_fn = jax.value_and_grad(potential_fn)
     kinetic_energy_grad_fn = jax.grad(kinetic_energy_fn)
 
     def one_step(state: IntegratorState, step_size: float) -> IntegratorState:

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -1,5 +1,5 @@
 """Public API for the NUTS Kernel"""
-from typing import Callable, NamedTuple, Optional, Tuple
+from typing import Callable, NamedTuple, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -105,7 +105,6 @@ def kernel(
         logprob_fn: Callable,
         step_size: float,
         inverse_mass_matrix: Array,
-        logprob_grad_fn: Optional[Callable] = None,
     ) -> Tuple[hmc.HMCState, NUTSInfo]:
         """Generate a new sample with the NUTS kernel.
 
@@ -120,9 +119,7 @@ def kernel(
             kinetic_energy_fn,
             uturn_check_fn,
         ) = metrics.gaussian_euclidean(inverse_mass_matrix)
-        symplectic_integrator = integrator(
-            potential_fn, kinetic_energy_fn, logprob_grad_fn
-        )
+        symplectic_integrator = integrator(potential_fn, kinetic_energy_fn)
         proposal_generator = iterative_nuts_proposal(
             symplectic_integrator,
             kinetic_energy_fn,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,7 @@ with the relevant hardware acceleration support.
 
    howto_use_ppl
    Sample with multiple chains?<examples/howto_sample_multiple_chains.md>
+   Use custom gradients?<examples/howto_custom_gradients.md>
    Use non-JAX log-prob functions?<examples/howto_other_frameworks.md>
 
 .. toctree::

--- a/examples/howto_custom_gradients.md
+++ b/examples/howto_custom_gradients.md
@@ -1,0 +1,193 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.0
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Use custom gradients
+
+
+JAX provides a convenient `jax.grad` function to evaluate the gradient of any function build with JAX primitives. Which is why Blackjax uses `jax.grad` internally whenever it needs to evaluate the gradient. This should be enough for most applications, but sometimes you may need to provide your own gradients to blackjax for several reasons:
+
+- You have a convenient closed-form expression for the gradient that is evaluated faster than the gradient that JAX produces;
+- The forward-mode differentiation is faster than the backward-mode;
+- The log-density function you are using is non differentiable by JAX, which is the case of [many optimizers](https://github.com/google/jaxopt).
+
+Do not despair! Blackjax covers these use cases using JAX's [custom derivative dispatch](https://jax.readthedocs.io/en/latest/notebooks/Custom_derivative_rules_for_Python_code.html). In the following we will consider a very academic example, but which should be enough to understand the mechanics of how to set custom gradients with JAX.
+
+## Functions defined as the minimum of another function
+
+Functions can be defined as the minimum of another one, $f(x) = min_{y} g(x,y)$. Computing their gradients may be tedious, especially if the minimisation happens numerically rather than in closed form. We show how automatic derivatives can be modified on such examples, resulting in better overall efficiency and stability.
+
+Our example is taken from the theory of [convex conjugates](https://en.wikipedia.org/wiki/Convex_conjugate), used for example in optimal transport. Let's consider the following function:
+
+$$
+\begin{align*}
+g(x, y) &= h(y) - \langle x, y\rangle\\
+h(x) &= \frac{1}{p}|x|^p,\qquad p > 1.\\
+\end{align*}
+$$
+
+And define the function $f$ as $f(x) = -min_y g(x, y)$ which we can be implemented as:
+
+```{code-cell} ipython3
+import jax
+import jax.numpy as jnp
+from jax.scipy.optimize import minimize
+
+def h(x, p):
+    out = jnp.abs(x) ** p
+    return out / p
+
+def f(x, p):
+    """Returns the minimum value of g and where it is achieved.
+    """
+    def g(y):
+        return jnp.sum(h(y, p) - x * y)
+
+    res = minimize(g, jnp.zeros((1,)), method="BFGS")
+    return -res.fun, res.x[0]
+```
+
+
+Note the we also return the value of $y$ where the minimum of $g$ is achieved (this will be useful later).
+
+
+### Trying to differentate the function with `jax.grad`
+
+The gradient of the function $f$ is undefined for JAX, which cannot differentiate through `while` loops, and trying to compute it directly raises an error:
+
+```{code-cell} ipython3
+# We only want the gradient with respect to `x`
+try:
+    jax.grad(f, has_aux=True)(0.5, 3)
+except Exception as e:
+    print(e)
+```
+
+### Deriving the gradient mathematically
+
+In order to avoid this, we can leverage the mathematical structure of $f(x) = -\min_y h(y) - \langle x, y\rangle$. Indeed, asumming that the minimum is unique and achieved at $y(x)$ we have
+
+```{math}
+\begin{equation*}
+    \frac{df}{dx} = -\bigg[\frac{dh}{dy} \frac{dy}{dx} - \frac{dy}{dx} x - y\bigg]
+\end{equation*}
+```
+
+The first order optimality criterion
+
+```{math}
+\begin{equation*}
+    \frac{dh}{dy} - x = 0,
+\end{equation*}
+```
+
+Ensures that:
+
+```{math}
+\begin{equation*}
+    \frac{df}{dx} = y(x).
+\end{equation*}
+```
+
+i.e. the value of the derivative at $x$ is the value $y(x)$ at which the minimum of the function $g$ is achieved.
+
+
+### Telling JAX to use a custom gradient
+
+We can thus now tell JAX to compute the derivative of the function using the argmin using `jax.custom_vjp`
+
+```{code-cell} ipython3
+from functools import partial
+
+
+@partial(jax.custom_jvp, nondiff_argnums=(1,))
+def f_with_gradient(x, p):
+    # We only return the value of f
+    return f(x, p)[0]
+
+@f_with_gradient.defjvp
+def f_jac_vec_prod(p, primals, tangents):
+    x, = primals
+    x_dot, = tangents
+
+    # We use the fact that the gradient of f is
+    # the argmin.
+    f_out, argmin = f(x, p)
+
+    return f_out, argmin * x_dot
+```
+
+Which now outputs a value:
+
+```{code-cell} ipython3
+jax.grad(f_with_gradient)(0.31415, 3)
+```
+
+### Making sure the result is correct
+
+The form of the function $g$ was specifically chosen because we have a closed-form expression for $f$ which is differentiable and will allow us to check the value of the previously defined gradient:
+
+$$
+\begin{align*}
+f(x) &=\frac{1}{q}|x|^q\\
+\frac{1}{q} + \frac{1}{p} &= 1\\
+\end{align*}
+$$
+
+Which is obviously differentiable. We implement it:
+
+```{code-cell} ipython3
+def true_f(x, p):
+    q = 1 / (1 - 1 / p)
+    out = jnp.abs(x) ** q
+    return out / q
+
+print(jax.grad(true_f)(0.31415, 3))
+```
+
+And compare the gradient of this function with the custom gradient defined above:
+
+```{code-cell} ipython3
+:tags: [hide-input]
+print(f"Gradient of closed-form f: {jax.grad(true_f)(0.31415, 3)}")
+print(f"Custom gradient based on argmin: {jax.grad(f_with_gradient)(0.31415, 3)}")
+```
+
+They give close enough values! In other words, it suffices to know that the value of the gradient is the argmin to define a custom gradient function that gives good results.
+
++++
+
+### Using the function with Blackjax
+
+
+Let us now demonstrate that we can use `f_with_gradients` with Blackjax. We define a toy log-density function and use a gradient-based sampler:
+
+```{code-cell} ipython3
+import blackjax
+
+
+def logprob_fn(y):
+    logprob = jax.scipy.stats.norm.logpdf(y)
+    x = f_with_gradient(y, 3)
+    logprob += jax.scipy.stats.norm.logpdf(x)
+    return logprob
+
+hmc = blackjax.hmc(logprob_fn,1e-3, jnp.ones(1), 10)
+state = hmc.init(1.)
+
+rng_key = jax.random.PRNGKey(0)
+new_state, info = hmc.step(rng_key, state)
+```
+
+```{code-cell} ipython3
+new_state
+```

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -102,23 +102,16 @@ class IntegratorTest(chex.TestCase):
         itertools.product(
             ["free_fall", "harmonic_oscillator", "planetary_motion"],
             ["velocity_verlet", "mclachlan", "yoshida"],
-            ["default_gradient", "forward_gradients"],
         )
     )
-    def test_integrator(self, example_name, integrator_name, gradient_type):
+    def test_integrator(self, example_name, integrator_name):
         integrator = algorithms[integrator_name]
         example = examples[example_name]
 
         model = example["model"]
         potential, kinetic_energy = model(example["inv_mass_matrix"])
 
-        if gradient_type == "default_gradient":
-            step = self.variant(integrator["algorithm"](potential, kinetic_energy))
-        elif gradient_type == "forward_gradients":
-            potential_grad = jax.jacfwd(potential)
-            step = self.variant(
-                integrator["algorithm"](potential, kinetic_energy, potential_grad)
-            )
+        step = self.variant(integrator["algorithm"](potential, kinetic_energy))
 
         step_size = example["step_size"]
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -442,17 +442,14 @@ mcse_test_cases = [
             "step_size": 1.0,
             "num_integration_steps": 32,
         },
-        "custom_gradients": False,
     },
     {
         "algorithm": blackjax.nuts,
         "parameters": {"step_size": 1.0},
-        "custom_gradients": False,
     },
     {
         "algorithm": blackjax.nuts,
         "parameters": {"step_size": 1.0},
-        "custom_gradients": True,
     },
 ]
 
@@ -497,21 +494,15 @@ class MonteCarloStandardErrorTest(chex.TestCase):
         return scaled_error
 
     @parameterized.parameters(mcse_test_cases)
-    def test_mcse(self, algorithm, parameters, custom_gradients):
+    def test_mcse(self, algorithm, parameters):
         """Test convergence using Monte Carlo CLT across multiple chains."""
         init_fn_key, pos_init_key, sample_key = jax.random.split(self.key, 3)
         logprob_fn, true_loc, true_scale, true_rho = self.generate_multivariate_target(
             None
         )
-        if custom_gradients:
-            logprob_grad_fn = jax.jacfwd(logprob_fn)
-        else:
-            logprob_grad_fn = None
-
         kernel = algorithm(
             logprob_fn,
             inverse_mass_matrix=true_scale,
-            logprob_grad_fn=logprob_grad_fn,
             **parameters,
         )
 


### PR DESCRIPTION
Custom gradient currently need to be passed to the algorithms all the way down to the integrators. However JAX has a much nicer way of doing that; you can write a logprob and register a gradient for that logprob; JAX will then use it when `jax.grad` is called on that function.

Closes #341 #318 

 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [x] The doc is up-to-date;