### PR TITLE
Make Window Adaptation Take Integrator As Argument

### DIFF
--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -17,6 +17,7 @@ from typing import Callable, NamedTuple
 import jax
 import jax.numpy as jnp
 
+import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
 from blackjax.adaptation.mass_matrix import (
     MassMatrixAdaptationState,
@@ -249,10 +250,11 @@ def window_adaptation(
     target_acceptance_rate: float = 0.80,
     progress_bar: bool = False,
     adaptation_info_fn: Callable = return_all_adapt_info,
+    integrator=mcmc.integrators.velocity_verlet,
     **extra_parameters,
 ) -> AdaptationAlgorithm:
     """Adapt the value of the inverse mass matrix and step size parameters of
-    algorithms in the HMC family.  See Blackjax.hmc_family
+    algorithms in the HMC fmaily. See Blackjax.hmc_family
 
     Algorithms in the HMC family on a euclidean manifold depend on the value of
     at least two parameters: the step size, related to the trajectory
@@ -294,7 +296,7 @@ def window_adaptation(
 
     """
 
-    mcmc_kernel = algorithm.build_kernel()
+    mcmc_kernel = algorithm.build_kernel(integrator)
 
     adapt_init, adapt_step, adapt_final = base(
         is_mass_matrix_diagonal,


### PR DESCRIPTION
Window adaptation did not previously accept an `integrator` argument, but instead used `velocity_verlet`. This was restrictive, since a user may want to run NUTS or HMC with a different integrator (such as `mclachlan`). They can do so, but then cannot use window adaptation. This PR addresses that shortcoming.