### PR TITLE
Enable progress bar under pmap

### DIFF
--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -41,14 +41,11 @@ def progress_bar_scan(num_samples, print_rate=None):
         idx_map[iter_num] += 1
         return idx
 
-    def _define_bar(arg):
-        del arg
-        idx = len(progress_bars)
-        progress_bars[idx] = progress_bar(range(num_samples))
-        progress_bars[idx].update(0)
-
     def _update_bar(arg):
         idx = _calc_chain_idx(arg)
+        if arg == 0:
+            progress_bars[idx] = progress_bar(range(num_samples))
+            progress_bars[idx].update(0)
         progress_bars[idx].update_bar(arg + 1)
 
     def _close_bar(arg):
@@ -57,12 +54,6 @@ def progress_bar_scan(num_samples, print_rate=None):
 
     def _update_progress_bar(iter_num):
         "Updates progress bar of a JAX scan or loop"
-        _ = lax.cond(
-            iter_num == 0,
-            lambda _: io_callback(_define_bar, None, iter_num),
-            lambda _: None,
-            operand=None,
-        )
 
         _ = lax.cond(
             # update every multiple of `print_rate` except at the end

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -14,10 +14,11 @@
 """Progress bar decorators for use with step functions.
 Adapted from Jeremie Coullon's blog post :cite:p:`progress_bar`.
 """
+from threading import Lock
+
 from fastprogress.fastprogress import progress_bar
 from jax import lax
 from jax.experimental import io_callback
-from threading import Lock
 
 
 def progress_bar_scan(num_samples, print_rate=None):

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -224,13 +224,19 @@ def run_inference_algorithm(
 
     one_step = jax.jit(partial(one_step, return_state=return_state_history))
 
+    xs = (jnp.arange(num_steps), keys)
     if progress_bar:
         one_step = progress_bar_scan(num_steps)(one_step)
+        (((_, average), final_state), _), history = lax.scan(
+            one_step,
+            (((0, expectation(transform(initial_state))), initial_state), -1),
+            xs,
+        )
 
-    xs = (jnp.arange(num_steps), keys)
-    ((_, average), final_state), history = lax.scan(
-        one_step, ((0, expectation(transform(initial_state))), initial_state), xs
-    )
+    else:
+        ((_, average), final_state), history = lax.scan(
+            one_step, ((0, expectation(transform(initial_state))), initial_state), xs
+        )
 
     if not return_state_history:
         return average, transform(final_state)


### PR DESCRIPTION
Enables proper progress bar behavior of `progress_bar_scan` under pmap.  However the progress bars are not tied to physical devices since `io_callback` won't expose the device id.  The bars behave as if they are physically tied but are always sorted by most to least complete (they're actually randomly shuffled but one bar will always be first and another last).

I haven't visually tested this under a multi-gpu setup as I don't have an identical pair of gpus - just using `JAX_PLATFORMS='cpu'`


https://github.com/blackjax-devs/blackjax/pull/655 - Related: changes progress bar to tqdm and requires the user to label devices - a different approach

 A few important guidelines and requirements before we can merge your PR:

 - [ ] We should be able to understand what the PR does from its title only;
 - [ ] There is a high-level description of the changes;
 - [ ] There are links to *all* the relevant issues, discussions and PRs;
 - [ ] The branch is rebased on the latest `main` commit;
 - [ ] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [ ] The code respects the current naming conventions;
 - [ ] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [ ] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [ ] There are tests covering the changes;
 - [ ] The doc is up-to-date;

