### PR TITLE
Update the pathfinder API

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -11,6 +11,7 @@ from .kernels import (
     mgrad_gaussian,
     nuts,
     orbital_hmc,
+    pathfinder,
     pathfinder_adaptation,
     rmh,
     sghmc,
@@ -39,6 +40,7 @@ __all__ = [
     "pathfinder_adaptation",
     "adaptive_tempered_smc",  # smc
     "tempered_smc",
+    "pathfinder",  # variational inference
     "ess",  # diagnostics
     "rhat",
 ]

--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Tuple
+from typing import Callable, NamedTuple, Tuple
 
 from typing_extensions import Protocol
 
@@ -73,8 +73,8 @@ class UpdateFn(Protocol):
         """
 
 
-class SamplingAlgorithm(NamedTuple):
-    """A pair of functions that implement a sampling algorithm.
+class MCMCSamplingAlgorithm(NamedTuple):
+    """A pair of functions that represents a MCMC sampling algorithm.
 
     Blackjax sampling algorithms are implemented as a pair of pure functions: a
     kernel, that takes a new samples starting from the current state, and an
@@ -101,6 +101,30 @@ class SamplingAlgorithm(NamedTuple):
 
     init: InitFn
     step: UpdateFn
+
+
+class VIAlgorithm(NamedTuple):
+    """A pair of functions that represents a Variational Inference algorithm.
+
+    Blackjax variational inference algorithms are implemented as a pair of pure
+    functions: an approximator, which takes a target probability density (and
+    potentially a guide), and a sampling function that uses the approximation to
+    draw samples.
+
+    Attributes
+    ----------
+    approximate
+        A pure function, which when called with an initial position (and
+        potentially a guide function) returns a state that allows to build
+        an approximation to the target probability density function.
+    sample
+        A pure function which returns samples from the approximation computed
+        by `approximate`.
+
+    """
+
+    approximate: Callable
+    sample: Callable
 
 
 class RunFn(Protocol):

--- a/blackjax/kernels.py
+++ b/blackjax/kernels.py
@@ -1246,7 +1246,7 @@ class pathfinder:
             **lbfgs_parameters,
         ):
             return cls.approximate(
-                rng_key, logprob_fn, position, num_samples, False, **lbfgs_parameters
+                rng_key, logprob_fn, position, num_samples, **lbfgs_parameters
             )
 
         def sample_fn(
@@ -1316,7 +1316,7 @@ def pathfinder_adaptation(
 
         init_key, sample_key, rng_key = jax.random.split(rng_key, 3)
 
-        pathfinder_state = vi.pathfinder.approximate(init_key, logprob_fn, position)
+        pathfinder_state, _ = vi.pathfinder.approximate(init_key, logprob_fn, position)
         init_warmup_state = init(
             pathfinder_state.alpha,
             pathfinder_state.beta,

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -338,9 +338,9 @@ def bfgs_sample(rng_key, num_samples, position, grad_position, alpha, beta, gamm
     u = jax.random.normal(rng_key, num_samples + (param_dims, 1))
     phi = mu[..., None] + jnp.diag(jnp.sqrt(alpha)) @ (Q @ (L - Id) @ (Q.T @ u) + u)
 
-    logq = -0.5 * (
+    logprob = -0.5 * (
         logdet
         + jnp.einsum("...ji,...ji->...", u, u)
         + param_dims * jnp.log(2.0 * jnp.pi)
     )
-    return phi[..., 0], logq
+    return phi[..., 0], logprob

--- a/examples/Pathfinder.md
+++ b/examples/Pathfinder.md
@@ -4,9 +4,9 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.0
+    jupytext_version: 1.14.1
 kernelspec:
-  display_name: Python 3.9.7 ('blackjax')
+  display_name: Python 3 (ipykernel)
   language: python
   name: python3
 ---
@@ -115,7 +115,8 @@ To help understand the approximations that pathfinder evaluates during its run, 
 ```{code-cell} ipython3
 rng_key = random.PRNGKey(314)
 w0 = random.multivariate_normal(rng_key, 2.0 + jnp.zeros(M), jnp.eye(M))
-path = blackjax.vi.pathfinder.init(rng_key, logprob_fn, w0, return_path=True, ftol=1e-4)
+_, info = blackjax.vi.pathfinder.approximate(rng_key, logprob_fn, w0, ftol=1e-4)
+path = info.path
 ```
 
 ```{code-cell} ipython3
@@ -156,7 +157,7 @@ for i, ax in zip(range(1, steps + 1), axs.flatten()):
 
     ax.contour(x_, y_, logp_, levels=levels_)
     state = jax.tree_map(lambda x: x[i], path)
-    sample_state, _ = blackjax.vi.pathfinder.sample_from_state(rng_key, state, 10_000)
+    sample_state, _ = blackjax.vi.pathfinder.sample(rng_key, state, 10_000)
     position_path = path.position[: i + 1]
     ax.plot(
         position_path[:, 0],
@@ -176,28 +177,15 @@ fig.show()
 Pathfinder can be used as a variational inference method, using its kernel API:
 
 ```{code-cell} ipython3
-pathfinder = blackjax.kernels.pathfinder(rng_key, logprob_fn, ftol=1e-4)
-state = pathfinder.init(w0)
+pathfinder = blackjax.kernels.pathfinder(logprob_fn)
+state, _ = pathfinder.approximate(rng_key, w0, ftol=1e-4)
 ```
 
-Since `blackjax` does not provide an inference loop we need to implement one ourselves:
-
-```{code-cell} ipython3
-def inference_loop(rng_key, kernel, initial_state, num_samples):
-    @jax.jit
-    def one_step(state, rng_key):
-        state, info = kernel(rng_key, state)
-        return state, (state, info)
-
-    keys = jax.random.split(rng_key, num_samples)
-    return jax.lax.scan(one_step, initial_state, keys)
-```
-
-We can now run the inference:
+We can now get samples from the approximation:
 
 ```{code-cell} ipython3
 _, rng_key = random.split(rng_key)
-_, (_, samples) = inference_loop(rng_key, pathfinder.step, state, 5_000)
+samples, _ = pathfinder.sample(rng_key, state, 5_000)
 ```
 
 And display the trace:
@@ -220,13 +208,24 @@ Please note that pathfinder is implemented as follows:
 hence it makes sense to `jit` the `init` function and then use the `blackjax.vi.pathfinder.sample_from_state` helper function instead of implementing the inference loop:
 
 ```{code-cell} ipython3
-state = jax.jit(pathfinder.init)(w0)
-samples, _ = blackjax.vi.pathfinder.sample_from_state(rng_key, state, 5_000)
+%%time
+
+state, _ = jax.jit(pathfinder.approximate)(rng_key, w0)
+samples, _ = pathfinder.sample(rng_key, state, 5_000)
 ```
 
 Quick comparison against `rmh` kernel:
 
 ```{code-cell} ipython3
+def inference_loop(rng_key, kernel, initial_state, num_samples):
+    @jax.jit
+    def one_step(state, rng_key):
+        state, info = kernel(rng_key, state)
+        return state, (state, info)
+
+    keys = jax.random.split(rng_key, num_samples)
+    return jax.lax.scan(one_step, initial_state, keys)
+
 rmh = blackjax.kernels.rmh(logprob_fn, sigma=jnp.ones(M) * 0.7)
 state_rmh = rmh.init(w0)
 _, (samples_rmh, _) = inference_loop(rng_key, rmh.step, state_rmh, 5_000)
@@ -267,7 +266,7 @@ This estimation of the inverse mass matrix, coupled with Nesterov's dual averagi
 This scheme is implemented in `blackjax.kernel.pathfinder_adaptation` function:
 
 ```{code-cell} ipython3
-adapt = blackjax.kernels.pathfinder_adaptation(blackjax.nuts, logprob_fn)
+adapt = blackjax.kernels.pathfinder_adaptation(jax.jit(blackjax.nuts), logprob_fn)
 state, kernel, info = adapt.run(rng_key, w0, 400)
 ```
 

--- a/tests/test_pathfinder.py
+++ b/tests/test_pathfinder.py
@@ -70,7 +70,7 @@ class PathfinderTest(chex.TestCase):
 
         x0 = jnp.ones(ndim)
         pathfinder = blackjax.pathfinder(logp_model)
-        out = self.variant(pathfinder.approximate)(rng_key_pathfinder, x0)
+        out, _ = self.variant(pathfinder.approximate)(rng_key_pathfinder, x0)
 
         sim_p, log_p = bfgs_sample(
             rng_key_pathfinder,

--- a/tests/test_pathfinder.py
+++ b/tests/test_pathfinder.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import jax.scipy.stats as stats
 from absl.testing import absltest, parameterized
 
-from blackjax.kernels import pathfinder
+import blackjax
 from blackjax.optimizers.lbfgs import bfgs_sample
 
 
@@ -69,8 +69,8 @@ class PathfinderTest(chex.TestCase):
         )
 
         x0 = jnp.ones(ndim)
-        kernel = pathfinder(rng_key_pathfinder, logp_model)
-        out = self.variant(kernel.init)(x0)
+        pathfinder = blackjax.pathfinder(logp_model)
+        out = self.variant(pathfinder.approximate)(rng_key_pathfinder, x0)
 
         sim_p, log_p = bfgs_sample(
             rng_key_pathfinder,


### PR DESCRIPTION
In this PR I update the pathfinder API to fit the variational inference semantics more closely. The `init`, `kernel` terminology is not adapted to variational inference: instead of using a markov kernel to update the state, vi algorithms compute an approximation to the target distribution and then sample from this approximation.

I thus propose the following API for pathfinder:

```python
import blackjax

pathfinder = blackjax.pathfinder(logprob_fn)
approximation, info = pathfinder.approximate(rng_key, initial_position)
samples, _ = pathfinder.sample(rng_key, approximation, num_samples)
```

Where `info` contains the full path (which is thus always returned), I created a new `VISamplingAlgorithm` type, and made a few simplifying tweaks to the implementation of pathfinder. Closes #282 