### PR TITLE
Draft

### DIFF
--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -159,8 +159,7 @@ def run_inference_algorithm(
     rng_key
         The random state used by JAX's random numbers generator.
     initial_state_or_position
-        The initial state OR the initial position of the inference algorithm. If an initial position
-        is passed in, the function will automatically convert it into an initial state.
+        The initial state of the inference algorithm.
     inference_algorithm
         One of blackjax's sampling algorithms or variational inference algorithms.
     num_steps

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -167,7 +167,7 @@ def run_inference_algorithm(
     progress_bar
         Whether to display a progress bar.
     transform
-        A transformation of the trace of states to be returned. This is useful for
+        A transform of the trace of states to be returned. This is useful for
         computing determinstic variables, or returning a subset of the states.
         By default, the states are returned as is.
 


### PR DESCRIPTION
# Remove option to give `initial_position` from `run_inference_algorithm`.

**Description**:

`run_inference_algorithm` currently uses a try-except clause to allow the user to either provide an initial position or an initial state. This has led to some problems, when the `except` clause fails to trigger.

More broadly, there doesn't seem to be a good reason to 

**Solution**:

Make `run_inference_algorithm` only take `initial_state`, so that the caller of `run_inference_algorithm` is responsible for providing `initial_state` from `initial_position`, rather than deferring this task.


 A few important guidelines and requirements before we can merge your PR:

 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [ ] The doc is up-to-date;

