### PR TITLE
wrapper for progress _bar_scan

### DIFF
--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -94,3 +94,17 @@ def progress_bar_scan(num_samples, print_rate=None):
         return wrapper_progress_bar
 
     return _progress_bar_scan
+
+
+def gen_scan_fn(num_samples, progress_bar, print_rate=None):
+    if progress_bar:
+
+        def scan_wrap(f, init, *args, **kwargs):
+            func = progress_bar_scan(num_samples, print_rate)(f)
+            carry = (init, -1)
+            (last_state, _), output = lax.scan(func, carry, *args, **kwargs)
+            return last_state, output
+
+        return scan_wrap
+    else:
+        return lax.scan


### PR DESCRIPTION
Cleans up progress bar handling as discussed in https://github.com/blackjax-devs/blackjax/pull/712 - hides the details of running with/without a progress bar.  It turns out the api change in https://github.com/blackjax-devs/blackjax/pull/712 will sometimes break pymc's blackjax based sampling due to the additional carry required and direct use of progress_bar_scan.  This allows for a simpler fix in those scenarios.

@zaxtax This seemed like the most reasonable way to wrap - is it similar to what you were thinking?

 A few important guidelines and requirements before we can merge your PR:

 - [ ] We should be able to understand what the PR does from its title only;
 - [ ] There is a high-level description of the changes;
 - [ ] There are links to *all* the relevant issues, discussions and PRs;
 - [ ] The branch is rebased on the latest `main` commit;
 - [ ] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [ ] The code respects the current naming conventions;
 - [ ] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [ ] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [ ] There are tests covering the changes;
 - [ ] The doc is up-to-date;

