### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -2,7 +2,6 @@
 aeppl>=0.0.40
 aesara>=2.8.8
 arviz
-distrax
 flax
 ipython
 jax
@@ -23,7 +22,6 @@ sphinx-book-theme
 sphinx-design
 sphinx-math-dollar
 tensorflow-cpu
-tensorflow-datasets
 tfp-nightly[jax]
 versioneer
 watermark


### PR DESCRIPTION
Resolves #303 and #364.

By removing `distrax`, we can unify the way the code is written.
`tensorflow-datasets` is no longer necessary as example code moves to sampling-book. (btw, huggingface datasets is lightweight and meets requirements)

 A few important guidelines and requirements before we can merge your PR:

 - [ ] *If I add a new sampler*, there is an issue discussing it already;
 - [x] We should be able to understand what the PR does from its title only;
 - [ ] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [ ] There are tests covering the changes;
 - [x] The doc is up-to-date;
 - [ ] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
