### PR TITLE
Only publish the docs on release

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -1,8 +1,8 @@
 name: Publish the documentation
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   publish:


### PR DESCRIPTION
We would ideally need a new version of the documentation for each minor version plus one for `HEAD` (#313). In the meantime, the best default is to have the documentation refer to the last release on PyPi. This PR changes the publication workflow so docs is only published on each new release.