### PR TITLE
Improve batch shape handling in MEADS and allow scaled step sizes in GHMC using `mcmc.integrators.velocity_verlet`

### DIFF
--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -83,14 +83,14 @@ def kernel(
     returns a new state of the chain along with information about the transition.
     """
 
-    _, kinetic_energy_fn, _ = metrics.gaussian_euclidean(jnp.ones(1))
     sample_proposal = proposal.nonreversible_slice_sampling
 
     def one_step(
         rng_key: PRNGKey,
         state: GHMCState,
         logprob_fn: Callable,
-        step_size: PyTree,  # float,
+        step_size: float,
+        momentum_inverse_scale: PyTree,
         alpha: float,
         delta: float,
     ) -> Tuple[GHMCState, hmc.HMCInfo]:
@@ -105,8 +105,11 @@ def kernel(
         logprob_fn
             (Unnormalized) Log density function being targeted.
         step_size
+            Variable specifying the size of the integration step.
+        momentum_inverse_scale
             Pytree with the same structure as the targeted position variable
-            specifying the step size used for each dimension of the target.
+            specifying the per dimension inverse scaling transformation applied
+            to the persistent momentum variable prior to the integration step.
         alpha
             Variable specifying the degree of persistent momentum, complementary
             to independent new momentum.
@@ -118,7 +121,12 @@ def kernel(
         def potential_fn(x):
             return -logprob_fn(x)
 
-        symplectic_integrator = velocity_verlet(potential_fn, kinetic_energy_fn)
+        flat_inverse_scale = jax.flatten_util.ravel_pytree(momentum_inverse_scale)[0]
+        _, kinetic_energy_fn, _ = metrics.gaussian_euclidean(flat_inverse_scale**2)
+
+        symplectic_integrator = integrators.velocity_verlet(
+            potential_fn, kinetic_energy_fn
+        )
         proposal_generator = hmc.hmc_proposal(
             symplectic_integrator,
             kinetic_energy_fn,
@@ -131,6 +139,7 @@ def kernel(
         position, momentum, potential_energy, potential_energy_grad, slice = state
         # New momentum is persistent
         momentum = update_momentum(key_momentum, state, alpha)
+        momentum = jax.tree_map(lambda m, s: m / s, momentum, momentum_inverse_scale)
         # Slice is non-reversible
         slice = ((slice + 1.0 + delta + noise_fn(key_noise)) % 2) - 1.0
 
@@ -141,69 +150,13 @@ def kernel(
         proposal = hmc.flip_momentum(proposal)
         state = GHMCState(
             proposal.position,
-            proposal.momentum,
+            jax.tree_map(lambda m, s: m * s, proposal.momentum, momentum_inverse_scale),
             proposal.potential_energy,
             proposal.potential_energy_grad,
             info.acceptance_probability,
         )
 
         return state, info
-
-    return one_step
-
-
-def velocity_verlet(
-    potential_fn: Callable,
-    kinetic_energy_fn: integrators.EuclideanKineticEnergy,
-) -> integrators.EuclideanIntegrator:
-    """The velocity Verlet (or Verlet-Störmer) integrator.
-
-    Generates an implementation similar to the one in `integrators` except
-    with a step_size parameter of the same PyTree structure as the position
-    (target) variable that specifies an independent step_size for each dimension
-    of the target.
-    """
-
-    potential_and_grad_fn = jax.value_and_grad(potential_fn)
-    kinetic_energy_grad_fn = jax.grad(kinetic_energy_fn)
-
-    def one_step(
-        state: integrators.IntegratorState, step_size: PyTree
-    ) -> integrators.IntegratorState:
-        position, momentum, _, potential_energy_grad = state
-
-        momentum = jax.tree_util.tree_map(
-            lambda momentum, potential_grad, step_size: momentum
-            - 0.5 * step_size * potential_grad,
-            momentum,
-            potential_energy_grad,
-            step_size,
-        )
-
-        kinetic_grad = kinetic_energy_grad_fn(momentum)
-        position = jax.tree_util.tree_map(
-            lambda position, kinetic_grad, step_size: position
-            + step_size * kinetic_grad,
-            position,
-            kinetic_grad,
-            step_size,
-        )
-
-        potential_energy, potential_energy_grad = potential_and_grad_fn(position)
-        momentum = jax.tree_util.tree_map(
-            lambda momentum, potential_grad, step_size: momentum
-            - 0.5 * step_size * potential_grad,
-            momentum,
-            potential_energy_grad,
-            step_size,
-        )
-
-        return integrators.IntegratorState(
-            position,
-            momentum,
-            potential_energy,
-            potential_energy_grad,
-        )
 
     return one_step
 

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -382,7 +382,8 @@ normal_test_cases = [
         "algorithm": blackjax.ghmc,
         "initial_position": jnp.array(1.0),
         "parameters": {
-            "step_size": jnp.array(1.0),
+            "step_size": 1.0,
+            "momentum_inverse_scale": jnp.array(1.0),
             "alpha": 0.8,
             "delta": 2.0,
         },


### PR DESCRIPTION
Also removing some unused parameters of high-level functions, see #285.

Moved `maximum_eigenvalue` and improved docstring (https://github.com/blackjax-devs/blackjax/pull/229/files#r973546148).

Close #285