### PR TITLE
Fix pymc example

### DIFF
--- a/examples/howto_use_pymc.md
+++ b/examples/howto_use_pymc.md
@@ -71,6 +71,7 @@ rng_key = jax.random.PRNGKey(1234)
 
 adapt = blackjax.window_adaptation(blackjax.nuts, logprob_fn)
 last_state, kernel, _ = adapt.run(rng_key, init_position, 1000)
+```
 
 Let us now perform inference with the tuned kernel:
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -14,6 +14,7 @@ numba
 numpyro
 optax
 oryx
+pymc
 scikit-learn
 seaborn
 sphinx


### PR DESCRIPTION
This is just a minor fix to make the pymc example work again.