### PR TITLE
Adjusts for the fact that IRMH proposal might not be symmetric

### DIFF
--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -278,6 +278,10 @@ def build_irmh() -> Callable:
         proposal_distribution
             A function that, given a PRNGKey, is able to produce a sample in the same
             domain of the target distribution.
+        proposal_logdensity_fn:
+            For non-symmetric proposals, a function that returns the log-density
+            to obtain a given proposal knowing the current state. If it is not
+            provided we assume the proposal is symmetric.
         """
 
         def proposal_generator(rng_key: PRNGKey, position: ArrayTree):
@@ -316,7 +320,10 @@ class irmh:
     proposal_distribution
         A Callable that takes a random number generator and produces a new proposal. The
         proposal is independent of the sampler's current state.
-
+    proposal_logdensity_fn:
+        For non-symmetric proposals, a function that returns the log-density
+        to obtain a given proposal knowing the current state. If it is not
+        provided we assume the proposal is symmetric.
     Returns
     -------
     A ``SamplingAlgorithm``.
@@ -330,6 +337,7 @@ class irmh:
         cls,
         logdensity_fn: Callable,
         proposal_distribution: Callable,
+        proposal_logdensity_fn: Optional[Callable] = None
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
@@ -337,7 +345,7 @@ class irmh:
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):
-            return kernel(rng_key, state, logdensity_fn, proposal_distribution)
+            return kernel(rng_key, state, logdensity_fn, proposal_distribution, proposal_logdensity_fn)
 
         return SamplingAlgorithm(init_fn, step_fn)
 

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -60,7 +60,7 @@ Examples
         new_state, info = step(rng_key, state)
 
 """
-from typing import Callable, NamedTuple, Optional, Tuple
+from typing import Callable, NamedTuple, Optional
 
 import jax
 from jax import numpy as jnp
@@ -271,7 +271,7 @@ def build_irmh() -> Callable:
         logdensity_fn: Callable,
         proposal_distribution: Callable,
         proposal_logdensity_fn: Optional[Callable] = None,
-    ) -> Tuple[RWState, RWInfo]:
+    ) -> tuple[RWState, RWInfo]:
         """
         Parameters
         ----------
@@ -285,6 +285,7 @@ def build_irmh() -> Callable:
         """
 
         def proposal_generator(rng_key: PRNGKey, position: ArrayTree):
+            del position
             return proposal_distribution(rng_key)
 
         inner_kernel = build_rmh()

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -270,7 +270,7 @@ def build_irmh() -> Callable:
         state: RWState,
         logdensity_fn: Callable,
         proposal_distribution: Callable,
-        proposal_logdensity_fn: Callable = None
+        proposal_logdensity_fn: Optional[Callable] = None,
     ) -> Tuple[RWState, RWInfo]:
         """
         Parameters
@@ -288,9 +288,12 @@ def build_irmh() -> Callable:
             return proposal_distribution(rng_key)
 
         inner_kernel = build_rmh()
-        return inner_kernel(rng_key, state, logdensity_fn, proposal_generator, proposal_logdensity_fn)
+        return inner_kernel(
+            rng_key, state, logdensity_fn, proposal_generator, proposal_logdensity_fn
+        )
 
     return kernel
+
 
 class irmh:
     """Implements the (basic) user interface for the independent RMH.
@@ -337,7 +340,7 @@ class irmh:
         cls,
         logdensity_fn: Callable,
         proposal_distribution: Callable,
-        proposal_logdensity_fn: Optional[Callable] = None
+        proposal_logdensity_fn: Optional[Callable] = None,
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
@@ -345,7 +348,13 @@ class irmh:
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):
-            return kernel(rng_key, state, logdensity_fn, proposal_distribution, proposal_logdensity_fn)
+            return kernel(
+                rng_key,
+                state,
+                logdensity_fn,
+                proposal_distribution,
+                proposal_logdensity_fn,
+            )
 
         return SamplingAlgorithm(init_fn, step_fn)
 

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -60,7 +60,7 @@ Examples
         new_state, info = step(rng_key, state)
 
 """
-from typing import Callable, NamedTuple, Optional
+from typing import Callable, NamedTuple, Optional, Tuple
 
 import jax
 from jax import numpy as jnp
@@ -270,9 +270,9 @@ def build_irmh() -> Callable:
         state: RWState,
         logdensity_fn: Callable,
         proposal_distribution: Callable,
-    ) -> tuple[RWState, RWInfo]:
+        proposal_logdensity_fn: Callable = None
+    ) -> Tuple[RWState, RWInfo]:
         """
-
         Parameters
         ----------
         proposal_distribution
@@ -280,15 +280,13 @@ def build_irmh() -> Callable:
             domain of the target distribution.
         """
 
-        def proposal_generator(rng_key: PRNGKey, position: ArrayTree):
-            del position
+        def proposal_generator(rng_key: PRNGKey, position):
             return proposal_distribution(rng_key)
 
         inner_kernel = build_rmh()
-        return inner_kernel(rng_key, state, logdensity_fn, proposal_generator)
+        return inner_kernel(rng_key, state, logdensity_fn, proposal_generator, proposal_logdensity_fn)
 
     return kernel
-
 
 class irmh:
     """Implements the (basic) user interface for the independent RMH.

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -280,7 +280,7 @@ def build_irmh() -> Callable:
             domain of the target distribution.
         """
 
-        def proposal_generator(rng_key: PRNGKey, position):
+        def proposal_generator(rng_key: PRNGKey, position: ArrayTree):
             return proposal_distribution(rng_key)
 
         inner_kernel = build_rmh()

--- a/tests/mcmc/test_random_walk_without_chex.py
+++ b/tests/mcmc/test_random_walk_without_chex.py
@@ -49,31 +49,58 @@ class AdditiveStepTest(unittest.TestCase):
 
 
 class IRMHTest(unittest.TestCase):
+    def proposal_distribution(self, key):
+        return jnp.array([10.0])
+
+    def logdensity_accepts(self, position):
+        """
+        a logdensity that gets maximized after the step
+        """
+        return 0.0 if all(position - 10.0 < 1e-10) else 0.5
+
     def test_proposal_is_independent_of_position(self):
-        """New position does not depend on previous"""
+        """New position does not depend on previous position"""
         rng_key = jax.random.key(0)
         initial_position = jnp.array([50.0])
         other_position = jnp.array([15000.0])
 
-        def proposal_distribution(key):
-            return jnp.array([10.0])
-
-        def test_logdensity_accepts(position):
-            """
-            a logdensity that gets maximized after the step
-            """
-            return 0.0 if all(position - 10.0 < 1e-10) else 0.5
-
         step = build_irmh()
 
         for previous_position in [initial_position, other_position]:
-            new_state, _ = step(
+            new_state, state_info = step(
                 rng_key,
                 RWState(position=previous_position, logdensity=1.0),
-                test_logdensity_accepts,
-                proposal_distribution,
+                self.logdensity_accepts,
+                self.proposal_distribution,
             )
             np.testing.assert_allclose(new_state.position, jnp.array([10.0]))
+            np.testing.assert_allclose(state_info.acceptance_rate, 0.367879, rtol=1e-5)
+
+    def test_non_symmetric_proposal(self):
+        """
+        Given that proposal_logdensity_fn is included,
+        thus the proposal is non-symmetric.
+        When computing the acceptance of the proposed state
+        Then proposal_logdensity_fn value is taken into account
+        """
+        rng_key = jax.random.key(0)
+        initial_position = jnp.array([50.0])
+
+        def test_proposal_logdensity(new_state, prev_state):
+            return 0.1 if all(new_state.position - 10 < 1e-10) else 0.5
+
+        step = build_irmh()
+
+        for previous_position in [initial_position]:
+            _, state_info = step(
+                rng_key,
+                RWState(position=previous_position, logdensity=1.0),
+                self.logdensity_accepts,
+                self.proposal_distribution,
+                test_proposal_logdensity,
+            )
+
+            np.testing.assert_allclose(state_info.acceptance_rate, 0.246597)
 
 
 class RMHProposalTest(unittest.TestCase):


### PR DESCRIPTION
# Thank you for opening a PR!
Adds proposal_logdensity_fn as parameter, so as to modify MH acceptance rule to accommodate for non-symmetry of the proposal distribution.

 A few important guidelines and requirements before we can merge your PR:

 - [N] *If I add a new sampler*, there is an issue discussing it already;
 - [Y] We should be able to understand what the PR does from its title only;
 - [Y] There is a high-level description of the changes;
 - [N/A] There are links to *all* the relevant issues, discussions and PRs;
 - [Y] The branch is rebased on the latest `main` commit;
 - [Y] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [Y] The code respects the current naming conventions;
 - [Y] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [Y] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [N] There are tests covering the changes;
 I haven't added new tests since this is just calling build_rmh from within a factory (IRMH is indeed a factory) and the functionality is already well tested.
 - [Y] The doc is up-to-date;
 - [N] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
