### PR TITLE
Convert explicit looping to bit twiddling for iterative_uturn calculations

### DIFF
--- a/blackjax/mcmc/termination.py
+++ b/blackjax/mcmc/termination.py
@@ -64,16 +64,10 @@ def iterative_uturn_numpyro(is_turning: CheckTurning):
         """Find the checkpoint id from a step number."""
         # computes the number of non-zero bits except the last bit
         # e.g. 6 -> 2, 7 -> 2, 13 -> 2
-        _, idx_max = jax.lax.while_loop(
-            lambda nc: nc[0] > 0,
-            lambda nc: (nc[0] >> 1, nc[1] + (nc[0] & 1)),
-            (n >> 1, 0),
-        )
+        idx_max = jnp.bitwise_count(n >> 1).astype(jnp.int32)
         # computes the number of contiguous last non-zero bits
         # e.g. 6 -> 0, 7 -> 3, 13 -> 1
-        _, num_subtrees = jax.lax.while_loop(
-            lambda nc: (nc[0] & 1) != 0, lambda nc: (nc[0] >> 1, nc[1] + 1), (n, 0)
-        )
+        num_subtrees = jnp.bitwise_count((~n & (n + 1)) - 1).astype(jnp.int32)
         idx_min = idx_max - num_subtrees + 1
         return idx_min, idx_max
 


### PR DESCRIPTION
Removes explicit looping for calculating the uturn checks to perform and replaces it with bitwise calculations.

I don't see much performance difference with a cpu backend but it gives ~30% boost with gpu on some models I'm working with.  This clearly will depend on the model and # of steps though.  For `jnp.bitwise_count((~n & (n + 1)) - 1)`   `(~n & (n + 1))` isolates the bit that changes from 0 to 1 when adding 1 - this is the first zero before the last sequence of ones.  `- 1` clears the above bit and sets all the original last non-zero bits 

