### PR TITLE
Extend function signature for InitFn

### DIFF
--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -92,7 +92,7 @@ def mclmc_find_L_and_step_size(
         initial_state = MCMCState(position=0, momentum=1)
 
         # Generate a random number generator key
-        rng_key = jax.random.PRNGKey(0)
+        rng_key = jax.random.key(0)
 
         # Find the optimal parameters for the MCLMC algorithm
         final_state, final_params = mclmc_find_L_and_step_size(

--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -10,7 +10,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, NamedTuple
+from typing import Callable, NamedTuple, Optional
 
 from typing_extensions import Protocol
 
@@ -34,7 +34,7 @@ class InitFn(Protocol):
 
     """
 
-    def __call__(self, position: Position) -> State:
+    def __call__(self, position: Position, rng_key: Optional[PRNGKey]) -> State:
         """Initialize the algorithm's state.
 
         Parameters

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -189,7 +189,8 @@ class barker_proposal:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/mcmc/dynamic_hmc.py
+++ b/blackjax/mcmc/dynamic_hmc.py
@@ -165,7 +165,7 @@ class dynamic_hmc:
 
         def init_fn(position: ArrayLikeTree, rng_key: Array):
             # Note that rng_key here is not necessarily a PRNGKey, could be a Array that
-            # for generates a sequence of pseudo or quasi-random numbers (previously 
+            # for generates a sequence of pseudo or quasi-random numbers (previously
             # named as `random_generator_arg`)
             return cls.init(position, logdensity_fn, rng_key)
 

--- a/blackjax/mcmc/dynamic_hmc.py
+++ b/blackjax/mcmc/dynamic_hmc.py
@@ -163,8 +163,11 @@ class dynamic_hmc:
             integrator, divergence_threshold, next_random_arg_fn, integration_steps_fn
         )
 
-        def init_fn(position: ArrayLikeTree, random_generator_arg: Array):
-            return cls.init(position, logdensity_fn, random_generator_arg)
+        def init_fn(position: ArrayLikeTree, rng_key: Array):
+            # Note that rng_key here is not necessarily a PRNGKey, could be a Array that
+            # for generates a sequence of pseudo or quasi-random numbers (previously 
+            # named as `random_generator_arg`)
+            return cls.init(position, logdensity_fn, rng_key)
 
         def step_fn(rng_key: PRNGKey, state):
             return kernel(
@@ -175,7 +178,7 @@ class dynamic_hmc:
                 inverse_mass_matrix,
             )
 
-        return SamplingAlgorithm(init_fn, step_fn)  # type: ignore[arg-type]
+        return SamplingAlgorithm(init_fn, step_fn)
 
 
 def halton_sequence(i: Array, max_bits: int = 10) -> float:

--- a/blackjax/mcmc/elliptical_slice.py
+++ b/blackjax/mcmc/elliptical_slice.py
@@ -164,7 +164,8 @@ class elliptical_slice:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(cov, mean)
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, loglikelihood_fn)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -287,4 +287,4 @@ class ghmc:
                 delta,
             )
 
-        return SamplingAlgorithm(init_fn, step_fn)  # type: ignore[arg-type]
+        return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/mcmc/hmc.py
+++ b/blackjax/mcmc/hmc.py
@@ -229,7 +229,8 @@ class hmc:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(integrator, divergence_threshold)
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/mcmc/mala.py
+++ b/blackjax/mcmc/mala.py
@@ -177,7 +177,8 @@ class mala:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/mcmc/marginal_latent_gaussian.py
+++ b/blackjax/mcmc/marginal_latent_gaussian.py
@@ -184,18 +184,20 @@ class mgrad_gaussian:
         cls,
         logdensity_fn: Callable,
         covariance: Array,
+        delta: float,
         mean: Optional[Array] = None,
     ) -> SamplingAlgorithm:
         init, kernel = init_and_kernel(logdensity_fn, covariance, mean)
 
-        def init_fn(position: Array):
+        def init_fn(position: Array, rng_key=None):
+            del rng_key
             return init(position)
 
-        def step_fn(rng_key: PRNGKey, state, delta: float):
+        def step_fn(rng_key: PRNGKey, state):
             return kernel(
                 rng_key,
                 state,
                 delta,
             )
 
-        return SamplingAlgorithm(init_fn, step_fn)  # type: ignore[arg-type]
+        return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -155,15 +155,14 @@ class mclmc:
         L,
         step_size,
         integrator=noneuclidean_mclachlan,
-        seed=1,
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(logdensity_fn, integrator)
 
+        def init_fn(position: ArrayLike, rng_key: PRNGKey):
+            return cls.init(position, logdensity_fn, rng_key)
+
         def update_fn(rng_key, state):
             return kernel(rng_key, state, L, step_size)
-
-        def init_fn(position: ArrayLike):
-            return cls.init(position, logdensity_fn, jax.random.PRNGKey(seed))
 
         return SamplingAlgorithm(init_fn, update_fn)
 

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -222,7 +222,8 @@ class nuts:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(integrator, divergence_threshold)
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/mcmc/periodic_orbital.py
+++ b/blackjax/mcmc/periodic_orbital.py
@@ -276,7 +276,8 @@ class orbital_hmc:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(bijection)
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn, period)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -243,7 +243,8 @@ class additive_step_random_walk:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):
@@ -345,7 +346,8 @@ class irmh:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):
@@ -466,7 +468,8 @@ class rmh:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, logdensity_fn)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/sgmcmc/csgld.py
+++ b/blackjax/sgmcmc/csgld.py
@@ -223,7 +223,8 @@ class csgld:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(num_partitions, energy_gap, min_energy)
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position, num_partitions)
 
         def step_fn(

--- a/blackjax/sgmcmc/sghmc.py
+++ b/blackjax/sgmcmc/sghmc.py
@@ -123,7 +123,8 @@ class sghmc:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel(alpha, beta)
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position)
 
         def step_fn(

--- a/blackjax/sgmcmc/sgld.py
+++ b/blackjax/sgmcmc/sgld.py
@@ -109,7 +109,8 @@ class sgld:
     ) -> SamplingAlgorithm:
         kernel = cls.build_kernel()
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position)
 
         def step_fn(

--- a/blackjax/smc/adaptive_tempered.py
+++ b/blackjax/smc/adaptive_tempered.py
@@ -159,7 +159,8 @@ class adaptive_tempered_smc:
             root_solver,
         )
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position)
 
         def step_fn(rng_key: PRNGKey, state):

--- a/blackjax/smc/inner_kernel_tuning.py
+++ b/blackjax/smc/inner_kernel_tuning.py
@@ -139,7 +139,8 @@ class inner_kernel_tuning:
             **extra_parameters,
         )
 
-        def init_fn(position):
+        def init_fn(position, rng_key=None):
+            del rng_key
             return cls.init(smc_algorithm.init, position, initial_parameter_value)
 
         def step_fn(

--- a/blackjax/smc/tempered.py
+++ b/blackjax/smc/tempered.py
@@ -203,7 +203,8 @@ class tempered_smc:
             resampling_fn,
         )
 
-        def init_fn(position: ArrayLikeTree):
+        def init_fn(position: ArrayLikeTree, rng_key=None):
+            del rng_key
             return cls.init(position)
 
         def step_fn(rng_key: PRNGKey, state, lmbda):

--- a/docs/examples/howto_use_oryx.md
+++ b/docs/examples/howto_use_oryx.md
@@ -43,7 +43,7 @@ import jax
 import jax.numpy as jnp
 
 from datetime import date
-rng_key = jax.random.PRNGKey(int(date.today().strftime("%Y%m%d")))
+rng_key = jax.random.key(int(date.today().strftime("%Y%m%d")))
 ```
 
 Oryx's approach, like Aesara's, is to implement probabilistic models as generative models and then apply transformations to get the log-probability density function. We begin with implementing a dense layer with normal prior probability on the weights and use the function `random_variable` to define random variables:

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -44,7 +44,7 @@ def test_chees_adaptation():
     num_chains = 16
     step_size = 0.1
 
-    init_key, warmup_key, inference_key = jax.random.split(jax.random.PRNGKey(0), 3)
+    init_key, warmup_key, inference_key = jax.random.split(jax.random.key(0), 3)
 
     warmup = blackjax.chees_adaptation(
         logprob_fn, num_chains=num_chains, target_acceptance_rate=0.75

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -513,13 +513,7 @@ class LatentGaussianTest(chex.TestCase):
         from blackjax import mgrad_gaussian
 
         inference_algorithm = mgrad_gaussian(
-            lambda x: -0.5 * jnp.sum((x - 1.0) ** 2), self.C
-        )
-        inference_algorithm = inference_algorithm._replace(
-            step=functools.partial(
-                inference_algorithm.step,
-                delta=self.delta,
-            )
+            lambda x: -0.5 * jnp.sum((x - 1.0) ** 2), self.C, self.delta
         )
 
         initial_state = inference_algorithm.init(jnp.zeros((1,)))
@@ -588,8 +582,8 @@ normal_test_cases = [
         "algorithm": blackjax.mala,
         "initial_position": 1.0,
         "parameters": {"step_size": 1e-1},
-        "num_sampling_steps": 20_000,
-        "burnin": 2_000,
+        "num_sampling_steps": 45_000,
+        "burnin": 5_000,
     },
     {
         "algorithm": blackjax.elliptical_slice,

--- a/tests/smc/test_inner_kernel_tuning.py
+++ b/tests/smc/test_inner_kernel_tuning.py
@@ -60,7 +60,7 @@ def log_weights_fn(x, y):
 class SMCParameterTuningTest(chex.TestCase):
     def setUp(self):
         super().setUp()
-        self.key = jax.random.PRNGKey(42)
+        self.key = jax.random.key(42)
 
     def logdensity_fn(self, log_scale, coefs, preds, x):
         """Linear regression"""
@@ -129,7 +129,7 @@ class SMCParameterTuningTest(chex.TestCase):
 class MeanAndStdFromParticlesTest(chex.TestCase):
     def setUp(self):
         super().setUp()
-        self.key = jax.random.PRNGKey(42)
+        self.key = jax.random.key(42)
 
     def test_mean_and_std(self):
         particles = np.array(
@@ -182,7 +182,7 @@ class MeanAndStdFromParticlesTest(chex.TestCase):
 class InverseMassMatrixFromParticles(chex.TestCase):
     def setUp(self):
         super().setUp()
-        self.key = jax.random.PRNGKey(42)
+        self.key = jax.random.key(42)
 
     def test_inverse_mass_matrix_from_particles(self):
         inverse_mass_matrix = mass_matrix_from_particles(


### PR DESCRIPTION
Close #619.

This PR introduce `rng_key` as optional input to `initFn` protocal.

For sampler like `dynamic_hmc` and `ghmc`, the `init_fn` of the top level API does not follow the old patter, as it needs an rng_key to generate part of the `state`. While it is possible to set a default rng_key in the class `__new__`, we actually wants to keep the rng_key as input to `init_fn` as we usually want to vmap init so that it takes a vector of PRNG_key to initialized parallel chains (see eg: in meads_adaptation https://github.com/blackjax-devs/blackjax/blob/08e0d7521b2c06ba29b94a1c186bdaf8c08e6310/blackjax/adaptation/meads_adaptation.py#L209, https://github.com/blackjax-devs/blackjax/blob/08e0d7521b2c06ba29b94a1c186bdaf8c08e6310/blackjax/adaptation/meads_adaptation.py#L239-L240).

Thus, in this PR we introduce rng_key to the `InitFn`, with some minor refactoring to other top level API follows the same contract and easier to plug into utility sampling function `run_inference_algorithm`