### PR TITLE
Use github-action-benchmark for continous benchmarking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   benchmark:
@@ -21,8 +24,24 @@ jobs:
       - name: Set up benchmark environment
         run: |
           python -m pip install -U pip
-          pip install .
-          less requirements.txt | grep 'pytest\|chex' | xargs -i -t pip install {}
+          pip install -r requirements.txt
+      - name: Load previous benchmark data from cache
+        uses: actions/cache@v3
+        with:
+          path: ./benchmark-cache
+          key: benchmark
       - name: Run benchmarks
         run: |
-          pytest -vv -m benchmark
+          pytest --benchmark-only --benchmark-json output.json
+      - name: Write benchmark results
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Python Benchmark with pytest-benchmark
+          tool: 'pytest'
+          output-file-path: output.json
+          external-data-json-path: ./benchmark-cache/benchmark-data.json
+          alert-threshold: '200%'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: ${{ github.event_name == 'push' }}
+          fail-on-alert: true
+          auto-push: false


### PR DESCRIPTION
We use https://github.com/benchmark-action/github-action-benchmark to benchmark the code both on PR and push on `main`. The results from previous runs are stored in cache and committed to gh-pages.