### PR TITLE
Fix deprecated call to jnp.clip

### DIFF
--- a/blackjax/mcmc/proposal.py
+++ b/blackjax/mcmc/proposal.py
@@ -153,7 +153,7 @@ def progressive_biased_sampling(
     biases the transition away from the trajectory's initial state.
 
     """
-    p_accept = jnp.clip(jnp.exp(new_proposal.weight - proposal.weight), a_max=1)
+    p_accept = jnp.clip(jnp.exp(new_proposal.weight - proposal.weight), max=1)
     do_accept = jax.random.bernoulli(rng_key, p_accept)
     new_weight = jnp.logaddexp(proposal.weight, new_proposal.weight)
     new_sum_log_p_accept = jnp.logaddexp(
@@ -224,7 +224,7 @@ def static_binomial_sampling(
     then the new proposal is accepted with probability 1.
 
     """
-    p_accept = jnp.clip(jnp.exp(log_p_accept), a_max=1)
+    p_accept = jnp.clip(jnp.exp(log_p_accept), max=1)
     do_accept = jax.random.bernoulli(rng_key, p_accept)
     info = do_accept, p_accept, None
     return (
@@ -253,7 +253,7 @@ def nonreversible_slice_sampling(
     to the accept/reject step of a current state and new proposal.
 
     """
-    p_accept = jnp.clip(jnp.exp(delta_energy), a_max=1)
+    p_accept = jnp.clip(jnp.exp(delta_energy), max=1)
     do_accept = jnp.log(jnp.abs(slice)) <= delta_energy
     slice_next = slice * (jnp.exp(-delta_energy) * do_accept + (1 - do_accept))
     info = do_accept, p_accept, slice_next


### PR DESCRIPTION
# Thank you for opening a PR!

Since [jax 0.4.27](https://jax.readthedocs.io/en/latest/changelog.html#jax-0-4-27-may-7-2024), `jax.numpy.clip` has a new signature.

Fixes #663

 A few important guidelines and requirements before we can merge your PR:

 - [ ] *If I add a new sampler*, there is an issue discussing it already;
 - [ ] We should be able to understand what the PR does from its title only;
 - [ ] There is a high-level description of the changes;
 - [ ] There are links to *all* the relevant issues, discussions and PRs;
 - [ ] The branch is rebased on the latest `main` commit;
 - [ ] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [ ] The code respects the current naming conventions;
 - [ ] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [ ] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [ ] There are tests covering the changes;
 - [ ] The doc is up-to-date;
 - [ ] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
