### PR TITLE
Add linebreak between function params in API doc

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -8,3 +8,20 @@ div.cell div.cell_input {
 		font-weight: bold;
 	}
 }
+
+/* Add a line break between the arguments of each function.
+   Taken from: https://github.com/sphinx-doc/sphinx/issues/1514#issuecomment-742703082
+*/
+.sig-param::before {
+    content: "\a\20\20\20\20\20\20";
+    white-space: pre;
+}
+
+dt em.sig-param:last-of-type::after {
+    content: "\a";
+    white-space: pre;
+}
+
+dl.class > dt:first-of-type {
+    display: block !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,17 +87,16 @@ html_title = "Blackjax"
 html_logo = "_static/blackjax.png"
 html_css_files = ["custom.css"]
 
-
+# We only display the typehints in the description, even though they would
+# be better in the signature, because we cannot apply our CSS trick to add
+# line breaks in the signature when the typehints are present.
 autosummary_generate = True
 autodoc_typehints = "description"
 add_module_names = False
-# autodoc_unqualified_typehints = True
-# autodoc_type_aliases = {"PyTree": "PyTree", "Array": "Array"}
-
 
 source_suffix = {".rst": "restructuredtext", ".ipynb": "myst-nb", ".md": "myst-nb"}
 
-nb_execution_mode = "auto"
+nb_execution_mode = "off"
 nb_execution_timeout = 300
 suppress_warnings = ["mystnb.unknown_mime_type"]
 


### PR DESCRIPTION
Makes the API documentation breathe a little bit.