### PR TITLE
s/logprob/logdensity

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,14 +63,14 @@ import numpy as np
 import blackjax
 
 observed = np.random.normal(10, 20, size=1_000)
-def logprob_fn(x):
+def logdensity_fn(x):
   logpdf = stats.norm.logpdf(observed, x["loc"], x["scale"])
   return jnp.sum(logpdf)
 
 # Build the kernel
 step_size = 1e-3
 inverse_mass_matrix = jnp.array([1., 1.])
-nuts = blackjax.nuts(logprob_fn, step_size, inverse_mass_matrix)
+nuts = blackjax.nuts(logdensity_fn, step_size, inverse_mass_matrix)
 
 # Initialize the state
 initial_position = {"loc": 1., "scale": 2.}

--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -51,10 +51,10 @@ class GHMCState(NamedTuple):
 def init(
     rng_key: PRNGKey,
     position: PyTree,
-    logprob_fn: Callable,
+    logdensity_fn: Callable,
 ):
     def potential_fn(x):
-        return -logprob_fn(x)
+        return -logdensity_fn(x)
 
     potential_energy, potential_energy_grad = jax.value_and_grad(potential_fn)(position)
 
@@ -101,7 +101,7 @@ def kernel(
     def one_step(
         rng_key: PRNGKey,
         state: GHMCState,
-        logprob_fn: Callable,
+        logdensity_fn: Callable,
         step_size: float,
         momentum_inverse_scale: PyTree,
         alpha: float,
@@ -115,7 +115,7 @@ def kernel(
             JAX's pseudo random number generating key.
         state
             Current state of the chain.
-        logprob_fn
+        logdensity_fn
             (Unnormalized) Log density function being targeted.
         step_size
             Variable specifying the size of the integration step.
@@ -133,7 +133,7 @@ def kernel(
         """
 
         def potential_fn(x):
-            return -logprob_fn(x)
+            return -logdensity_fn(x)
 
         flat_inverse_scale = jax.flatten_util.ravel_pytree(momentum_inverse_scale)[0]
         _, kinetic_energy_fn, _ = metrics.gaussian_euclidean(flat_inverse_scale**2)

--- a/blackjax/mcmc/hmc.py
+++ b/blackjax/mcmc/hmc.py
@@ -78,9 +78,9 @@ class HMCInfo(NamedTuple):
     num_integration_steps: int
 
 
-def init(position: PyTree, logprob_fn: Callable):
+def init(position: PyTree, logdensity_fn: Callable):
     def potential_fn(x):
-        return -logprob_fn(x)
+        return -logdensity_fn(x)
 
     potential_energy, potential_energy_grad = jax.value_and_grad(potential_fn)(position)
     return HMCState(position, potential_energy, potential_energy_grad)
@@ -110,7 +110,7 @@ def kernel(
     def one_step(
         rng_key: PRNGKey,
         state: HMCState,
-        logprob_fn: Callable,
+        logdensity_fn: Callable,
         step_size: float,
         inverse_mass_matrix: Array,
         num_integration_steps: int,
@@ -118,7 +118,7 @@ def kernel(
         """Generate a new sample with the HMC kernel."""
 
         def potential_fn(x):
-            return -logprob_fn(x)
+            return -logdensity_fn(x)
 
         momentum_generator, kinetic_energy_fn, _ = metrics.gaussian_euclidean(
             inverse_mass_matrix

--- a/blackjax/mcmc/irmh.py
+++ b/blackjax/mcmc/irmh.py
@@ -41,12 +41,12 @@ def kernel(proposal_distribution: Callable) -> Callable:
     """
 
     def one_step(
-        rng_key: PRNGKey, state: RMHState, logprob_fn: Callable
+        rng_key: PRNGKey, state: RMHState, logdensity_fn: Callable
     ) -> Tuple[RMHState, RMHInfo]:
         def proposal_generator(rng_key: PRNGKey, position: PyTree):
             return proposal_distribution(rng_key)
 
-        kernel = rmh(logprob_fn, proposal_generator)
+        kernel = rmh(logdensity_fn, proposal_generator)
         return kernel(rng_key, state)
 
     return one_step

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -132,14 +132,14 @@ def kernel(
     def one_step(
         rng_key: PRNGKey,
         state: hmc.HMCState,
-        logprob_fn: Callable,
+        logdensity_fn: Callable,
         step_size: float,
         inverse_mass_matrix: Array,
     ) -> Tuple[hmc.HMCState, NUTSInfo]:
         """Generate a new sample with the NUTS kernel."""
 
         def potential_fn(x):
-            return -logprob_fn(x)
+            return -logdensity_fn(x)
 
         (
             momentum_generator,

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -362,9 +362,9 @@ def bfgs_sample(rng_key, num_samples, position, grad_position, alpha, beta, gamm
     u = jax.random.normal(rng_key, num_samples + (param_dims, 1))
     phi = mu[..., None] + jnp.diag(jnp.sqrt(alpha)) @ (Q @ (L - Id) @ (Q.T @ u) + u)
 
-    logprob = -0.5 * (
+    logdensity = -0.5 * (
         logdet
         + jnp.einsum("...ji,...ji->...", u, u)
         + param_dims * jnp.log(2.0 * jnp.pi)
     )
-    return phi[..., 0], logprob
+    return phi[..., 0], logdensity

--- a/blackjax/sgmcmc/diffusions.py
+++ b/blackjax/sgmcmc/diffusions.py
@@ -37,7 +37,7 @@ def overdamped_langevin():
     def one_step(
         rng_key: PRNGKey,
         position: PyTree,
-        logprob_grad: PyTree,
+        logdensity_grad: PyTree,
         step_size: float,
     ) -> PyTree:
 
@@ -45,7 +45,7 @@ def overdamped_langevin():
         position = jax.tree_util.tree_map(
             lambda p, g, n: p + step_size * g + jnp.sqrt(2 * step_size) * n,
             position,
-            logprob_grad,
+            logdensity_grad,
             noise,
         )
 
@@ -74,7 +74,7 @@ def sghmc(alpha: float = 0.01, beta: float = 0):
         rng_key: PRNGKey,
         position: PyTree,
         momentum: PyTree,
-        logprob_grad: PyTree,
+        logdensity_grad: PyTree,
         step_size: float,
     ):
         noise = generate_gaussian_noise(rng_key, position)
@@ -84,7 +84,7 @@ def sghmc(alpha: float = 0.01, beta: float = 0):
             + step_size * g
             + jnp.sqrt(2 * step_size * (alpha - beta)) * n,
             momentum,
-            logprob_grad,
+            logdensity_grad,
             noise,
         )
 

--- a/blackjax/sgmcmc/sghmc.py
+++ b/blackjax/sgmcmc/sghmc.py
@@ -38,9 +38,9 @@ def kernel(alpha: float = 0.01, beta: float = 0) -> Callable:
     ) -> PyTree:
         def body_fn(state, rng_key):
             position, momentum = state
-            logprob_grad = grad_estimator(position, minibatch)
+            logdensity_grad = grad_estimator(position, minibatch)
             position, momentum = integrator(
-                rng_key, position, momentum, logprob_grad, step_size
+                rng_key, position, momentum, logdensity_grad, step_size
             )
             return ((position, momentum), position)
 

--- a/blackjax/sgmcmc/sgld.py
+++ b/blackjax/sgmcmc/sgld.py
@@ -32,8 +32,8 @@ def kernel() -> Callable:
         step_size: float,
     ):
 
-        logprob_grad = grad_estimator(position, minibatch)
-        new_position = integrator(rng_key, position, logprob_grad, step_size)
+        logdensity_grad = grad_estimator(position, minibatch)
+        new_position = integrator(rng_key, position, logdensity_grad, step_size)
 
         return new_position
 

--- a/blackjax/smc/ess.py
+++ b/blackjax/smc/ess.py
@@ -47,7 +47,7 @@ def ess(log_weights: jnp.ndarray, log: bool = True) -> float:
 
 
 def ess_solver(
-    logprob_fn: Callable,
+    logdensity_fn: Callable,
     particles: PyTree,
     target_ess: float,
     max_delta: float,
@@ -58,7 +58,7 @@ def ess_solver(
 
     Parameters
     ----------
-    logprob_fn: Callable
+    logdensity_fn: Callable
         The log probability function we wish to sample from.
     smc_state: SMCState
         Current state of the tempered SMC algorithm
@@ -81,14 +81,14 @@ def ess_solver(
     """
     n_particles = jax.tree_util.tree_flatten(particles)[0][0].shape[0]
 
-    logprob = logprob_fn(particles)
+    logdensity = logdensity_fn(particles)
     if use_log_ess:
         target_val = jnp.log(n_particles * target_ess)
     else:
         target_val = n_particles * target_ess
 
     def fun_to_solve(delta):
-        log_weights = jnp.nan_to_num(-delta * logprob)
+        log_weights = jnp.nan_to_num(-delta * logdensity)
         ess_val = ess(log_weights, log=use_log_ess)
 
         return ess_val - target_val

--- a/blackjax/vi/pathfinder.py
+++ b/blackjax/vi/pathfinder.py
@@ -65,7 +65,7 @@ class PathfinderInfo(NamedTuple):
 
 def approximate(
     rng_key: PRNGKey,
-    logprob_fn: Callable,
+    logdensity_fn: Callable,
     initial_position: PyTree,
     num_samples: int = 200,
     *,  # lgbfs parameters
@@ -87,7 +87,7 @@ def approximate(
     ----------
     rng_key
         PRPNG key
-    logprob_fn
+    logdensity_fn
         (un-normalized) log densify function of target distribution to take
         approximate samples from
     initial_position
@@ -122,7 +122,7 @@ def approximate(
 
     """
     initial_position_flatten, unravel_fn = ravel_pytree(initial_position)
-    objective_fn = lambda x: -logprob_fn(unravel_fn(x))
+    objective_fn = lambda x: -logdensity_fn(unravel_fn(x))
 
     (_, status), history = _minimize_lbfgs(
         objective_fn,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,14 +20,14 @@ It integrates really well with PPLs as long as they can provide a (potentially u
    import blackjax
 
    observed = np.random.normal(10, 20, size=1_000)
-   def logprob_fn(x):
+   def logdensity_fn(x):
        logpdf = stats.norm.logpdf(observed, x["loc"], x["scale"])
        return jnp.sum(logpdf)
 
    # Build the kernel
    step_size = 1e-3
    inverse_mass_matrix = jnp.array([1., 1.])
-   nuts = blackjax.nuts(logprob_fn, step_size, inverse_mass_matrix)
+   nuts = blackjax.nuts(logdensity_fn, step_size, inverse_mass_matrix)
 
    # Initialize the state
    initial_position = {"loc": 1., "scale": 2.}

--- a/docs/mcmc.rst
+++ b/docs/mcmc.rst
@@ -24,7 +24,7 @@ We initialize an algorithm using the log-probability function we wish to sample 
 
    import blackjax
 
-   algorithm = blackjax.algorithm(logprob_fn, **parameters)
+   algorithm = blackjax.algorithm(logdensity_fn, **parameters)
 
 
 One can then initialize the sampling state and take a new sample starting from a given position in the parameter space:
@@ -39,7 +39,7 @@ One can then initialize the sampling state and take a new sample starting from a
    new_state, info = algorithm.step(rng_key, state)
 
 
-Under the hood, kernels have a signature of the form ``kernel(rng_key, state, logprob_fn, **parameter)`` and this high-level interface provides convenient wrappers around these functions. It is possible to access the base kernel doing:
+Under the hood, kernels have a signature of the form ``kernel(rng_key, state, logdensity_fn, **parameter)`` and this high-level interface provides convenient wrappers around these functions. It is possible to access the base kernel doing:
 
 .. code::
 

--- a/examples/GP_EllipticalSliceSampler.md
+++ b/examples/GP_EllipticalSliceSampler.md
@@ -132,8 +132,8 @@ samples = states.position[n_warm:]
 %%time
 n_iter = 2000
 
-logprob_fn = lambda f: loglikelihood_fn(f) - 0.5 * jnp.dot(f @ invSigma, f)
-warmup = window_adaptation(nuts, logprob_fn, n_warm, target_acceptance_rate=0.8)
+logdensity_fn = lambda f: loglikelihood_fn(f) - 0.5 * jnp.dot(f @ invSigma, f)
+warmup = window_adaptation(nuts, logdensity_fn, n_warm, target_acceptance_rate=0.8)
 key_warm, key_sample = jrnd.split(jrnd.PRNGKey(0))
 state, kernel, _ = warmup.run(key_warm, f)
 states, _ = inference_loop(key_sample, state, kernel, n_iter)

--- a/examples/GP_Marginal.md
+++ b/examples/GP_Marginal.md
@@ -158,7 +158,7 @@ Next, we define the the log-probability function. For this we need to set the lo
 
 ```{code-cell} python
 loglikelihood_fn = lambda f: -0.5 * jnp.dot(y - f, y - f) / y_sd**2
-logprob_fn = lambda f: loglikelihood_fn(f) - 0.5 * jnp.dot(f @ invSigma, f)
+logdensity_fn = lambda f: loglikelihood_fn(f) - 0.5 * jnp.dot(f @ invSigma, f)
 ```
 
 Now we are ready to initialize the sampler. The output is type is a `NamedTuple` with the following fields:
@@ -176,7 +176,7 @@ step:
 ```
 
 ```{code-cell} python
-init, step = mgrad_gaussian(logprob_fn=logprob_fn, mean=jnp.zeros(n), covariance=Sigma)
+init, step = mgrad_gaussian(logdensity_fn=logdensity_fn, mean=jnp.zeros(n), covariance=Sigma)
 ```
 
 We continue by setting the inference loop.

--- a/examples/Introduction.md
+++ b/examples/Introduction.md
@@ -37,14 +37,14 @@ observed = np.random.normal(loc, scale, size=1_000)
 ```
 
 ```{code-cell} python
-def logprob_fn(loc, log_scale, observed=observed):
+def logdensity_fn(loc, log_scale, observed=observed):
     """Univariate Normal"""
     scale = jnp.exp(log_scale)
     logpdf = stats.norm.logpdf(observed, loc, scale)
     return jnp.sum(logpdf)
 
 
-logprob = lambda x: logprob_fn(**x)
+logdensity = lambda x: logdensity_fn(**x)
 ```
 
 ## HMC
@@ -56,7 +56,7 @@ inv_mass_matrix = np.array([0.5, 0.01])
 num_integration_steps = 60
 step_size = 1e-3
 
-hmc = blackjax.hmc(logprob, step_size, inv_mass_matrix, num_integration_steps)
+hmc = blackjax.hmc(logdensity, step_size, inv_mass_matrix, num_integration_steps)
 ```
 
 ### Set the Initial State
@@ -125,7 +125,7 @@ NUTS is a *dynamic* algorithm: the number of integration steps is determined at 
 inv_mass_matrix = np.array([0.5, 0.01])
 step_size = 1e-3
 
-nuts = blackjax.nuts(logprob, step_size, inv_mass_matrix)
+nuts = blackjax.nuts(logdensity, step_size, inv_mass_matrix)
 ```
 
 ```{code-cell} python
@@ -165,7 +165,7 @@ The adaptation algorithm takes a function that returns a transition kernel given
 ```{code-cell} python
 %%time
 
-warmup = blackjax.window_adaptation(blackjax.nuts, logprob)
+warmup = blackjax.window_adaptation(blackjax.nuts, logdensity)
 state, kernel, _ = warmup.run(rng_key, initial_position, num_steps=1000)
 ```
 

--- a/examples/LogisticRegression.md
+++ b/examples/LogisticRegression.md
@@ -92,7 +92,7 @@ def log_sigmoid(z):
     return z - jnp.log(1 + jnp.exp(z))
 
 
-def logprob_fn(w, alpha=1.0):
+def logdensity_fn(w, alpha=1.0):
     """The log-probability density function of the posterior distribution of the model."""
     log_an = log_sigmoid(Phi @ w)
     an = Phi @ w
@@ -111,7 +111,7 @@ rng_key = random.PRNGKey(314)
 
 w0 = random.multivariate_normal(rng_key, 0.1 + jnp.zeros(M), jnp.eye(M))
 
-rmh = blackjax.rmh(logprob_fn, sigma=jnp.ones(M) * 0.7)
+rmh = blackjax.rmh(logdensity_fn, sigma=jnp.ones(M) * 0.7)
 initial_state = rmh.init(w0)
 ```
 

--- a/examples/RegimeSwitchingModel.md
+++ b/examples/RegimeSwitchingModel.md
@@ -142,7 +142,7 @@ class RegimeSwitchHMM:
         }
         # self.init_params = {name: 3. + value if name in ['sigma'] else value for name, value in self.init_params.items()}
 
-    def logprob_fn(self, params):
+    def logdensity_fn(self, params):
         return -self.potential_fn(self.y)(params)
 
 
@@ -177,7 +177,7 @@ dist.initialize_model(kinit, n_chain)
 ```{code-cell} python
 tic1 = pd.Timestamp.now()
 k_warm, k_sample = jrnd.split(ksam)
-warmup = blackjax.meads(dist.logprob_fn, n_chain)
+warmup = blackjax.meads(dist.logdensity_fn, n_chain)
 init_state, kernel, _ = warmup.run(k_warm, dist.init_params, n_warm)
 
 def one_chain(k_sam, init_state):

--- a/examples/SparseLogisticRegression.md
+++ b/examples/SparseLogisticRegression.md
@@ -57,7 +57,7 @@ class HorseshoeLogisticReg:
             "tau": jax.random.normal(kt, (n_chain,)),
         }
 
-    def logprob(self, beta, lamda, tau):  # non-centered
+    def logdensity(self, beta, lamda, tau):  # non-centered
         # priors
         lprob = (
             jnp.sum(
@@ -74,8 +74,8 @@ class HorseshoeLogisticReg:
         lprob += jnp.sum(bernoulli.logpmf(self.y, p))
         return lprob
 
-    def logprob_fn(self, x):
-        return self.logprob(**x)
+    def logdensity_fn(self, x):
+        return self.logdensity(**x)
 
 
 def inference_loop(rng, init_state, kernel, n_iter):
@@ -109,7 +109,7 @@ dist.initialize_model(kinit, n_chain)
 
 tic1 = pd.Timestamp.now()
 k_warm, k_sample = jrnd.split(ksam)
-warmup = blackjax.meads(dist.logprob_fn, n_chain)
+warmup = blackjax.meads(dist.logdensity_fn, n_chain)
 adaptation_results = warmup.run(k_warm, dist.init_params, n_warm)
 init_state = adaptation_results.state
 kernel = adaptation_results.kernel

--- a/examples/TemperedSMC.md
+++ b/examples/TemperedSMC.md
@@ -105,7 +105,7 @@ def inference_loop(rng_key, mcmc_kernel, initial_state, num_samples):
     return states
 
 
-def full_logprob(x):
+def full_logdensity(x):
     return -V(x) + prior_log_prob(x)
 
 
@@ -126,7 +126,7 @@ hmc_parameters = dict(
     step_size=1e-4, inverse_mass_matrix=inv_mass_matrix, num_integration_steps=50
 )
 
-hmc = blackjax.hmc(full_logprob, **hmc_parameters)
+hmc = blackjax.hmc(full_logdensity, **hmc_parameters)
 hmc_state = hmc.init(jnp.ones((1,)))
 hmc_samples = inference_loop(key, hmc.step, hmc_state, n_samples)
 ```
@@ -148,7 +148,7 @@ We now use a NUTS kernel.
 
 nuts_parameters = dict(step_size=1e-4, inverse_mass_matrix=inv_mass_matrix)
 
-nuts = blackjax.nuts(full_logprob, **nuts_parameters)
+nuts = blackjax.nuts(full_logdensity, **nuts_parameters)
 nuts_state = nuts.init(jnp.ones((1,)))
 nuts_samples = inference_loop(key, nuts.step, nuts_state, n_samples)
 ```
@@ -298,7 +298,7 @@ hmc_parameters = dict(
     step_size=1e-2, inverse_mass_matrix=inv_mass_matrix, num_integration_steps=50
 )
 
-hmc = blackjax.hmc(full_logprob, **hmc_parameters)
+hmc = blackjax.hmc(full_logdensity, **hmc_parameters)
 hmc_state = hmc.init(jnp.ones((1,)))
 hmc_samples = inference_loop(key, hmc.step, hmc_state, n_samples)
 ```
@@ -321,7 +321,7 @@ We do the same using a NUTS kernel.
 
 nuts_parameters = dict(step_size=1e-2, inverse_mass_matrix=inv_mass_matrix)
 
-nuts = blackjax.nuts(full_logprob, **nuts_parameters)
+nuts = blackjax.nuts(full_logdensity, **nuts_parameters)
 nuts_state = nuts.init(jnp.ones((1,)))
 nuts_samples = inference_loop(key, nuts.step, nuts_state, n_samples)
 ```

--- a/examples/howto_custom_gradients.md
+++ b/examples/howto_custom_gradients.md
@@ -175,13 +175,13 @@ Let us now demonstrate that we can use `f_with_gradients` with Blackjax. We defi
 import blackjax
 
 
-def logprob_fn(y):
-    logprob = jax.scipy.stats.norm.logpdf(y)
+def logdensity_fn(y):
+    logdensity = jax.scipy.stats.norm.logpdf(y)
     x = f_with_gradient(y, 3)
-    logprob += jax.scipy.stats.norm.logpdf(x)
-    return logprob
+    logdensity += jax.scipy.stats.norm.logpdf(x)
+    return logdensity
 
-hmc = blackjax.hmc(logprob_fn,1e-3, jnp.ones(1), 10)
+hmc = blackjax.hmc(logdensity_fn,1e-3, jnp.ones(1), 10)
 state = hmc.init(1.)
 
 rng_key = jax.random.PRNGKey(0)

--- a/examples/howto_sample_multiple_chains.md
+++ b/examples/howto_sample_multiple_chains.md
@@ -54,15 +54,15 @@ loc, scale = 10, 20
 observed = np.random.normal(loc, scale, size=1_000)
 
 
-def logprob_fn(loc, log_scale, observed=observed):
+def logdensity_fn(loc, log_scale, observed=observed):
     """Univariate Normal"""
     scale = jnp.exp(log_scale)
     logpdf = stats.norm.logpdf(observed, loc, scale)
     return jnp.sum(logpdf)
 
 
-def logprob(x):
-    return logprob_fn(**x)
+def logdensity(x):
+    return logdensity_fn(**x)
 
 
 def inference_loop(rng_key, kernel, initial_state, num_samples):
@@ -87,7 +87,7 @@ import blackjax
 inv_mass_matrix = np.array([0.5, 0.01])
 step_size = 1e-3
 
-nuts = blackjax.nuts(logprob, step_size, inv_mass_matrix)
+nuts = blackjax.nuts(logdensity, step_size, inv_mass_matrix)
 ```
 
 And finally, to put `jax.vmap` and `jax.pmap` on an equal foot we sample as many chains as the machine has CPU cores:

--- a/examples/howto_use_aesara.md
+++ b/examples/howto_use_aesara.md
@@ -104,8 +104,8 @@ To sample with Blackjax we will need to use Aesara's JAX backend; `logprob_jax` 
 ```{code-cell} python
 :tags: [remove-stderr]
 
-logprob_fn = aesara.function((a_vv, b_vv, theta_vv, y_vv), logprob, mode="JAX")
-logprob_jax = logprob_fn.vm.jit_fn
+logdensity_fn = aesara.function((a_vv, b_vv, theta_vv, y_vv), logprob, mode="JAX")
+logprob_jax = logdensity_fn.vm.jit_fn
 ```
 
 Let's wrap this function to make our life simpler:
@@ -115,7 +115,7 @@ Let's wrap this function to make our life simpler:
 3. `Y_vv` is observed, so let's fix its value.
 
 ```{code-cell} python
-def logprob_fn(position):
+def logdensity_fn(position):
     flat_position = tuple(position.values())
     return logprob_jax(*flat_position, n_of_positives)[0]
 ```
@@ -165,7 +165,7 @@ import blackjax
 n_adapt = 3000
 n_samples = 1000
 
-adapt = blackjax.window_adaptation(blackjax.nuts, logprob_fn)
+adapt = blackjax.window_adaptation(blackjax.nuts, logdensity_fn)
 state, kernel, _ = adapt.run(rng_key, init_position, n_adapt)
 
 states, infos = inference_loop(

--- a/examples/howto_use_numpyro.md
+++ b/examples/howto_use_numpyro.md
@@ -76,11 +76,11 @@ init_params, potential_fn_gen, *_ = initialize_model(
 )
 ```
 
-Numpyro return a potential function, which is easily transformed back into a logprob function that is required by Blackjax:
+Numpyro return a potential function, which is easily transformed back into a logdensity function that is required by Blackjax:
 
 
 ```{code-cell} python
-logprob_fn = lambda position: -potential_fn_gen(J, sigma, y)(position)
+logdensity_fn = lambda position: -potential_fn_gen(J, sigma, y)(position)
 initial_position = init_params.z
 ```
 
@@ -92,7 +92,7 @@ import blackjax
 num_warmup = 2000
 
 adapt = blackjax.window_adaptation(
-    blackjax.nuts, logprob_fn, target_acceptance_rate=0.8
+    blackjax.nuts, logdensity_fn, target_acceptance_rate=0.8
 )
 last_state, kernel, _ = adapt.run(rng_key, initial_position, num_warmup)
 ```

--- a/examples/howto_use_oryx.md
+++ b/examples/howto_use_oryx.md
@@ -127,7 +127,7 @@ To sample from this model we will need to obtain its joint distribution log-prob
 ```{code-cell} python
 from oryx.core.ppl import joint_log_prob
 
-def logprob_fn(weights):
+def logdensity_fn(weights):
   return joint_log_prob(predict(bnn))(dict(weights, y=labels), features)
 ```
 
@@ -138,7 +138,7 @@ We can now run the window adaptation to get good values for the parameters of th
 import blackjax
 
 rng_key = jax.random.PRNGKey(0)
-adapt = blackjax.window_adaptation(blackjax.nuts, logprob_fn)
+adapt = blackjax.window_adaptation(blackjax.nuts, logdensity_fn)
 last_state, kernel, _ = adapt.run(rng_key, initial_weights, 100)
 ```
 

--- a/examples/howto_use_pymc.md
+++ b/examples/howto_use_pymc.md
@@ -54,7 +54,7 @@ We need to translate the model into a log-probability function that will be used
 from pymc.sampling_jax import get_jaxified_logp
 
 rvs = [rv.name for rv in model.value_vars]
-logprob_fn = get_jaxified_logp(model)
+logdensity_fn = get_jaxified_logp(model)
 ```
 
 We can now run the window adaptation for the NUTS sampler:
@@ -69,7 +69,7 @@ init_position = [init_position_dict[rv] for rv in rvs]
 
 rng_key = jax.random.PRNGKey(1234)
 
-adapt = blackjax.window_adaptation(blackjax.nuts, logprob_fn)
+adapt = blackjax.window_adaptation(blackjax.nuts, logdensity_fn)
 last_state, kernel, _ = adapt.run(rng_key, init_position, 1000)
 ```
 

--- a/examples/howto_use_tfp.md
+++ b/examples/howto_use_tfp.md
@@ -86,14 +86,14 @@ model = tfd.JointDistributionSequential(
 We need to translate the model into a log-probability density function that will be used by Blackjax to perform inference.
 
 ```{code-cell} python
-def target_logprob_fn(avg_effect, avg_stddev, school_effects_standard):
+def target_logdensity_fn(avg_effect, avg_stddev, school_effects_standard):
     """Unnormalized target density as a function of states."""
     return model.log_prob(
         (avg_effect, avg_stddev, school_effects_standard, treatment_effects)
     )
 
 
-logprob_fn = lambda x: target_logprob_fn(**x)
+logdensity_fn = lambda x: target_logdensity_fn(**x)
 ```
 
 We can now initialize the
@@ -117,7 +117,7 @@ initial_position = {
 
 rng_key = jax.random.PRNGKey(0)
 adapt = blackjax.window_adaptation(
-    blackjax.hmc, logprob_fn, num_integration_steps=3
+    blackjax.hmc, logdensity_fn, num_integration_steps=3
 )
 
 last_state, kernel, _ = adapt.run(rng_key, initial_position, 1000)

--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -16,24 +16,24 @@ import blackjax
 
 class CompilationTest(chex.TestCase):
     def test_hmc(self):
-        """Count the number of times the logprob is compiled when using HMC.
+        """Count the number of times the logdensity is compiled when using HMC.
 
-        The logprob is compiled twice: when initializing the state and when
+        The logdensity is compiled twice: when initializing the state and when
         compiling the kernel.
 
         """
 
         @chex.assert_max_traces(n=2)
-        def logprob_fn(x):
+        def logdensity_fn(x):
             return jscipy.stats.norm.logpdf(x)
 
         chex.clear_trace_counter()
 
         rng_key = jax.random.PRNGKey(0)
-        state = blackjax.hmc.init(1.0, logprob_fn)
+        state = blackjax.hmc.init(1.0, logdensity_fn)
 
         kernel = blackjax.hmc(
-            logprob_fn,
+            logdensity_fn,
             step_size=1e-2,
             inverse_mass_matrix=jnp.array([1.0]),
             num_integration_steps=10,
@@ -45,24 +45,24 @@ class CompilationTest(chex.TestCase):
             state, _ = step(sample_key, state)
 
     def test_nuts(self):
-        """Count the number of times the logprob is compiled when using NUTS.
+        """Count the number of times the logdensity is compiled when using NUTS.
 
-        The logprob is compiled twice: when initializing the state and when
+        The logdensity is compiled twice: when initializing the state and when
         compiling the kernel.
 
         """
 
         @chex.assert_max_traces(n=2)
-        def logprob_fn(x):
+        def logdensity_fn(x):
             return jscipy.stats.norm.logpdf(x)
 
         chex.clear_trace_counter()
 
         rng_key = jax.random.PRNGKey(0)
-        state = blackjax.nuts.init(1.0, logprob_fn)
+        state = blackjax.nuts.init(1.0, logdensity_fn)
 
         kernel = blackjax.nuts(
-            logprob_fn, step_size=1e-2, inverse_mass_matrix=jnp.array([1.0])
+            logdensity_fn, step_size=1e-2, inverse_mass_matrix=jnp.array([1.0])
         )
         step = jax.jit(kernel.step)
 
@@ -71,14 +71,14 @@ class CompilationTest(chex.TestCase):
             state, _ = step(sample_key, state)
 
     def test_hmc_warmup(self):
-        """Count the number of times the logprob is compiled when using window
+        """Count the number of times the logdensity is compiled when using window
         adaptation to adapt the value of the step size and the inverse mass
         matrix for the HMC algorithm.
 
         """
 
         @chex.assert_max_traces(n=3)
-        def logprob_fn(x):
+        def logdensity_fn(x):
             return jscipy.stats.norm.logpdf(x)
 
         chex.clear_trace_counter()
@@ -87,7 +87,7 @@ class CompilationTest(chex.TestCase):
 
         warmup = blackjax.window_adaptation(
             algorithm=blackjax.hmc,
-            logprob_fn=logprob_fn,
+            logdensity_fn=logdensity_fn,
             target_acceptance_rate=0.8,
             num_integration_steps=10,
         )
@@ -99,14 +99,14 @@ class CompilationTest(chex.TestCase):
             state, _ = kernel(sample_key, state)
 
     def test_nuts_warmup(self):
-        """Count the number of times the logprob is compiled when using window
+        """Count the number of times the logdensity is compiled when using window
         adaptation to adapt the value of the step size and the inverse mass
         matrix for the NUTS algorithm.
 
         """
 
         @chex.assert_max_traces(n=3)
-        def logprob_fn(x):
+        def logdensity_fn(x):
             return jscipy.stats.norm.logpdf(x)
 
         chex.clear_trace_counter()
@@ -115,7 +115,7 @@ class CompilationTest(chex.TestCase):
 
         warmup = blackjax.window_adaptation(
             algorithm=blackjax.nuts,
-            logprob_fn=logprob_fn,
+            logdensity_fn=logdensity_fn,
             target_acceptance_rate=0.8,
         )
         state, kernel, _ = warmup.run(rng_key, 1.0, num_steps=100)

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -510,10 +510,10 @@ class MonteCarloStandardErrorTest(chex.TestCase):
         cov = cov.at[0, 1].set(rho * scale[0] * scale[1])
         cov = cov.at[1, 0].set(rho * scale[0] * scale[1])
 
-        def logprob_fn(x):
+        def logdensity_fn(x):
             return stats.multivariate_normal.logpdf(x, loc, cov).sum()
 
-        return logprob_fn, loc, scale, rho
+        return logdensity_fn, loc, scale, rho
 
     def mcse_test(self, samples, true_param, p_val=0.01):
         posterior_mean = jnp.mean(samples, axis=[0, 1])
@@ -530,11 +530,14 @@ class MonteCarloStandardErrorTest(chex.TestCase):
     def test_mcse(self, algorithm, parameters):
         """Test convergence using Monte Carlo CLT across multiple chains."""
         init_fn_key, pos_init_key, sample_key = jax.random.split(self.key, 3)
-        logprob_fn, true_loc, true_scale, true_rho = self.generate_multivariate_target(
-            None
-        )
+        (
+            logdensity_fn,
+            true_loc,
+            true_scale,
+            true_rho,
+        ) = self.generate_multivariate_target(None)
         kernel = algorithm(
-            logprob_fn,
+            logdensity_fn,
             inverse_mass_matrix=true_scale,
             **parameters,
         )

--- a/tests/test_smc.py
+++ b/tests/test_smc.py
@@ -13,7 +13,7 @@ import blackjax.smc.base as base
 import blackjax.smc.resampling as resampling
 
 
-def kernel_logprob_fn(position):
+def kernel_logdensity_fn(position):
     return jnp.sum(stats.norm.logpdf(position))
 
 
@@ -30,8 +30,8 @@ class SMCTest(chex.TestCase):
     @parameterized.parameters([500, 1000, 5000])
     def test_smc(self, N):
 
-        mcmc_factory = lambda logprob_fn: blackjax.hmc(
-            logprob_fn,
+        mcmc_factory = lambda logdensity_fn: blackjax.hmc(
+            logdensity_fn,
             step_size=1e-2,
             inverse_mass_matrix=jnp.eye(1),
             num_integration_steps=50,
@@ -49,7 +49,7 @@ class SMCTest(chex.TestCase):
         updated_particles, _ = self.variant(
             functools.partial(
                 kernel,
-                logprob_fn=kernel_logprob_fn,
+                logdensity_fn=kernel_logdensity_fn,
                 log_weight_fn=specialized_log_weights_fn,
             )
         )(self.key, init_particles)

--- a/tests/test_step_size.py
+++ b/tests/test_step_size.py
@@ -13,14 +13,14 @@ from blackjax.adaptation.step_size import find_reasonable_step_size
 class StepSizeTest(chex.TestCase):
     @chex.all_variants(with_pmap=False)
     def test_reasonable_step_size(self):
-        def logprob_fn(x):
+        def logdensity_fn(x):
             return -jnp.sum(0.5 * x)
 
         rng_key = jax.random.PRNGKey(0)
         run_key0, run_key1 = jax.random.split(rng_key, 2)
 
         init_position = jnp.array([3.0])
-        reference_state = hmc.init(init_position, logprob_fn)
+        reference_state = hmc.init(init_position, logdensity_fn)
 
         inv_mass_matrix = jnp.array([1.0])
 
@@ -29,7 +29,7 @@ class StepSizeTest(chex.TestCase):
         def kernel_generator(step_size: float):
             return functools.partial(
                 kernel,
-                logprob_fn=logprob_fn,
+                logdensity_fn=logdensity_fn,
                 step_size=step_size,
                 inverse_mass_matrix=inv_mass_matrix,
                 num_integration_steps=10,


### PR DESCRIPTION
Renaming logprob to logdensity for more consistent terminology.

How: search for `logprob(?!ability)` and replace with `logdensity`, excluding everything in `docs/**`, `examples/`, `tests/**` as they are mostly logprob.

# Thank you for opening a PR!


 A few important guidelines and requirements before we can merge your PR:

 - [ ] *If I add a new sampler*, there is an issue discussing it already;
 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [x] The doc is up-to-date;
 - [ ] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
