### PR TITLE
Add ReadTheDocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+version: 2
+
+python:
+  version: "3.8"
+  install:
+      - method: pip
+        path: .
+        extra_requirements:
+          - rtd
+      - requirements: requirements-doc.txt
+
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: true


### PR DESCRIPTION
The goal is to hand the documentation build over to ReadTheDocs. This would make it easier to version the documentation and simplify the CI code.

However, it looks like we're hitting ReadTheDocs's [build resources limits](https://docs.readthedocs.io/en/stable/builds.html) even just with the Oryx example. We may need to simplify this model; we don't need anything fancy for this How To.

This would only ever make sense for a "minimal" documentation where the longer examples are moved to the Sampling Book Project.