### PR TITLE
FIX KWARG BUG

### DIFF
--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -80,7 +80,9 @@ def build_kernel(logdensity_fn, sqrt_diag_cov, integrator):
 
     """
 
-    step = with_isokinetic_maruyama(integrator(logdensity_fn=logdensity_fn, sqrt_diag_cov=sqrt_diag_cov))
+    step = with_isokinetic_maruyama(
+        integrator(logdensity_fn=logdensity_fn, sqrt_diag_cov=sqrt_diag_cov)
+    )
 
     def kernel(
         rng_key: PRNGKey, state: IntegratorState, L: float, step_size: float

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -80,7 +80,7 @@ def build_kernel(logdensity_fn, sqrt_diag_cov, integrator):
 
     """
 
-    step = with_isokinetic_maruyama(integrator(logdensity_fn, sqrt_diag_cov))
+    step = with_isokinetic_maruyama(integrator(logdensity_fn=logdensity_fn, sqrt_diag_cov=sqrt_diag_cov))
 
     def kernel(
         rng_key: PRNGKey, state: IntegratorState, L: float, step_size: float


### PR DESCRIPTION
This is a small change which addresses quite a severe bug, namely that kwargs.get was not picking up the intended argument (because it was not passed as a kwarg)