### PR TITLE
Enable shared mcmc parameters with tempered smc

### DIFF
--- a/blackjax/smc/adaptive_tempered.py
+++ b/blackjax/smc/adaptive_tempered.py
@@ -130,7 +130,8 @@ def as_top_level_api(
     mcmc_init_fn
         The MCMC init function used to build a MCMC state from a particle position.
     mcmc_parameters
-        The parameters of the MCMC step function.
+        The parameters of the MCMC step function.  Parameters with leading dimension
+        length of 1 are shared amongst the particles.
     resampling_fn
         The function used to resample the particles.
     target_ess

--- a/blackjax/smc/base.py
+++ b/blackjax/smc/base.py
@@ -150,12 +150,9 @@ def step(
     )
 
 
-def extend_params(n_particles, params):
+def extend_params(params):
     """Given a dictionary of params, repeats them for every single particle. The expected
     usage is in cases where the aim is to repeat the same parameters for all chains within SMC.
     """
 
-    def extend(param):
-        return jnp.repeat(jnp.asarray(param)[None, ...], n_particles, axis=0)
-
-    return jax.tree.map(extend, params)
+    return jax.tree.map(lambda x: jnp.asarray(x)[None, ...], params)

--- a/blackjax/smc/tempered.py
+++ b/blackjax/smc/tempered.py
@@ -109,6 +109,9 @@ def build_kernel(
             Current state of the tempered SMC algorithm
         lmbda
             Current value of the tempering parameter
+        mcmc_parameters
+            The parameters of the MCMC step function.  Parameters with leading dimension
+            length of 1 are shared amongst the particles.
 
         Returns
         -------
@@ -120,12 +123,13 @@ def build_kernel(
         """
         delta = lmbda - state.lmbda
 
-        shared_mcmc_parameters = {
-            k: v[0, ...] for k, v in mcmc_parameters.items() if v.shape[0] == 1
-        }
-        unshared_mcmc_parameters = {
-            k: v for k, v in mcmc_parameters.items() if v.shape[0] != 1
-        }
+        shared_mcmc_parameters = {}
+        unshared_mcmc_parameters = {}
+        for k, v in mcmc_parameters.items():
+            if v.shape[0] == 1:
+                shared_mcmc_parameters[k] = v[0, ...]
+            else:
+                unshared_mcmc_parameters[k] = v
 
         def log_weights_fn(position: ArrayLikeTree) -> float:
             return delta * loglikelihood_fn(position)
@@ -188,7 +192,8 @@ def as_top_level_api(
     mcmc_init_fn
         The MCMC init function used to build a MCMC state from a particle position.
     mcmc_parameters
-        The parameters of the MCMC step function.
+        The parameters of the MCMC step function.  Parameters with leading dimension
+        length of 1 are shared amongst the particles.
     resampling_fn
         The function used to resample the particles.
     num_mcmc_steps

--- a/tests/smc/test_inner_kernel_tuning.py
+++ b/tests/smc/test_inner_kernel_tuning.py
@@ -281,7 +281,7 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
 
         def parameter_update(state, info):
             return extend_params(
-                100,
+                1,
                 {
                     "inverse_mass_matrix": mass_matrix_from_particles(state.particles),
                     "step_size": 10e-2,
@@ -298,7 +298,7 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
             resampling.systematic,
             mcmc_parameter_update_fn=parameter_update,
             initial_parameter_value=extend_params(
-                100,
+                1,
                 dict(
                     inverse_mass_matrix=jnp.eye(2),
                     step_size=10e-2,
@@ -326,7 +326,7 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
 
         _, state = inference_loop(smc_kernel, self.key, init_state)
 
-        assert state.parameter_override["inverse_mass_matrix"].shape == (100, 2, 2)
+        assert state.parameter_override["inverse_mass_matrix"].shape == (1, 2, 2)
         self.assert_linear_regression_test_case(state.sampler_state)
 
     @chex.all_variants(with_pmap=False)
@@ -340,7 +340,7 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
 
         def parameter_update(state, info):
             return extend_params(
-                100,
+                1,
                 {
                     "inverse_mass_matrix": mass_matrix_from_particles(state.particles),
                     "step_size": 10e-2,
@@ -357,7 +357,7 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
             resampling.systematic,
             mcmc_parameter_update_fn=parameter_update,
             initial_parameter_value=extend_params(
-                100,
+                1,
                 dict(
                     inverse_mass_matrix=jnp.eye(2),
                     step_size=10e-2,

--- a/tests/smc/test_inner_kernel_tuning.py
+++ b/tests/smc/test_inner_kernel_tuning.py
@@ -94,7 +94,7 @@ class SMCParameterTuningTest(chex.TestCase):
         proposal_factory.return_value = 100
 
         def mcmc_parameter_update_fn(state, info):
-            return extend_params(1000, {"mean": 100})
+            return extend_params({"mean": 100})
 
         prior = lambda x: stats.norm.logpdf(x)
 
@@ -114,7 +114,7 @@ class SMCParameterTuningTest(chex.TestCase):
             resampling_fn=resampling.systematic,
             smc_algorithm=smc_algorithm,
             mcmc_parameter_update_fn=mcmc_parameter_update_fn,
-            initial_parameter_value=extend_params(1000, {"mean": 1.0}),
+            initial_parameter_value=extend_params({"mean": 1.0}),
             **smc_parameters,
         )
 
@@ -281,7 +281,6 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
 
         def parameter_update(state, info):
             return extend_params(
-                1,
                 {
                     "inverse_mass_matrix": mass_matrix_from_particles(state.particles),
                     "step_size": 10e-2,
@@ -298,7 +297,6 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
             resampling.systematic,
             mcmc_parameter_update_fn=parameter_update,
             initial_parameter_value=extend_params(
-                1,
                 dict(
                     inverse_mass_matrix=jnp.eye(2),
                     step_size=10e-2,
@@ -340,7 +338,6 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
 
         def parameter_update(state, info):
             return extend_params(
-                1,
                 {
                     "inverse_mass_matrix": mass_matrix_from_particles(state.particles),
                     "step_size": 10e-2,
@@ -357,7 +354,6 @@ class InnerKernelTuningJitTest(SMCLinearRegressionTestCase):
             resampling.systematic,
             mcmc_parameter_update_fn=parameter_update,
             initial_parameter_value=extend_params(
-                1,
                 dict(
                     inverse_mass_matrix=jnp.eye(2),
                     step_size=10e-2,

--- a/tests/smc/test_kernel_compatibility.py
+++ b/tests/smc/test_kernel_compatibility.py
@@ -50,7 +50,7 @@ class SMCAndMCMCIntegrationTest(unittest.TestCase):
         self.check_compatible(
             kernel,
             blackjax.additive_step_random_walk.init,
-            extend_params(self.n_particles, {"proposal_mean": 1.0}),
+            extend_params({"proposal_mean": 1.0}),
         )
 
     def test_compatible_with_rmh(self):
@@ -70,7 +70,7 @@ class SMCAndMCMCIntegrationTest(unittest.TestCase):
         self.check_compatible(
             kernel,
             blackjax.rmh.init,
-            extend_params(self.n_particles, {"proposal_mean": 1.0}),
+            extend_params({"proposal_mean": 1.0}),
         )
 
     def test_compatible_with_hmc(self):
@@ -78,7 +78,6 @@ class SMCAndMCMCIntegrationTest(unittest.TestCase):
             blackjax.hmc.build_kernel(),
             blackjax.hmc.init,
             extend_params(
-                self.n_particles,
                 {
                     "step_size": 0.3,
                     "inverse_mass_matrix": jnp.array([1.0]),
@@ -100,7 +99,7 @@ class SMCAndMCMCIntegrationTest(unittest.TestCase):
         self.check_compatible(
             kernel,
             blackjax.irmh.init,
-            extend_params(self.n_particles, {"mean": jnp.array([1.0, 1.0])}),
+            extend_params({"mean": jnp.array([1.0, 1.0])}),
         )
 
     def test_compatible_with_nuts(self):
@@ -108,7 +107,6 @@ class SMCAndMCMCIntegrationTest(unittest.TestCase):
             blackjax.nuts.build_kernel(),
             blackjax.nuts.init,
             extend_params(
-                self.n_particles,
                 {"step_size": 1e-10, "inverse_mass_matrix": jnp.eye(2)},
             ),
         )
@@ -117,7 +115,7 @@ class SMCAndMCMCIntegrationTest(unittest.TestCase):
         self.check_compatible(
             blackjax.mala.build_kernel(),
             blackjax.mala.init,
-            extend_params(self.n_particles, {"step_size": 1e-10}),
+            extend_params({"step_size": 1e-10}),
         )
 
     @staticmethod

--- a/tests/smc/test_tempered_smc.py
+++ b/tests/smc/test_tempered_smc.py
@@ -65,16 +65,25 @@ class TemperedSMCTest(SMCLinearRegressionTestCase):
 
         hmc_kernel = blackjax.hmc.build_kernel()
         hmc_init = blackjax.hmc.init
-        hmc_parameters = extend_params(
-            num_particles,
-            {
-                "step_size": 10e-2,
-                "inverse_mass_matrix": jnp.eye(2),
-                "num_integration_steps": 50,
-            },
+        hmc_parameters_list = [
+            extend_params(
+                num_particles if extend else 1,
+                {
+                    "step_size": 10e-2,
+                    "inverse_mass_matrix": jnp.eye(2),
+                    "num_integration_steps": 50,
+                },
+            )
+            for extend in [True, False]
+        ]
+        hmc_parameters_list.append(
+            extend_params(
+                num_particles, {"step_size": 10e-2, "num_integration_steps": 50}
+            )
+            | extend_params(num_particles, {"inverse_mass_matrix": jnp.eye(2)})
         )
 
-        for target_ess in [0.5, 0.75]:
+        for target_ess, hmc_parameters in zip([0.5, 0.5, 0.75], hmc_parameters_list):
             tempering = adaptive_tempered_smc(
                 logprior_fn,
                 loglikelihood_fn,
@@ -115,7 +124,7 @@ class TemperedSMCTest(SMCLinearRegressionTestCase):
         hmc_init = blackjax.hmc.init
         hmc_kernel = blackjax.hmc.build_kernel()
         hmc_parameters = extend_params(
-            100,
+            1,
             {
                 "step_size": 10e-2,
                 "inverse_mass_matrix": jnp.eye(2),


### PR DESCRIPTION
Allows for `mcmc_parameters` to be passed to the mcmc kernel as shared parameters prior to applying vmap.  Thus shared parameters will not need to be duplicated for each individual particle.

This change filters `mcmc_parameters` by the length of the first dimension.  Any parameters with length 1 are considered shared (note this is also acceptable in the case of just a single particle) and the rest are unshared.  Shared parameters are then closed over before applying vmap so they don't need duplication.  The behavior remains the same for shared parameters that are duplicated as they are just treated as unshared as before.  This seems like the most reasonable way to handle shared parameters but let me know.

Related to https://github.com/blackjax-devs/blackjax/issues/690
cc @ciguaran

Some notes:
- the some of tests in test_kernel_compatibility.py can use 1 instead of self.n_particles though the correct choice arguably depends on the meaning of the parameter - I changed the ones in test_inner_kernel_tuning.py that were apparently shared
- https://blackjax-devs.github.io/sampling-book/algorithms/TemperedSMC.html and https://blackjax-devs.github.io/sampling-book/algorithms/TemperedSMCWithOptimizedInnerKernel.html should probably change to avoid duplication of the shared parameters
- I couldn't find a way to filter shared/unshared parameters with jax.tree_util functions - None always remains in the structure but maybe I missed something