### PR TITLE
Check only for negative divergences

### DIFF
--- a/blackjax/mcmc/proposal.py
+++ b/blackjax/mcmc/proposal.py
@@ -108,7 +108,7 @@ def proposal_from_energy_diff(
     new_energy
         the energy at the proposed state
     divergence_threshold
-        max value allowed for the difference in energies not to be considered a divergence
+        max value allowed for an increase in energies not to be considered a divergence
     state
         the proposed state
 
@@ -118,7 +118,7 @@ def proposal_from_energy_diff(
     """
     delta_energy = initial_energy - new_energy
     delta_energy = jnp.where(jnp.isnan(delta_energy), -jnp.inf, delta_energy)
-    is_transition_divergent = jnp.abs(delta_energy) > divergence_threshold
+    is_transition_divergent = -delta_energy > divergence_threshold
 
     # The weight of the new proposal is equal to H0 - H(z_new)
     weight = delta_energy


### PR DESCRIPTION
Currently, a divergence error is triggered both when the energy increases and decreases excessively. However a large `delta_energy` can also occur in complex models, when initial points are widely outside the typical set. Then proposal steps typically vastly improve the likelihood and have large energy differences, but these are currently rejected. Changing the current behavior to only trigger when `delta_energy` is excessively negative fixes this behavior.

This is in line with the implementation in Stan: https://github.com/stan-dev/stan/blob/88cffcf6271da06b0474dd6ce90d69a54127a5e6/src/stan/mcmc/hmc/nuts/base_nuts.hpp#L262C11-L262C19 and Numpyro: https://github.com/pyro-ppl/numpyro/blob/065aa4352dbc9ebeb1132b15b51d8b3149848640/numpyro/infer/hmc.py#L382C13-L382C13

I only modified the documentation of the local function, otherwise left that `divergence_threshold` is the "max value allowed for **the difference** in energies to be considered a divergence". I think it would lead to more confusion than be helpful if replaced by "**an increase**". Also, effectively, when the chain converged to the typical set, it shouldn't change anything. 
