### PR TITLE
Losen the input requirement for ess computation.

### DIFF
--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -255,11 +255,10 @@ def make_adaptation_L(kernel, frac, Lfactor):
         )
         samples = info.transformed_position  # tranform is the identity here
         flat_samples = jax.vmap(lambda x: ravel_pytree(x)[0])(samples)
-        flat_samples = flat_samples.reshape(2, num_steps // 2, -1)
-        ESS = effective_sample_size(flat_samples)
+        ess = effective_sample_size(flat_samples[None, ...])
 
         return state, params._replace(
-            L=Lfactor * params.step_size * jnp.mean(num_steps / ESS)
+            L=Lfactor * params.step_size * jnp.mean(num_steps / ess)
         )
 
     return adaptation_L

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -115,9 +115,6 @@ def effective_sample_size(
     sample_axis = sample_axis if sample_axis >= 0 else len(input_shape) + sample_axis
     num_chains = input_shape[chain_axis]
     num_samples = input_shape[sample_axis]
-    assert (
-        num_chains > 1
-    ), "effective_sample_size as implemented only works for two or more chains."
 
     mean_across_chain = input_array.mean(axis=sample_axis, keepdims=True)
     # Compute autocovariance estimates for every lag for the input array using FFT.
@@ -138,10 +135,10 @@ def effective_sample_size(
     weighted_var = mean_var0 * (num_samples - 1.0) / num_samples
     weighted_var = jax.lax.cond(
         num_chains > 1,
-        lambda _: weighted_var
+        lambda mean_across_chain: weighted_var
         + mean_across_chain.var(axis=chain_axis, ddof=1, keepdims=True),
         lambda _: weighted_var,
-        operand=None,
+        operand=mean_across_chain,
     )
 
     # Geyer's initial positive sequence

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -80,12 +80,9 @@ class DiagnosticsTest(chex.TestCase):
         effective_sample_size = self.variant(
             functools.partial(diagnostics.effective_sample_size, **case)
         )
-        if num_chains > 1:
-            ess_val = effective_sample_size(mc_samples)
-            np.testing.assert_array_equal(ess_val.shape, event_shape)
-            np.testing.assert_allclose(ess_val, num_chains * self.num_samples, rtol=10)
-        else:
-            np.testing.assert_raises(AssertionError, effective_sample_size, mc_samples)
+        ess_val = effective_sample_size(mc_samples)
+        np.testing.assert_array_equal(ess_val.shape, event_shape)
+        np.testing.assert_allclose(ess_val, num_chains * self.num_samples, rtol=10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `effective_sample_size` implementation already contain safeguarding to compute ess when `num_chain == 1`
close #608 

cc @reubenharry 