### PR TITLE
Revert "Change documentation background color"

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,8 +1,3 @@
-body { background-color: #fefefa;}
-div.cell div.cell_input {
-    background-color: #f7f7f3;
-}
-
 #site-navigation{
 	h1.site-logo {
 		font-weight: bold;


### PR DESCRIPTION
This reverts commit 6963ecfc8b7a727f65e9e77272936180209660a8.

With the background-color added in custom.css the documentation page in dark mode is displayed like this.
![Screenshot 2023-04-20 at 07-34-35 A Quick Introduction to Blackjax](https://user-images.githubusercontent.com/6321836/233278947-08bf9020-f3cd-42f2-9f10-15ebac0d6f11.png)
