### PR TITLE
Do not fail RTD build on warning

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,4 +12,4 @@ python:
 sphinx:
   builder: html
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false


### PR DESCRIPTION
Read the Docs builds are currently failing because the build is issuing warnings and we set `fail_on_warning` to `True`. Let's set it to `False` temporarily to get the docs building and figure out the reasons for the warnings later.