### PR TITLE
Modify linear regressions to parameters in R

### DIFF
--- a/examples/Introduction.md
+++ b/examples/Introduction.md
@@ -29,7 +29,7 @@ import blackjax
 
 ## The Problem
 
-We'll generate observations from a normal distribution of known `loc` and `scale` to see if we can recover the parameters in sampling. Let's take a decent-size dataset with 1,000 points:
+We'll generate observations from a normal distribution of known `loc` and `scale` to see if we can recover the parameters in sampling. **MCMC algorithms usually assume samples are being drawn from an unconstrained Euclidean space.** Hence why we'll log transform the scale parameter, so that sampling is done on the real line. Samples can be transformed back to their original space in post-processing. Let's take a decent-size dataset with 1,000 points:
 
 ```{code-cell} ipython3
 loc, scale = 10, 20
@@ -37,8 +37,9 @@ observed = np.random.normal(loc, scale, size=1_000)
 ```
 
 ```{code-cell} ipython3
-def logprob_fn(loc, scale, observed=observed):
+def logprob_fn(loc, log_scale, observed=observed):
     """Univariate Normal"""
+    scale = jnp.exp(log_scale)
     logpdf = stats.norm.logpdf(observed, loc, scale)
     return jnp.sum(logpdf)
 
@@ -51,7 +52,7 @@ logprob = lambda x: logprob_fn(**x)
 ### Sampler Parameters
 
 ```{code-cell} ipython3
-inv_mass_matrix = np.array([0.5, 0.5])
+inv_mass_matrix = np.array([0.5, 0.01])
 num_integration_steps = 60
 step_size = 1e-3
 
@@ -63,7 +64,7 @@ hmc = blackjax.hmc(logprob, step_size, inv_mass_matrix, num_integration_steps)
 The initial state of the HMC algorithm requires not only an initial position, but also the potential energy and gradient of the potential energy at this position. BlackJAX provides a `new_state` function to initialize the state from an initial position.
 
 ```{code-cell} ipython3
-initial_position = {"loc": 1.0, "scale": 2.0}
+initial_position = {"loc": 1.0, "log_scale": 1.0}
 initial_state = hmc.init(initial_position)
 initial_state
 ```
@@ -100,7 +101,7 @@ rng_key = jax.random.PRNGKey(0)
 states = inference_loop(rng_key, hmc_kernel, initial_state, 10_000)
 
 loc_samples = states.position["loc"].block_until_ready()
-scale_samples = states.position["scale"]
+scale_samples = jnp.exp(states.position["log_scale"])
 ```
 
 ```{code-cell} ipython3
@@ -121,14 +122,14 @@ ax1.set_ylabel("scale")
 NUTS is a *dynamic* algorithm: the number of integration steps is determined at runtime. We still need to specify a step size and a mass matrix:
 
 ```{code-cell} ipython3
-inv_mass_matrix = np.array([0.5, 0.5])
+inv_mass_matrix = np.array([0.5, 0.01])
 step_size = 1e-3
 
 nuts = blackjax.nuts(logprob, step_size, inv_mass_matrix)
 ```
 
 ```{code-cell} ipython3
-initial_position = {"loc": 1.0, "scale": 2.0}
+initial_position = {"loc": 1.0, "log_scale": 1.0}
 initial_state = nuts.init(initial_position)
 initial_state
 ```
@@ -139,7 +140,7 @@ rng_key = jax.random.PRNGKey(0)
 states = inference_loop(rng_key, nuts.step, initial_state, 4_000)
 
 loc_samples = states.position["loc"].block_until_ready()
-scale_samples = states.position["scale"]
+scale_samples = jnp.exp(states.position["log_scale"])
 ```
 
 ```{code-cell} ipython3
@@ -176,7 +177,7 @@ We can use the obtained parameters to define a new kernel. Note that we do not h
 states = inference_loop(rng_key, kernel, state, 1_000)
 
 loc_samples = states.position["loc"].block_until_ready()
-scale_samples = states.position["scale"]
+scale_samples = jnp.exp(states.position["log_scale"])
 ```
 
 ```{code-cell} ipython3

--- a/examples/RegimeSwitchingModel.md
+++ b/examples/RegimeSwitchingModel.md
@@ -171,7 +171,6 @@ dist = RegimeSwitchHMM(T, y)
 ```
 
 ```{code-cell} ipython3
-batch_fn = jax.vmap
 [n_chain, n_warm, n_iter] = [128, 5000, 200]
 ksam, kinit = jrnd.split(jrnd.PRNGKey(0), 2)
 dist.initialize_model(kinit, n_chain)
@@ -181,7 +180,7 @@ dist.initialize_model(kinit, n_chain)
 print("Running MEADS...")
 tic1 = pd.Timestamp.now()
 k_warm, k_sample = jrnd.split(ksam)
-warmup = blackjax.meads(dist.logprob_fn, n_chain, batch_fn=batch_fn)
+warmup = blackjax.meads(dist.logprob_fn, n_chain)
 init_state, kernel, _ = warmup.run(k_warm, dist.init_params, n_warm)
 
 def one_chain(k_sam, init_state):

--- a/examples/SparseLogisticRegression.md
+++ b/examples/SparseLogisticRegression.md
@@ -101,14 +101,13 @@ N_OBS, N_REG = X.shape
 N_PARAM = N_REG * 2 + 1
 dist = HorseshoeLogisticReg(X, y)
 
-batch_fn = jax.vmap
 [n_chain, n_warm, n_iter] = [128, 20000, 10000]
 ksam, kinit = jrnd.split(jrnd.PRNGKey(0), 2)
 dist.initialize_model(kinit, n_chain)
 
 tic1 = pd.Timestamp.now()
 k_warm, k_sample = jrnd.split(ksam)
-warmup = blackjax.meads(dist.logprob_fn, n_chain, batch_fn=batch_fn)
+warmup = blackjax.meads(dist.logprob_fn, n_chain)
 adaptation_results = warmup.run(k_warm, dist.init_params, n_warm)
 init_state = adaptation_results.state
 kernel = adaptation_results.kernel

--- a/examples/howto_sample_multiple_chains.md
+++ b/examples/howto_sample_multiple_chains.md
@@ -54,8 +54,9 @@ loc, scale = 10, 20
 observed = np.random.normal(loc, scale, size=1_000)
 
 
-def logprob_fn(loc, scale, observed=observed):
+def logprob_fn(loc, log_scale, observed=observed):
     """Univariate Normal"""
+    scale = jnp.exp(log_scale)
     logpdf = stats.norm.logpdf(observed, loc, scale)
     return jnp.sum(logpdf)
 
@@ -83,7 +84,7 @@ To make our demonstration more dramatic we will used a NUTS sampler with poorly 
 import blackjax
 
 
-inv_mass_matrix = np.array([0.5, 0.5])
+inv_mass_matrix = np.array([0.5, 0.01])
 step_size = 1e-3
 
 nuts = blackjax.nuts(logprob, step_size, inv_mass_matrix)
@@ -125,7 +126,7 @@ def inference_loop_multiple_chains(
 We now prepare the initial states using `jax.vmap` again, to vectorize the `init` function:
 
 ```{code-cell} ipython3
-initial_positions = {"loc": np.ones(num_chains), "scale": 2.0 * np.ones(num_chains)}
+initial_positions = {"loc": np.ones(num_chains), "log_scale": np.ones(num_chains)}
 initial_states = jax.vmap(nuts.init, in_axes=(0))(initial_positions)
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "fastprogress>=0.2.0",
         "jax>=0.3.13",
         "jaxlib>=0.3.10",
-        "jaxopt>=0.4.2",
+        "jaxopt>=0.5.5",
     ],
     long_description_content_type="text/markdown",
     keywords="probabilistic machine learning bayesian statistics sampling algorithms",

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -15,9 +15,10 @@ import pytest
 import blackjax
 
 
-def regression_logprob(scale, coefs, preds, x):
+def regression_logprob(log_scale, coefs, preds, x):
     """Linear regression"""
-    scale_prior = stats.expon.logpdf(scale, 1, 1)
+    scale = jnp.exp(log_scale)
+    scale_prior = stats.expon.logpdf(scale, 0, 1) + log_scale
     coefs_prior = stats.norm.logpdf(coefs, 0, 5)
     y = jnp.dot(x, coefs)
     logpdf = stats.norm.logpdf(preds, y, scale)
@@ -53,7 +54,7 @@ def run_regression(algorithm, **parameters):
         is_mass_matrix_diagonal=False,
         **parameters,
     )
-    state, kernel, _ = warmup.run(warmup_key, {"scale": 1.0, "coefs": 2.0}, 1000)
+    state, kernel, _ = warmup.run(warmup_key, {"log_scale": 0.0, "coefs": 2.0}, 1000)
 
     states = inference_loop(kernel, 10_000, inference_key, state)
 


### PR DESCRIPTION
Closes #378 

As a side note: If initial parameters for the `log_scale` are set to $1.0$ in `regression_test_cases` only `test_pathfinder_adaptation` fails with samples for `log_scale` diverging to `inf`.