### PR TITLE
Converting scan to fori_loop in static_integration in order to support a variable number of integration steps in HMC sampler

### DIFF
--- a/blackjax/mcmc/trajectory.py
+++ b/blackjax/mcmc/trajectory.py
@@ -115,19 +115,14 @@ def static_integration(
     def integrate(
         initial_state: IntegratorState, step_size, num_integration_steps
     ) -> IntegratorState:
-        directed_step_size = jax.tree_map(
+        directed_step_size = jax.tree_util.tree_map(
             lambda step_size: direction * step_size, step_size
         )
 
-        def one_step(state, _):
-            state = integrator(state, directed_step_size)
-            return state, state
+        def one_step(_, state):
+            return integrator(state, directed_step_size)
 
-        last_state, _ = jax.lax.scan(
-            one_step, initial_state, jnp.arange(num_integration_steps)
-        )
-
-        return last_state
+        return jax.lax.fori_loop(0, num_integration_steps, one_step, initial_state)
 
     return integrate
 


### PR DESCRIPTION
It is common practice to jitter the integration lengths HMC sampling for each proposal, but as currently written, BlackJAX's implementation of HMC doesn't support this. This tiny PR adds support for non-static integration lengths by converting the `scan` that currently backs the HMC proposal integration to a `fori_loop` which supports both static and variable numbers of steps. In the case where a static number is passed, `fori_loop` automatically rewrites itself as the `scan` that was previously used so I don't expect this to introduce any changes for the currently supported use case.

I don't believe this has been previously discussed, but I'm happy to chat if anyone has suggestions!

---

 A few important guidelines and requirements before we can merge your PR:

 - [ ] *If I add a new sampler*, there is an issue discussing it already;
 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [ ] The doc is up-to-date;
 - [ ] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
