### PR TITLE
Unify SGMCMC init structure

### DIFF
--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -204,7 +204,7 @@ def meads_adaptation(
 
     adapt_init, adapt_update = base()
 
-    batch_init = jax.vmap(lambda r, p: mcmc.ghmc.init(r, p, logdensity_fn))
+    batch_init = jax.vmap(lambda p, r: mcmc.ghmc.init(p, r, logdensity_fn))
 
     def one_step(carry, rng_key):
         states, adaptation_state = carry
@@ -235,7 +235,7 @@ def meads_adaptation(
         key_init, key_adapt = jax.random.split(rng_key)
 
         rng_keys = jax.random.split(key_init, num_chains)
-        init_states = batch_init(rng_keys, positions)
+        init_states = batch_init(positions, rng_keys)
         init_adaptation_state = adapt_init(positions, init_states.logdensity_grad)
 
         keys = jax.random.split(key_adapt, num_steps)

--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -50,10 +50,10 @@ class GHMCState(NamedTuple):
 
 
 def init(
-    rng_key: PRNGKey,
     position: PyTree,
+    rng_key: PRNGKey,
     logdensity_fn: Callable,
-):
+) -> GHMCState:
     logdensity, logdensity_grad = jax.value_and_grad(logdensity_fn)(position)
 
     key_mometum, key_slice = jax.random.split(rng_key)
@@ -249,7 +249,7 @@ class ghmc:
         kernel = cls.build_kernel(noise_gn, divergence_threshold)
 
         def init_fn(position: PyTree, rng_key: PRNGKey):
-            return cls.init(rng_key, position, logdensity_fn)
+            return cls.init(position, rng_key, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):
             return kernel(

--- a/blackjax/sgmcmc/csgld.py
+++ b/blackjax/sgmcmc/csgld.py
@@ -1,3 +1,16 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Public API for the Contour Stochastic gradient Langevin Dynamics kernel :cite:p:`deng2020contour,deng2022interacting`.
 
 """
@@ -33,7 +46,7 @@ class ContourSGLDState(NamedTuple):
     energy_idx: int
 
 
-def init(position: PyTree, num_partitions=512):
+def init(position: PyTree, num_partitions=512) -> ContourSGLDState:
     energy_pdf = (
         jnp.arange(num_partitions, 0, -1) / jnp.arange(num_partitions, 0, -1).sum()
     )
@@ -204,7 +217,6 @@ class csgld:
         logdensity_estimator: Callable,
         gradient_estimator: Callable,
         zeta: float = 1,
-        temperature: float = 0.01,
         num_partitions: int = 512,
         energy_gap: float = 100,
         min_energy: float = 0,
@@ -220,6 +232,7 @@ class csgld:
             minibatch: PyTree,
             step_size_diff: float,
             step_size_stoch: float,
+            temperature: float = 1.0,
         ):
             return kernel(
                 rng_key,

--- a/blackjax/sgmcmc/csgld.py
+++ b/blackjax/sgmcmc/csgld.py
@@ -228,12 +228,12 @@ class csgld:
 
         def step_fn(
             rng_key: PRNGKey,
-            state,
+            state: ContourSGLDState,
             minibatch: PyTree,
             step_size_diff: float,
             step_size_stoch: float,
             temperature: float = 1.0,
-        ):
+        ) -> ContourSGLDState:
             return kernel(
                 rng_key,
                 state,

--- a/blackjax/sgmcmc/diffusions.py
+++ b/blackjax/sgmcmc/diffusions.py
@@ -75,7 +75,7 @@ def sghmc(alpha: float = 0.01, beta: float = 0):
         momentum = jax.tree_util.tree_map(
             lambda p, g, n: (1.0 - alpha * step_size) * p
             + step_size * g
-            + jnp.sqrt(step_size * (2 * alpha - step_size * beta) * temperature) * n,
+            + jnp.sqrt(step_size * temperature * (2 * alpha - step_size * temperature * beta)) * n,
             momentum,
             logdensity_grad,
             noise,
@@ -109,7 +109,7 @@ def sgnht(alpha: float = 0.01, beta: float = 0):
         momentum = jax.tree_util.tree_map(
             lambda p, g, n: (1.0 - xi * step_size) * p
             + step_size * g
-            + jnp.sqrt(step_size * (2 * alpha - step_size * beta) * temperature) * n,
+            + jnp.sqrt(step_size * temperature * (2 * alpha - step_size * temperature * beta)) * n,
             momentum,
             logdensity_grad,
             noise,
@@ -118,7 +118,7 @@ def sgnht(alpha: float = 0.01, beta: float = 0):
             operator.add, jax.tree_util.tree_map(lambda x: jnp.sum(x * x), momentum)
         )
         d = pytree_size(momentum)
-        xi = xi + step_size * (momentum_dot / d - 1)
+        xi = xi + step_size * (momentum_dot / d - temperature)
         return position, momentum, xi
 
     return one_step

--- a/blackjax/sgmcmc/diffusions.py
+++ b/blackjax/sgmcmc/diffusions.py
@@ -75,7 +75,10 @@ def sghmc(alpha: float = 0.01, beta: float = 0):
         momentum = jax.tree_util.tree_map(
             lambda p, g, n: (1.0 - alpha * step_size) * p
             + step_size * g
-            + jnp.sqrt(step_size * temperature * (2 * alpha - step_size * temperature * beta)) * n,
+            + jnp.sqrt(
+                step_size * temperature * (2 * alpha - step_size * temperature * beta)
+            )
+            * n,
             momentum,
             logdensity_grad,
             noise,
@@ -109,7 +112,10 @@ def sgnht(alpha: float = 0.01, beta: float = 0):
         momentum = jax.tree_util.tree_map(
             lambda p, g, n: (1.0 - xi * step_size) * p
             + step_size * g
-            + jnp.sqrt(step_size * temperature * (2 * alpha - step_size * temperature * beta)) * n,
+            + jnp.sqrt(
+                step_size * temperature * (2 * alpha - step_size * temperature * beta)
+            )
+            * n,
             momentum,
             logdensity_grad,
             noise,

--- a/blackjax/sgmcmc/sghmc.py
+++ b/blackjax/sgmcmc/sghmc.py
@@ -132,7 +132,7 @@ class sghmc:
             minibatch: PyTree,
             step_size: float,
             temperature: float = 1,
-        ):
+        ) -> PyTree:
             return kernel(
                 rng_key,
                 state,

--- a/blackjax/sgmcmc/sghmc.py
+++ b/blackjax/sgmcmc/sghmc.py
@@ -17,10 +17,15 @@ from typing import Callable
 import jax
 
 import blackjax.sgmcmc.diffusions as diffusions
+from blackjax.base import MCMCSamplingAlgorithm
 from blackjax.types import PRNGKey, PyTree
 from blackjax.util import generate_gaussian_noise
 
-__all__ = ["build_kernel", "sghmc"]
+__all__ = ["init", "build_kernel", "sghmc"]
+
+
+def init(position: PyTree) -> PyTree:
+    return position
 
 
 def build_kernel(alpha: float = 0.01, beta: float = 0) -> Callable:
@@ -102,20 +107,32 @@ class sghmc:
 
     Returns
     -------
-    A step function.
+    A ``MCMCSamplingAlgorithm``.
 
     """
 
+    init = staticmethod(init)
     build_kernel = staticmethod(build_kernel)
 
     def __new__(  # type: ignore[misc]
         cls,
         grad_estimator: Callable,
         num_integration_steps: int = 10,
-    ) -> Callable:
-        kernel = cls.build_kernel()
+        alpha: float = 0.01,
+        beta: float = 0,
+    ) -> MCMCSamplingAlgorithm:
+        kernel = cls.build_kernel(alpha, beta)
 
-        def step_fn(rng_key: PRNGKey, state, minibatch: PyTree, step_size: float):
+        def init_fn(position: PyTree):
+            return cls.init(position)
+
+        def step_fn(
+            rng_key: PRNGKey,
+            state: PyTree,
+            minibatch: PyTree,
+            step_size: float,
+            temperature: float = 1,
+        ):
             return kernel(
                 rng_key,
                 state,
@@ -123,6 +140,7 @@ class sghmc:
                 minibatch,
                 step_size,
                 num_integration_steps,
+                temperature,
             )
 
-        return step_fn
+        return MCMCSamplingAlgorithm(init_fn, step_fn)  # type: ignore[arg-type]

--- a/blackjax/sgmcmc/sgld.py
+++ b/blackjax/sgmcmc/sgld.py
@@ -114,11 +114,11 @@ class sgld:
 
         def step_fn(
             rng_key: PRNGKey,
-            state,
+            state: PyTree,
             minibatch: PyTree,
             step_size: float,
             temperature: float = 1,
-        ):
+        ) -> PyTree:
             return kernel(
                 rng_key, state, grad_estimator, minibatch, step_size, temperature
             )

--- a/blackjax/sgmcmc/sgld.py
+++ b/blackjax/sgmcmc/sgld.py
@@ -15,9 +15,14 @@
 from typing import Callable
 
 import blackjax.sgmcmc.diffusions as diffusions
+from blackjax.base import MCMCSamplingAlgorithm
 from blackjax.types import PRNGKey, PyTree
 
-__all__ = ["build_kernel", "sgld"]
+__all__ = ["init", "build_kernel", "sgld"]
+
+
+def init(position: PyTree) -> PyTree:
+    return position
 
 
 def build_kernel() -> Callable:
@@ -91,17 +96,21 @@ class sgld:
 
     Returns
     -------
-    A step function.
+    A ``MCMCSamplingAlgorithm``.
 
     """
 
+    init = staticmethod(init)
     build_kernel = staticmethod(build_kernel)
 
     def __new__(  # type: ignore[misc]
         cls,
         grad_estimator: Callable,
-    ) -> Callable:
+    ) -> MCMCSamplingAlgorithm:
         kernel = cls.build_kernel()
+
+        def init_fn(position: PyTree):
+            return cls.init(position)
 
         def step_fn(
             rng_key: PRNGKey,
@@ -114,4 +123,4 @@ class sgld:
                 rng_key, state, grad_estimator, minibatch, step_size, temperature
             )
 
-        return step_fn
+        return MCMCSamplingAlgorithm(init_fn, step_fn)  # type: ignore[arg-type]

--- a/blackjax/sgmcmc/sgnht.py
+++ b/blackjax/sgmcmc/sgnht.py
@@ -139,11 +139,11 @@ class sgnht:
 
         def step_fn(
             rng_key: PRNGKey,
-            state,
+            state: SGNHTState,
             minibatch: PyTree,
             step_size: float,
             temperature: float = 1,
-        ):
+        ) -> SGNHTState:
             return kernel(
                 rng_key, state, grad_estimator, minibatch, step_size, temperature
             )

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -270,7 +270,7 @@ class SGMCMCTest(chex.TestCase):
 
         data_batch = X_data[:100, :]
         init_position = 1.0
-        _ = sgld(rng_key, init_position, data_batch, 1e-3)
+        _ = sgld.step(rng_key, init_position, data_batch, 1e-3)
 
     def test_linear_regression_sgld_cv(self):
         rng_key, data_key = jax.random.split(self.key, 2)
@@ -291,7 +291,7 @@ class SGMCMCTest(chex.TestCase):
 
         init_position = 1.0
         data_batch = X_data[:100, :]
-        _ = sgld(rng_key, init_position, data_batch, 1e-3)
+        _ = sgld.step(rng_key, init_position, data_batch, 1e-3)
 
     def test_linear_regression_sghmc(self):
         rng_key, data_key = jax.random.split(self.key, 2)
@@ -307,7 +307,7 @@ class SGMCMCTest(chex.TestCase):
         data_batch = X_data[100:200, :]
         init_position = 1.0
         data_batch = X_data[:100, :]
-        _ = sghmc(rng_key, init_position, data_batch, 1e-3)
+        _ = sghmc.step(rng_key, init_position, data_batch, 1e-3)
 
     def test_linear_regression_sghmc_cv(self):
         rng_key, data_key = jax.random.split(self.key, 2)
@@ -327,7 +327,7 @@ class SGMCMCTest(chex.TestCase):
 
         init_position = 1.0
         data_batch = X_data[:100, :]
-        _ = sghmc(rng_key, init_position, data_batch, 1e-3)
+        _ = sghmc.step(rng_key, init_position, data_batch, 1e-3)
 
     def test_linear_regression_sgnht(self):
         rng_key, data_key = jax.random.split(self.key, 2)

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -289,7 +289,7 @@ class SGMCMCTest(chex.TestCase):
         )
 
         sgld = blackjax.sgld(cv_grad_fn)
-        
+
         init_position = 1.0
         init_position = sgld.init(init_position)
         data_batch = X_data[:100, :]

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -270,6 +270,7 @@ class SGMCMCTest(chex.TestCase):
 
         data_batch = X_data[:100, :]
         init_position = 1.0
+        init_position = sgld.init(init_position)
         _ = sgld.step(rng_key, init_position, data_batch, 1e-3)
 
     def test_linear_regression_sgld_cv(self):
@@ -288,8 +289,9 @@ class SGMCMCTest(chex.TestCase):
         )
 
         sgld = blackjax.sgld(cv_grad_fn)
-
+        
         init_position = 1.0
+        init_position = sgld.init(init_position)
         data_batch = X_data[:100, :]
         _ = sgld.step(rng_key, init_position, data_batch, 1e-3)
 
@@ -306,6 +308,7 @@ class SGMCMCTest(chex.TestCase):
 
         data_batch = X_data[100:200, :]
         init_position = 1.0
+        init_position = sghmc.init(init_position)
         data_batch = X_data[:100, :]
         _ = sghmc.step(rng_key, init_position, data_batch, 1e-3)
 
@@ -326,6 +329,7 @@ class SGMCMCTest(chex.TestCase):
         sghmc = blackjax.sghmc(cv_grad_fn, 10)
 
         init_position = 1.0
+        init_position = sghmc.init(init_position)
         data_batch = X_data[:100, :]
         _ = sghmc.step(rng_key, init_position, data_batch, 1e-3)
 


### PR DESCRIPTION
As discussed in #537 , this PR unifies the `sgmcmc` module such that all algorithms have an `init` function and return a `MCMCSamplingAlgorithm`, in the case of `sgld` and `sghmc` the init function is the trivial `lambda position: position`.

This does not result in totally seamless switching since some algorithms (`sgnht` and `csgld`) require a `rng_key` whereas others do not. However, the block to seamless switching is not just down to the `init` since some algorithms (`csgld`) also require custom `step_fun` signatures.

I have reordered the `init` signatures such that `position` is first, `rng_key` is second (if required) followed by any other 
algorithm-specific arguments. This included a refactor to `ghmc` and as a results `meads_adaptation`.

I suggest that possibly we should consider a global reordering of `step_fn` with `state` before `rng_key` since it is possible for an algorithm to not require a `rng_key` in their `step_fn`, e.g. SVGD #512

Finally, I unified the `temperature` parameter such that it is given as an input to the `step_fn` with a default value of 1, previously it had a default value of 0.01 for `csgld` which I am not sure was intended.

I also left the `init` out of the `docs` for `sgld` and `sghmc` since they still work without it, i.e. only using `.step`

 A few important guidelines and requirements before we can merge your PR:

 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [x] The doc is up-to-date;