### PR TITLE
A draft PR on the removal of Algorithm classes.

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -60,7 +60,6 @@ __all__ = [
     "rmhmc",
     "mala",
     "mgrad_gaussian",
-    "nuts",
     "orbital_hmc",
     "additive_step_random_walk",
     "rmh",

--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -1,3 +1,6 @@
+import dataclasses
+from typing import Callable, Union
+
 from blackjax._version import __version__
 
 from .adaptation.chees_adaptation import chees_adaptation
@@ -5,17 +8,16 @@ from .adaptation.mclmc_adaptation import mclmc_find_L_and_step_size
 from .adaptation.meads_adaptation import meads_adaptation
 from .adaptation.pathfinder_adaptation import pathfinder_adaptation
 from .adaptation.window_adaptation import window_adaptation
+from .base import SamplingAlgorithm
 from .diagnostics import effective_sample_size as ess
 from .diagnostics import potential_scale_reduction as rhat
 from .mcmc.barker import barker_proposal
 from .mcmc.dynamic_hmc import dynamic_hmc
 from .mcmc.elliptical_slice import elliptical_slice
 from .mcmc.ghmc import ghmc
-from .mcmc.hmc import hmc
 from .mcmc.mala import mala
 from .mcmc.marginal_latent_gaussian import mgrad_gaussian
 from .mcmc.mclmc import mclmc
-from .mcmc.nuts import nuts
 from .mcmc.periodic_orbital import orbital_hmc
 from .mcmc.random_walk import additive_step_random_walk, irmh, rmh
 from .mcmc.rmhmc import rmhmc
@@ -31,12 +33,29 @@ from .vi.meanfield_vi import meanfield_vi
 from .vi.pathfinder import pathfinder
 from .vi.schrodinger_follmer import schrodinger_follmer
 from .vi.svgd import svgd
+from .mcmc import hmc as _hmc
+from .mcmc import nuts as _nuts
+
+
+@dataclasses.dataclass
+class SamplingAlgorithmFactory:
+    differentiable_callable: Callable
+    init: Callable
+    build_kernel: Callable
+
+    def __call__(self, *args, **kwargs) -> SamplingAlgorithm:
+        return self.differentiable_callable(*args, **kwargs)
+
+
+hmc = SamplingAlgorithmFactory(_hmc.as_sampling_algorithm, _hmc.init, _hmc.build_kernel)
+nuts = SamplingAlgorithmFactory(_nuts.as_sampling_algorithm, _nuts.init, _nuts.build_kernel)
+
+hmc_family = [hmc, nuts]
 
 __all__ = [
     "__version__",
     "dual_averaging",  # optimizers
     "lbfgs",
-    "hmc",  # mcmc
     "dynamic_hmc",
     "rmhmc",
     "mala",

--- a/blackjax/adaptation/pathfinder_adaptation.py
+++ b/blackjax/adaptation/pathfinder_adaptation.py
@@ -138,7 +138,7 @@ def base(
 
 
 def pathfinder_adaptation(
-    algorithm: Union[mcmc.hmc.hmc, mcmc.nuts.nuts],
+    algorithm,
     logdensity_fn: Callable,
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -17,7 +17,6 @@ from typing import Callable, NamedTuple, Union
 import jax
 import jax.numpy as jnp
 
-import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import AdaptationInfo, AdaptationResults
 from blackjax.adaptation.mass_matrix import (
     MassMatrixAdaptationState,
@@ -243,7 +242,7 @@ def base(
 
 
 def window_adaptation(
-    algorithm: Union[mcmc.hmc.hmc, mcmc.nuts.nuts],
+    algorithm,
     logdensity_fn: Callable,
     is_mass_matrix_diagonal: bool = True,
     initial_step_size: float = 1.0,
@@ -252,7 +251,7 @@ def window_adaptation(
     **extra_parameters,
 ) -> AdaptationAlgorithm:
     """Adapt the value of the inverse mass matrix and step size parameters of
-    algorithms in the HMC fmaily.
+    algorithms in the HMC family.  See Blackjax.hmc_family
 
     Algorithms in the HMC family on a euclidean manifold depend on the value of
     at least two parameters: the step size, related to the trajectory

--- a/blackjax/mcmc/hmc.py
+++ b/blackjax/mcmc/hmc.py
@@ -29,7 +29,7 @@ __all__ = [
     "HMCInfo",
     "init",
     "build_kernel",
-    "hmc",
+    "as_sampling_algorithm",
 ]
 
 
@@ -150,7 +150,14 @@ def build_kernel(
     return kernel
 
 
-class hmc:
+def as_sampling_algorithm(logdensity_fn: Callable,
+        step_size: float,
+        inverse_mass_matrix: metrics.MetricTypes,
+        num_integration_steps: int,
+        *,
+        divergence_threshold: int = 1000,
+        integrator: Callable = integrators.velocity_verlet,
+    ) -> SamplingAlgorithm:
     """Implements the (basic) user interface for the HMC kernel.
 
     The general hmc kernel builder (:meth:`blackjax.mcmc.hmc.build_kernel`, alias
@@ -225,36 +232,24 @@ class hmc:
     A ``SamplingAlgorithm``.
     """
 
-    init = staticmethod(init)
-    build_kernel = staticmethod(build_kernel)
 
-    def __new__(  # type: ignore[misc]
-        cls,
-        logdensity_fn: Callable,
-        step_size: float,
-        inverse_mass_matrix: metrics.MetricTypes,
-        num_integration_steps: int,
-        *,
-        divergence_threshold: int = 1000,
-        integrator: Callable = integrators.velocity_verlet,
-    ) -> SamplingAlgorithm:
-        kernel = cls.build_kernel(integrator, divergence_threshold)
+    kernel = build_kernel(integrator, divergence_threshold)
 
-        def init_fn(position: ArrayLikeTree, rng_key=None):
-            del rng_key
-            return cls.init(position, logdensity_fn)
+    def init_fn(position: ArrayLikeTree, rng_key=None):
+        del rng_key
+        return init(position, logdensity_fn)
 
-        def step_fn(rng_key: PRNGKey, state):
-            return kernel(
-                rng_key,
-                state,
-                logdensity_fn,
-                step_size,
-                inverse_mass_matrix,
-                num_integration_steps,
-            )
+    def step_fn(rng_key: PRNGKey, state):
+        return kernel(
+            rng_key,
+            state,
+            logdensity_fn,
+            step_size,
+            inverse_mass_matrix,
+            num_integration_steps,
+        )
 
-        return SamplingAlgorithm(init_fn, step_fn)
+    return SamplingAlgorithm(init_fn, step_fn)
 
 
 def hmc_proposal(
@@ -341,3 +336,5 @@ def flip_momentum(
         state.logdensity,
         state.logdensity_grad,
     )
+
+

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -27,7 +27,7 @@ import blackjax.mcmc.trajectory as trajectory
 from blackjax.base import SamplingAlgorithm
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
 
-__all__ = ["NUTSInfo", "init", "build_kernel", "nuts"]
+__all__ = ["NUTSInfo", "init", "build_kernel", "as"]
 
 
 init = hmc.init
@@ -147,7 +147,14 @@ def build_kernel(
     return kernel
 
 
-class nuts:
+def as_sampling_algorithm(logdensity_fn: Callable,
+        step_size: float,
+        inverse_mass_matrix: metrics.MetricTypes,
+        *,
+        max_num_doublings: int = 10,
+        divergence_threshold: int = 1000,
+        integrator: Callable = integrators.velocity_verlet,
+    ) -> SamplingAlgorithm:
     """Implements the (basic) user interface for the nuts kernel.
 
     Examples
@@ -202,37 +209,23 @@ class nuts:
     A ``SamplingAlgorithm``.
 
     """
+    kernel = build_kernel(integrator, divergence_threshold)
 
-    init = staticmethod(hmc.init)
-    build_kernel = staticmethod(build_kernel)
+    def init_fn(position: ArrayLikeTree, rng_key=None):
+        del rng_key
+        return init(position, logdensity_fn)
 
-    def __new__(  # type: ignore[misc]
-        cls,
-        logdensity_fn: Callable,
-        step_size: float,
-        inverse_mass_matrix: metrics.MetricTypes,
-        *,
-        max_num_doublings: int = 10,
-        divergence_threshold: int = 1000,
-        integrator: Callable = integrators.velocity_verlet,
-    ) -> SamplingAlgorithm:
-        kernel = cls.build_kernel(integrator, divergence_threshold)
+    def step_fn(rng_key: PRNGKey, state):
+        return kernel(
+            rng_key,
+            state,
+            logdensity_fn,
+            step_size,
+            inverse_mass_matrix,
+            max_num_doublings,
+        )
 
-        def init_fn(position: ArrayLikeTree, rng_key=None):
-            del rng_key
-            return cls.init(position, logdensity_fn)
-
-        def step_fn(rng_key: PRNGKey, state):
-            return kernel(
-                rng_key,
-                state,
-                logdensity_fn,
-                step_size,
-                inverse_mass_matrix,
-                max_num_doublings,
-            )
-
-        return SamplingAlgorithm(init_fn, step_fn)
+    return SamplingAlgorithm(init_fn, step_fn)
 
 
 def iterative_nuts_proposal(


### PR DESCRIPTION
This is a super draft PR showcasing how can we remove the algorithm classes. These are static classes we don't use directly, but via calling `new` and getting a `SamplingAlgorithm` result. This PR:

- replaces these classes with instances of a single class so now each module contains: an init, build_kernel and a as_sampling_algorithm functions. The idea is that the latter fixes dependencies/parameters, in particular when these are not differentiable. The init and build_kernel still exist and are exposed since we need that lower level API, specially when composing algorithms (for example, when tuning SMC inner kernel we need to be able to change parameter on every call).

By doing this we still can call algorithms directly, like blackjax.hmc(). What we do loose is the (light) type annotations we are doing, for example in window_adaptation. I have been thinking about this type of annotations, and I think we should remove them. 

The reason for doing it is the following: python fosters duck and structural typing, in contrast to nominal typing like you can find in say Java. In the case of window adaptation, we want the type to mean "hmc family" as algorithms that have an inverse_mass_matrix and a step size. But the way is implemented right now, it actually means whatever the class hmc or the class nuts does! So the classes kind of exist just to be able to name them (aka to use nominal typing). Since most of our codebase is functional, from a typing perspective most samplers are Callables that take in matrixes, doubles, pytrees and return something of the same flavours. There's no way to say: this is the type of a callable that takes in an inverse_mass_matrix and a step size and uses it in some consistent way, because that is not duck typing nor structural! aka we are trying to statically type using tools that are not pythonic. I'd suggest we replace this kind of "algorithm level" type annotations with docs and tests. Check for example the smc_compatibility_test 

PD: I haven't repeated the pattern throughout the codebase so as to illustrate the point with a simple example.



