### PR TITLE
Add transform TO `run_inference_loop`

### DIFF
--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -146,6 +146,7 @@ def run_inference_algorithm(
     inference_algorithm,
     num_steps,
     progress_bar: bool = False,
+    transform = lambda x: x,
 ) -> tuple[State, State, Info]:
     """Wrapper to run an inference algorithm.
 
@@ -180,7 +181,7 @@ def run_inference_algorithm(
     def _one_step(state, xs):
         _, rng_key = xs
         state, info = inference_algorithm.step(rng_key, state)
-        return state, (state, info)
+        return state, (transform(state), info)
 
     if progress_bar:
         one_step = progress_bar_scan(num_steps)(_one_step)

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -161,6 +161,8 @@ def run_inference_algorithm(
         One of blackjax's sampling algorithms or variational inference algorithms.
     num_steps : int
         Number of learning steps.
+    transform:
+        a transformation of the sequence of states to be returned. By default, the states are returned as is.
 
     Returns
     -------

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -146,7 +146,7 @@ def run_inference_algorithm(
     inference_algorithm,
     num_steps,
     progress_bar: bool = False,
-    transform = lambda x: x,
+    transform=lambda x: x,
 ) -> tuple[State, State, Info]:
     """Wrapper to run an inference algorithm.
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -30,6 +30,7 @@ class RunInferenceAlgorithmTest(chex.TestCase):
             self.algorithm,
             self.num_steps,
             progress_bar,
+            transform=lambda x: x.position,
         )
 
     @parameterized.parameters([True, False])


### PR DESCRIPTION
A first step towards issue #615.

A simple change, in case a user doesn't want to store all the history of the state in a large high dimensional run, for reasons of memory.

 A few important guidelines and requirements before we can merge your PR:

 - [x] *If I add a new sampler*, there is an issue discussing it already;
 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;


