### PR TITLE
Moving max_num_doublings of NUTS from build_kernel to kernel

### DIFF
--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -77,7 +77,6 @@ class NUTSInfo(NamedTuple):
 def build_kernel(
     integrator: Callable = integrators.velocity_verlet,
     divergence_threshold: int = 1000,
-    max_num_doublings: int = 10,
 ):
     """Build an iterative NUTS kernel.
 
@@ -108,10 +107,6 @@ def build_kernel(
     divergence_threshold
         The absolute difference in energy above which we consider
         a transition "divergent".
-    max_num_doublings
-        The maximum number of times we expand the trajectory by
-        doubling the number of steps if the trajectory does not
-        turn onto itself.
 
     """
 
@@ -121,6 +116,7 @@ def build_kernel(
         logdensity_fn: Callable,
         step_size: float,
         inverse_mass_matrix: Array,
+        max_num_doublings: int = 10,
     ) -> tuple[hmc.HMCState, NUTSInfo]:
         """Generate a new sample with the NUTS kernel."""
 
@@ -224,7 +220,7 @@ class nuts:
         divergence_threshold: int = 1000,
         integrator: Callable = integrators.velocity_verlet,
     ) -> SamplingAlgorithm:
-        kernel = cls.build_kernel(integrator, divergence_threshold, max_num_doublings)
+        kernel = cls.build_kernel(integrator, divergence_threshold)
 
         def init_fn(position: ArrayLikeTree):
             return cls.init(position, logdensity_fn)
@@ -236,6 +232,7 @@ class nuts:
                 logdensity_fn,
                 step_size,
                 inverse_mass_matrix,
+                max_num_doublings,
             )
 
         return SamplingAlgorithm(init_fn, step_fn)


### PR DESCRIPTION
Implement #564 

1. Making the argument consistent with 'num_integration_steps' in HMC
2. Allows running adaptation (e.g. `window_adaptation`) with an arbitrary `max_num_doublings` 

---

 A few important guidelines and requirements before we can merge your PR:

 - [ ] *If I add a new sampler*, there is an issue discussing it already;
 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [x] The doc is up-to-date;
 - [ ] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
