### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ state = nuts.init(initial_position)
 # Iterate
 rng_key = jax.random.key(0)
 step = jax.jit(nuts.step)
-for step in range(100):
-    nuts_key = jax.random.fold_in(rng_key, step)
+for i in range(100):
+    nuts_key = jax.random.fold_in(rng_key, i)
     state, _ = step(nuts_key, state)
 ```
 


### PR DESCRIPTION
Change duplicate variable name to harmonize with doc example.

The for loop iterate and JIT-ed step function are both called `step`. This changes the for loop iterate to `i` to better harmonize with the quickstart example in the documentation website.

I forgot to make this change in https://github.com/blackjax-devs/blackjax/pull/717 that first harmonized README and doc example.