### PR TITLE
Drop support of Python 3.7 and install latest developments of optax to avoid failing tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Give PyPI some time to update the index
       run: sleep 240
     - name: Attempt install from PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - style
     strategy:
       matrix:
-        python-version: [ '3.7', '3.10']
+        python-version: [ '3.8', '3.10']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "blackjax"
 authors= [{name = "The Blackjax team", email = "remi@thetypicalset.com"}]
 description = "Flexible and fast sampling in Python"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords=[
     "probability",
     "machine learning",
@@ -22,7 +22,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -36,7 +35,7 @@ dependencies = [
     "jax>=0.3.13",
     "jaxlib>=0.3.10",
     "jaxopt>=0.5.5",
-    "optax",
+    "optax@git+https://github.com/deepmind/optax.git",
     "typing-extensions>=4.4.0",
 ]
 dynamic = ["version"]

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -11,7 +11,7 @@ jupytext
 myst_nb
 numba
 numpyro
-optax
+optax@git+https://github.com/deepmind/optax.git
 oryx
 pymc
 scikit-learn


### PR DESCRIPTION
The latest release of JAX raises an error for the use of any deprecated version of `jax.Array`. This creates errors in tests when importing optax (the latest release is from Nov 2022). In the latests developments of the library this is fixed, so we now install these latests developments instead of the latests release.

We could install an earlier version of JAX, instead of the latest developments of optax.
