### PR TITLE
Streamline `run_inference_algorithm` and the streaming average

### DIFF
--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
 from blackjax.diagnostics import effective_sample_size
-from blackjax.util import pytree_size, incremental_value_update
+from blackjax.util import incremental_value_update, pytree_size
 
 
 class MCLMCAdaptationState(NamedTuple):
@@ -199,7 +199,7 @@ def make_L_step_size_adaptation(
 
         x = ravel_pytree(state.position)[0]
         # update the running average of x, x^2
-        streaming_avg = streaming_average_update(
+        streaming_avg = incremental_value_update(
             current_value=jnp.array([x, jnp.square(x)]),
             previous_weight_and_average=streaming_avg,
             weight=(1 - mask) * success * params.step_size,

--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -200,8 +200,8 @@ def make_L_step_size_adaptation(
         x = ravel_pytree(state.position)[0]
         # update the running average of x, x^2
         streaming_avg = streaming_average_update(
-            expectation=jnp.array([x, jnp.square(x)]),
-            streaming_avg=streaming_avg,
+            current_value=jnp.array([x, jnp.square(x)]),
+            previous_weight_and_average=streaming_avg,
             weight=(1 - mask) * success * params.step_size,
             zero_prevention=mask,
         )

--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
 from blackjax.diagnostics import effective_sample_size
-from blackjax.util import pytree_size, streaming_average_update
+from blackjax.util import pytree_size, incremental_value_update
 
 
 class MCLMCAdaptationState(NamedTuple):

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -279,7 +279,7 @@ def run_inference_algorithm(
     if progress_bar:
         one_step = progress_bar_scan(num_steps)(one_step)
 
-    xs = (jnp.arange(num_steps), keys)
+    xs = jnp.arange(num_steps), keys
     final_state, history = lax.scan(one_step, initial_state, xs)
     return final_state, history
 

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -10,7 +10,7 @@ from jax.flatten_util import ravel_pytree
 from jax.random import normal, split
 from jax.tree_util import tree_leaves
 
-from blackjax.base import SamplingAlgorithm, VIAlgorithm
+from blackjax.base import Info, SamplingAlgorithm, State, VIAlgorithm
 from blackjax.progress_bar import progress_bar_scan
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
@@ -142,6 +142,77 @@ def index_pytree(input_pytree: ArrayLikeTree) -> ArrayTree:
     return unravel_fn(array)
 
 
+# def run_inference_algorithm(
+#     rng_key: PRNGKey,
+#     inference_algorithm: Union[SamplingAlgorithm, VIAlgorithm],
+#     num_steps: int,
+#     initial_state: ArrayLikeTree = None,
+#     initial_position: ArrayLikeTree = None,
+#     progress_bar: bool = False,
+#     transform: Callable = lambda x: x,
+# ) -> tuple[State, State, Info]:
+    
+    
+#     """Wrapper to run an inference algorithm.
+
+#     Note that this utility function does not work for Stochastic Gradient MCMC samplers
+#     like sghmc, as SG-MCMC samplers require additional control flow for batches of data
+#     to be passed in during each sample.
+
+#     Parameters
+#     ----------
+#     rng_key
+#         The random state used by JAX's random numbers generator.
+#     initial_state_or_position
+#         The initial state OR the initial position of the inference algorithm. If an initial position
+#         is passed in, the function will automatically convert it into an initial state.
+#     inference_algorithm
+#         One of blackjax's sampling algorithms or variational inference algorithms.
+#     num_steps
+#         Number of MCMC steps.
+#     progress_bar
+#         Whether to display a progress bar.
+#     transform
+#         A transformation of the trace of states to be returned. This is useful for
+#         computing determinstic variables, or returning a subset of the states.
+#         By default, the states are returned as is.
+
+#     Returns
+#     -------
+#     Tuple[State, State, Info]
+#         1. The final state of the inference algorithm.
+#         2. The trace of states of the inference algorithm (contains the MCMC samples).
+#         3. The trace of the info of the inference algorithm for diagnostics.
+#     """
+
+#     if initial_state is None and initial_position is None:
+#         raise ValueError("Either initial_state or initial_position must be provided.")
+#     if initial_state is not None and initial_position is not None:
+#         raise ValueError(
+#             "Only one of initial_state or initial_position must be provided."
+#         )
+    
+#     init_key, sample_key = split(rng_key, 2)
+#     if initial_position is not None:
+#         initial_state = inference_algorithm.init(initial_position, init_key)
+    
+#     keys = split(sample_key, num_steps)
+
+#     @jit
+#     def _one_step(state, xs):
+#         _, rng_key = xs
+#         state, info = inference_algorithm.step(rng_key, state)
+#         return state, transform(state, info)
+
+#     if progress_bar:
+#         one_step = progress_bar_scan(num_steps)(_one_step)
+#     else:
+#         one_step = _one_step
+
+#     xs = (jnp.arange(num_steps), keys)
+#     final_state, (state_history, info_history) = lax.scan(one_step, initial_state, xs)
+#     return final_state, state_history, info_history
+
 def run_inference_algorithm(
     rng_key: PRNGKey,
     inference_algorithm: Union[SamplingAlgorithm, VIAlgorithm],
@@ -149,9 +220,7 @@ def run_inference_algorithm(
     initial_state: ArrayLikeTree = None,
     initial_position: ArrayLikeTree = None,
     progress_bar: bool = False,
-    transform: Callable = lambda x: x,
-    return_state_history=True,
-    expectation: Callable = lambda x: x,
+    transform: Callable = lambda state, info: (state, info),
 ) -> tuple:
     """Wrapper to run an inference algorithm.
 
@@ -166,8 +235,7 @@ def run_inference_algorithm(
     initial_state
         The initial state of the inference algorithm.
     initial_position
-        The initial position of the inference algorithm. This is used when the initial
-        state is not provided.
+        The initial position of the inference algorithm. This is used when the initial state is not provided.
     inference_algorithm
         One of blackjax's sampling algorithms or variational inference algorithms.
     num_steps
@@ -179,91 +247,121 @@ def run_inference_algorithm(
         computing determinstic variables, or returning a subset of the states.
         By default, the states are returned as is.
     expectation
-        A function that computes the expectation of the state. This is done
-        incrementally, so doesn't require storing all the states.
+        A function that computes the expectation of the state. This is done incrementally, so doesn't require storing all the states.
     return_state_history
-        if False, `run_inference_algorithm` will only return an expectation of the value
-        of transform, and return that average instead of the full set of samples. This
-        is useful when memory is a bottleneck.
+        if False, `run_inference_algorithm` will only return an expectation of the value of transform, and return that average instead of the full set of samples. This is useful when memory is a bottleneck.
 
     Returns
     -------
-    If return_state_history is True:
         1. The final state.
-        2. The trace of the state.
+        2. The trace of the transform(state)
         3. The trace of the info of the inference algorithm for diagnostics.
-    If return_state_history is False:
-        1. This is the expectation of state over the chain. Otherwise the final state.
-        2. The final state of the inference algorithm.
     """
 
     if initial_state is None and initial_position is None:
-        raise ValueError(
-            "Either `initial_state` or `initial_position` must be provided."
-        )
+        raise ValueError("Either initial_state or initial_position must be provided.")
     if initial_state is not None and initial_position is not None:
         raise ValueError(
-            "Only one of `initial_state` or `initial_position` must be provided."
+            "Only one of initial_state or initial_position must be provided."
         )
 
-    if initial_state is None:
-        rng_key, init_key = split(rng_key, 2)
+    rng_key, init_key = split(rng_key, 2)
+    if initial_position is not None:
         initial_state = inference_algorithm.init(initial_position, init_key)
 
     keys = split(rng_key, num_steps)
 
-    def one_step(average_and_state, xs, return_state):
+    def one_step(state, xs):
         _, rng_key = xs
-        average, state = average_and_state
         state, info = inference_algorithm.step(rng_key, state)
-        average = streaming_average_update(expectation(transform(state)), average)
-        if return_state:
-            return (average, state), (transform(state), info)
-        else:
-            return (average, state), None
-
-    one_step = jax.jit(partial(one_step, return_state=return_state_history))
-
+        return state, transform(state, info)
+        
     if progress_bar:
         one_step = progress_bar_scan(num_steps)(one_step)
 
     xs = (jnp.arange(num_steps), keys)
-    ((_, average), final_state), history = lax.scan(
-        one_step, ((0, expectation(transform(initial_state))), initial_state), xs
-    )
+    final_state, history = lax.scan(one_step, initial_state, xs)
+    return final_state, history
 
-    if not return_state_history:
-        return average, transform(final_state)
-    else:
-        state_history, info_history = history
-        return transform(final_state), state_history, info_history
+def store_only_expectation_values(sampling_algorithm, state_transform= lambda x: x, exp_vals_transform= lambda x: x):
+    """Takes a sampling algorithm and constructs from it a new sampling algorithm object. The new sampling algorithm has the same 
+        kernel but only stores the streaming expectation values of some observables, not the full states; to save memory.
+
+       It saves exp_vals_transform(E[state_transform(x)]) at each step i, where expectation is computed with samples up to i-th sample.
+       
+       Example:
+
+       .. code::
+
+            init_key, state_key, run_key = jax.random.split(jax.random.PRNGKey(0),3)
+            model = StandardNormal(2)
+            initial_position = model.sample_init(init_key)
+            initial_state = blackjax.mcmc.mclmc.init(
+                position=initial_position, logdensity_fn=model.logdensity_fn, rng_key=state_key
+            )
+            integrator_type = "mclachlan"
+            L = 1.0
+            step_size = 0.1
+            num_steps = 4
+
+            integrator = map_integrator_type_to_integrator['mclmc'][integrator_type]
+            state_transform = lambda x: x.position
+            memory_efficient_sampling_alg, transform = store_only_expectation_values(
+                sampling_algorithm=sampling_alg,
+                state_transform=state_transform)
+            
+            initial_state = memory_efficient_sampling_alg.init(initial_state)
+                
+            final_state, trace_at_every_step = run_inference_algorithm(
+
+                rng_key=run_key,
+                initial_state=initial_state,
+                inference_algorithm=memory_efficient_sampling_alg,
+                num_steps=num_steps,
+                transform=transform,
+                progress_bar=True,
+            )           
+    """
+    
+    def init_fn(state):
+        averaging_state = (0., state_transform(state))
+        return (state, averaging_state)
+
+    def update_fn(rng_key, state_full):
+        state, averaging_state = state_full
+        state, info = sampling_algorithm.step(rng_key, state) # update the state with the sampling algorithm
+        averaging_state = streaming_average_update(state_transform(state), averaging_state) # update the expectation value with the Kalman filter
+        return (state, averaging_state), (averaging_state, info)
+
+    transform= lambda full_state, info: exp_vals_transform(full_state[1][1])
+
+    return SamplingAlgorithm(init_fn, update_fn), transform
+    
 
 
-def streaming_average_update(
-    current_value, previous_weight_and_average, weight=1.0, zero_prevention=0.0
-):
+def streaming_average_update(expectation, streaming_avg, weight=1.0, zero_prevention=0.0):
     """Compute the streaming average of a function O(x) using a weight.
     Parameters:
     ----------
-        current_value
-            the current value of the function that we want to take average of
-        previous_weight_and_average
-            tuple of (previous_weight, previous_average) where previous_weight is the
-            sum of weights and average is the current estimated average
+        expectation
+            the value of the expectation at the current timestep
+        streaming_avg
+            tuple of (total, average) where total is the sum of weights and average is the current average
         weight
             weight of the current state
         zero_prevention
             small value to prevent division by zero
     Returns:
     ----------
-        new total weight and streaming average
+        new streaming average
     """
-    previous_weight, previous_average = previous_weight_and_average
-    current_weight = previous_weight + weight
-    current_average = jax.tree.map(
-        lambda x, avg: (previous_weight * avg + weight * x)
-        / (current_weight + zero_prevention),
-        current_value,
-        previous_average,
+
+    flat_expectation, unravel_fn = ravel_pytree(expectation)
+    total, average = streaming_avg
+    flat_average, _ = ravel_pytree(average)
+    average = (total * flat_average + weight * flat_expectation) / (
+        total + weight + zero_prevention
     )
-    return current_weight, current_average
+    total += weight
+    streaming_avg = (total, unravel_fn(average))
+    return streaming_avg

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -90,7 +90,7 @@ def test_chees_adaptation(adaptation_filters):
     algorithm = blackjax.dynamic_hmc(logprob_fn, **parameters)
 
     chain_keys = jax.random.split(inference_key, num_chains)
-    _, _, infos = jax.vmap(
+    _, (_, infos) = jax.vmap(
         lambda key, state: run_inference_algorithm(
             rng_key=key,
             initial_state=state,

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -721,6 +721,7 @@ class UnivariateNormalTest(chex.TestCase):
         num_sampling_steps,
         burnin,
         postprocess_samples=None,
+        **kwargs,
     ):
         inference_key, orbit_key = jax.random.split(rng_key)
         _, states, _ = self.variant(
@@ -728,10 +729,10 @@ class UnivariateNormalTest(chex.TestCase):
                 run_inference_algorithm,
                 inference_algorithm=inference_algorithm,
                 num_steps=num_sampling_steps,
+                **kwargs,
             )
         )(rng_key=inference_key, initial_state=initial_state)
 
-        # else:
         if postprocess_samples:
             samples = postprocess_samples(states, orbit_key)
         else:
@@ -844,9 +845,8 @@ class UnivariateNormalTest(chex.TestCase):
         burnin = 15_000
 
         def postprocess_samples(states, key):
-            return orbit_samples(
-                states.positions[burnin:], states.weights[burnin:], key
-            )
+            positions, weights = states
+            return orbit_samples(positions[burnin:], weights[burnin:], key)
 
         self.univariate_normal_test_case(
             inference_algorithm,
@@ -855,6 +855,7 @@ class UnivariateNormalTest(chex.TestCase):
             20_000,
             burnin,
             postprocess_samples,
+            transform=lambda x: (x.positions, x.weights),
         )
 
     @chex.all_variants(with_pmap=False)

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -48,7 +48,7 @@ def run_regression(algorithm, **parameters):
     )
     inference_algorithm = algorithm(logdensity_fn, **parameters)
 
-    _, states, _ = run_inference_algorithm(
+    _, (states, _) = run_inference_algorithm(
         rng_key=inference_key,
         initial_state=state,
         inference_algorithm=inference_algorithm,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -4,7 +4,7 @@ import jax.numpy as jnp
 from absl.testing import absltest, parameterized
 
 import blackjax
-from blackjax.util import run_inference_algorithm
+from blackjax.util import run_inference_algorithm, store_only_expectation_values
 
 
 class RunInferenceAlgorithmTest(chex.TestCase):
@@ -41,37 +41,49 @@ class RunInferenceAlgorithmTest(chex.TestCase):
             10,
         )
 
-        init_key, run_key = jax.random.split(self.key, 2)
-
+        init_key, state_key, run_key = jax.random.split(jax.random.PRNGKey(0), 3)
         initial_state = blackjax.mcmc.mclmc.init(
-            position=initial_position, logdensity_fn=logdensity_fn, rng_key=init_key
+            position=initial_position, logdensity_fn=logdensity_fn, rng_key=state_key
+        )
+        L = 1.0
+        step_size = 0.1
+        num_steps = 4
+
+        sampling_alg = blackjax.mclmc(
+            logdensity_fn,
+            L=L,
+            step_size=step_size,
         )
 
-        alg = blackjax.mclmc(logdensity_fn=logdensity_fn, L=0.5, step_size=0.1)
+        state_transform = lambda x: x.position
 
-        _, states, info = run_inference_algorithm(
+        _, samples = run_inference_algorithm(
             rng_key=run_key,
             initial_state=initial_state,
-            inference_algorithm=alg,
-            num_steps=50,
-            progress_bar=False,
-            expectation=lambda x: x,
-            transform=lambda x: x.position,
-            return_state_history=True,
+            inference_algorithm=sampling_alg,
+            num_steps=num_steps,
+            transform=lambda state, info: state_transform(state),
+            progress_bar=True,
         )
 
-        average, _ = run_inference_algorithm(
+        print("average of steps (slow way):", samples.mean(axis=0))
+
+        memory_efficient_sampling_alg, transform = store_only_expectation_values(
+            sampling_algorithm=sampling_alg, state_transform=state_transform
+        )
+
+        initial_state = memory_efficient_sampling_alg.init(initial_state)
+
+        final_state, trace_at_every_step = run_inference_algorithm(
             rng_key=run_key,
             initial_state=initial_state,
-            inference_algorithm=alg,
-            num_steps=50,
-            progress_bar=False,
-            expectation=lambda x: x,
-            transform=lambda x: x.position,
-            return_state_history=False,
+            inference_algorithm=memory_efficient_sampling_alg,
+            num_steps=num_steps,
+            transform=transform,
+            progress_bar=True,
         )
 
-        assert jnp.allclose(states.mean(axis=0), average)
+        assert jnp.allclose(trace_at_every_step[0][-1], samples.mean(axis=0))
 
     @parameterized.parameters([True, False])
     def test_compatible_with_initial_pos(self, progress_bar):


### PR DESCRIPTION
The `run_inference_algorithm` code currently has a mode to incrementally compute a value (e.g. an incremental expectation), which saves memory. This PR presents a cleaner (and in my opinion, more functional) version of the code. The core idea is that to incrementally compute an expectation, the right thing to do is to modify the kernel, and then pass that kernel to `run_inference_algorithm`, rather than modify `run_inference_algorithm`. As part of this change, we also let `transform` be a general function on `(state, info)`, which allows information from the info to be used (which we have needed). 

 - [x] There is a high-level description of the changes;
 - [ ] The branch is rebased on the latest `main` commit;
 - [ ] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [ ] There are tests covering the changes;
 - [ ] The doc is up-to-date;
 
