### PR TITLE
Automatically open an issue for Blackjax meetings

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting.md
+++ b/.github/ISSUE_TEMPLATE/meeting.md
@@ -1,0 +1,15 @@
+---
+name: Blackjax Meeting
+about: Blackjax public meeting
+title: '👋 Blackjax Meeting - {{ MONTH }}'
+labels: meeting
+assignees: ''
+---
+
+Hello! This is an issue to track the next Blackjax meeting. Here's some relevant information:
+
+- **Date**: Paris time at **5:00PM on the FIRST Friday of the month**
+- [**Google Calendar Link**](https://calendar.google.com/calendar/u/0?cid=MDVlMzVkODQyYzJmZDc1YjkxZjFmNTExYWJlNmVjYzhiYjM2NDk3OWYxMTFjOWVkNzhkYzliN2Y3MDk3YTc0M0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t).
+- [**Video Link**](meet.google.com/ack-uozu-xww)
+
+These meetings are public and can be attended by anyone. If you'd like to discuss something at the meeting, we kindly ask you to comment on this issue beforehand.

--- a/.github/workflows/schedule-meeting.yml
+++ b/.github/workflows/schedule-meeting.yml
@@ -1,0 +1,18 @@
+# Open a Meeting issue the 25th day of the month.
+# Meetings happen on the first Friday of the month
+name: Open a meeting issue
+on:
+  schedule:
+    - cron: '0 0 20 * *'
+  workflow_dispatch:
+
+jobs:
+  create-meeting-issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/team-meeting.md


### PR DESCRIPTION
We will be hosting Blackjax meetings every first Friday of the month. In this PR I add a github action that opens a new issue the 20th of the month with the video link, so people can add items to the agenda.