### PR TITLE
Add pre-conditioning matrix to Barker proposal

### DIFF
--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -22,7 +22,7 @@ from jax.scipy import stats
 
 from blackjax.base import SamplingAlgorithm
 from blackjax.mcmc.proposal import static_binomial_sampling
-from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
+from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
 __all__ = ["BarkerState", "BarkerInfo", "init", "build_kernel", "as_top_level_api"]
 
@@ -81,7 +81,7 @@ def build_kernel():
     """
 
     def _compute_acceptance_probability(
-        state: BarkerState, proposal: BarkerState, C_t: jnp.Array, C_t_inv: jnp.Array
+        state: BarkerState, proposal: BarkerState, C_t: Array, C_t_inv: Array
     ) -> float:
         """Compute the acceptance probability of the Barker's proposal kernel."""
 
@@ -106,7 +106,7 @@ def build_kernel():
         state: BarkerState,
         logdensity_fn: Callable,
         step_size: float,
-        inverse_mass_matrix: jnp.Array,
+        inverse_mass_matrix: Array,
     ) -> tuple[BarkerState, BarkerInfo]:
         """Generate a new sample with the Barker kernel."""
         grad_fn = jax.value_and_grad(logdensity_fn)
@@ -142,7 +142,7 @@ def build_kernel():
 
 
 def as_top_level_api(
-    logdensity_fn: Callable, step_size: float, inverse_mass_matrix: jnp.Array
+    logdensity_fn: Callable, step_size: float, inverse_mass_matrix: Array
 ) -> SamplingAlgorithm:
     """Implements the (basic) user interface for the Barker's proposal :cite:p:`Livingstone2022Barker` kernel with a
     Gaussian base kernel.

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -186,7 +186,7 @@ def as_top_level_api(
     logdensity_fn
         The log-density function we wish to draw samples from.
     step_size
-        The value to use for the step size in the symplectic integrator.
+        The value of the step_size correspnoding to the global scale of the proposal distribution.
     inverse_mass_matrix
         The inverse mass matrix to use for pre-conditioning (see Appendix G of :cite:p:`Livingstone2022Barker`).
 
@@ -231,7 +231,8 @@ def _barker_sample_nd(key, mean, a, scale, C_t):
         The global scale, a scalar. This corresponds to :math:`\\sigma` in the equation above.
         It encodes the step size of the proposal.
     C_t
-        The transpose of the sqrt of the mass matrix, an Array. It is not used in the 1D version of Barker's proposal and thus not present in the equation above.
+        The transpose of the sqrt of the mass matrix, an Array. It is not used in the
+        1D version of Barker's proposal and thus not present in the equation above.
 
     Returns
     -------

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -16,9 +16,9 @@ from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
+import jax.scipy as jscipy
 from jax.flatten_util import ravel_pytree
 from jax.scipy import stats
-from jax.tree_util import tree_leaves, tree_map
 
 from blackjax.base import SamplingAlgorithm
 from blackjax.mcmc.proposal import static_binomial_sampling
@@ -81,44 +81,57 @@ def build_kernel():
     """
 
     def _compute_acceptance_probability(
-        state: BarkerState,
-        proposal: BarkerState,
+        state: BarkerState, proposal: BarkerState, C_t: jnp.Array, C_t_inv: jnp.Array
     ) -> float:
         """Compute the acceptance probability of the Barker's proposal kernel."""
 
-        def ratio_proposal_nd(y, x, log_y, log_x):
-            num = -_log1pexp(-log_y * (x - y))
-            den = -_log1pexp(-log_x * (y - x))
+        x_flat, _ = ravel_pytree(state.position)
+        y_flat, _ = ravel_pytree(proposal.position)
+        log_x_flat, _ = ravel_pytree(state.logdensity_grad)
+        log_y_flat, _ = ravel_pytree(proposal.logdensity_grad)
 
-            return jnp.sum(num - den)
+        z = C_t_inv.dot(y_flat - x_flat)
+        c_x = log_x_flat.dot(C_t)
+        c_y = log_y_flat.dot(C_t)
 
-        ratios_proposals = tree_map(
-            ratio_proposal_nd,
-            proposal.position,
-            state.position,
-            proposal.logdensity_grad,
-            state.logdensity_grad,
-        )
-        ratio_proposal = sum(tree_leaves(ratios_proposals))
+        num = _log1pexp(-z * c_x)
+        denom = _log1pexp(z * c_y)
+
+        ratio_proposal = jnp.sum(num - denom)
+
         return proposal.logdensity - state.logdensity + ratio_proposal
 
     def kernel(
-        rng_key: PRNGKey, state: BarkerState, logdensity_fn: Callable, step_size: float
+        rng_key: PRNGKey,
+        state: BarkerState,
+        logdensity_fn: Callable,
+        step_size: float,
+        inverse_mass_matrix: jnp.Array,
     ) -> tuple[BarkerState, BarkerInfo]:
-        """Generate a new sample with the MALA kernel."""
+        """Generate a new sample with the Barker kernel."""
         grad_fn = jax.value_and_grad(logdensity_fn)
-
         key_sample, key_rmh = jax.random.split(rng_key)
 
-        proposed_pos = _barker_sample(
-            key_sample, state.position, state.logdensity_grad, step_size
+        mass_matrix_sqrt, inv_mass_matrix_sqrt = _get_mass_matrix_sqrt(
+            inverse_mass_matrix
         )
+
+        proposed_pos = _barker_sample(
+            key_sample,
+            state.position,
+            state.logdensity_grad,
+            step_size,
+            mass_matrix_sqrt,
+        )
+
         proposed_logdensity, proposed_logdensity_grad = grad_fn(proposed_pos)
         proposed_state = BarkerState(
             proposed_pos, proposed_logdensity, proposed_logdensity_grad
         )
 
-        log_p_accept = _compute_acceptance_probability(state, proposed_state)
+        log_p_accept = _compute_acceptance_probability(
+            state, proposed_state, mass_matrix_sqrt, inv_mass_matrix_sqrt
+        )
         accepted_state, info = static_binomial_sampling(
             key_rmh, log_p_accept, state, proposed_state
         )
@@ -129,8 +142,7 @@ def build_kernel():
 
 
 def as_top_level_api(
-    logdensity_fn: Callable,
-    step_size: float,
+    logdensity_fn: Callable, step_size: float, inverse_mass_matrix: jnp.Array
 ) -> SamplingAlgorithm:
     """Implements the (basic) user interface for the Barker's proposal :cite:p:`Livingstone2022Barker` kernel with a
     Gaussian base kernel.
@@ -175,6 +187,8 @@ def as_top_level_api(
         The log-density function we wish to draw samples from.
     step_size
         The value to use for the step size in the symplectic integrator.
+    inverse_mass_matrix
+        The inverse mass matrix to use for pre-conditioning (see Appendix G of :cite:p:`Livingstone2022Barker`).
 
     Returns
     -------
@@ -189,12 +203,12 @@ def as_top_level_api(
         return init(position, logdensity_fn)
 
     def step_fn(rng_key: PRNGKey, state):
-        return kernel(rng_key, state, logdensity_fn, step_size)
+        return kernel(rng_key, state, logdensity_fn, step_size, inverse_mass_matrix)
 
     return SamplingAlgorithm(init_fn, step_fn)
 
 
-def _barker_sample_nd(key, mean, a, scale):
+def _barker_sample_nd(key, mean, a, scale, C_t):
     """
     Sample from a multivariate Barker's proposal distribution. In 1D, this has the following probability density function:
 
@@ -214,8 +228,10 @@ def _barker_sample_nd(key, mean, a, scale):
     a
         The parameter :math:`a` in the equation above, an Array. This is a skewness parameter.
     scale
-        The standard deviation of the normal distribution, a scalar. This corresponds to :math:`\\sigma` in the equation above.
+        The global scale, a scalar. This corresponds to :math:`\\sigma` in the equation above.
         It encodes the step size of the proposal.
+    C_t
+        The transpose of the sqrt of the mass matrix, an Array. It is not used in the 1D version of Barker's proposal and thus not present in the equation above.
 
     Returns
     -------
@@ -225,17 +241,18 @@ def _barker_sample_nd(key, mean, a, scale):
 
     key1, key2 = jax.random.split(key)
     z = scale * jax.random.normal(key1, shape=mean.shape)
+    c = a.dot(C_t)
 
     # Sample b=1 with probability p and 0 with probability 1 - p where
     # p = 1 / (1 + exp(-a * (z - mean)))
-    log_p = -_log1pexp(-a * z)
+    log_p = -_log1pexp(-c * z)
     b = jax.random.bernoulli(key2, p=jnp.exp(log_p), shape=mean.shape)
 
     # return mean + z if b == 1 else mean - z
-    return mean + b * z - (1 - b) * z
+    return mean + C_t.dot(b * z - (1 - b) * z)
 
 
-def _barker_sample(key, mean, a, scale):
+def _barker_sample(key, mean, a, scale, C_t):
     r"""
     Sample from a multivariate Barker's proposal distribution for PyTrees.
 
@@ -248,19 +265,45 @@ def _barker_sample(key, mean, a, scale):
     a
         The parameter :math:`a` in the equation above, the same PyTree as `mean`. This is a skewness parameter.
     scale
-        The standard deviation of the normal distribution, a scalar. This corresponds to :math:`\sigma` in the equation above.
+        The global scale, a scalar. This corresponds to :math:`\\sigma` in the equation above.
         It encodes the step size of the proposal.
-
+    C_t
+        The transpose of the sqrt of the mass matrix, an Array.
     """
 
     flat_mean, unravel_fn = ravel_pytree(mean)
     flat_a, _ = ravel_pytree(a)
-    flat_sample = _barker_sample_nd(key, flat_mean, flat_a, scale)
+    flat_sample = _barker_sample_nd(key, flat_mean, flat_a, scale, C_t)
     return unravel_fn(flat_sample)
 
 
 def _log1pexp(a):
     return jnp.log1p(jnp.exp(a))
+
+
+def _get_mass_matrix_sqrt(inverse_mass_matrix):
+    # want transpoed cholesky decomposition C_t of mass matrix (see Appendix G of paper)
+
+    ndim = jnp.ndim(inverse_mass_matrix)  # type: ignore[arg-type]
+    shape = jnp.shape(inverse_mass_matrix)[:1]  # type: ignore[arg-type]
+    if ndim == 1:  # diagonal
+        inv_mass_matrix_sqrt = jnp.sqrt(inverse_mass_matrix)
+        mass_matrix_sqrt = jnp.reciprocal(inv_mass_matrix_sqrt)
+    elif ndim == 2:
+        # inverse mass matrix can be factored into L*L.T. We want the cholesky
+        # factor (inverse of L.T) of the mass matrix.
+        L = jscipy.linalg.cholesky(inverse_mass_matrix, lower=True)
+        identity = jnp.identity(shape[0])
+        mass_matrix_sqrt = jscipy.linalg.solve_triangular(
+            L, identity, lower=True, trans=True
+        )
+        inv_mass_matrix_sqrt = L.T
+    else:
+        raise ValueError(
+            "The mass matrix has the wrong number of dimensions:"
+            f" expected 1 or 2, got {ndim}."
+        )
+    return mass_matrix_sqrt, inv_mass_matrix_sqrt
 
 
 def _barker_logpdf(x, mean, a, scale):

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -94,11 +94,11 @@ def build_kernel():
 
         y_minus_x = jax.tree_util.tree_map(lambda a, b: a - b, y, x)
         x_minus_y = jax.tree_util.tree_map(lambda a: -a, y_minus_x)
-        z_tilde_x_to_y = metric.scale(x, y_minus_x, True, True)
-        z_tilde_y_to_x = metric.scale(y, x_minus_y, True, True)
+        z_tilde_x_to_y = metric.scale(x, y_minus_x, inv=True, trans=True)
+        z_tilde_y_to_x = metric.scale(y, x_minus_y, inv=True, trans=True)
 
-        c_x_to_y = metric.scale(x, log_x, False, True)
-        c_y_to_x = metric.scale(y, log_y, False, True)
+        c_x_to_y = metric.scale(x, log_x, inv=False, trans=True)
+        c_y_to_x = metric.scale(y, log_y, inv=False, trans=True)
 
         z_tilde_x_to_y_flat, _ = ravel_pytree(z_tilde_x_to_y)
         z_tilde_y_to_x_flat, _ = ravel_pytree(z_tilde_y_to_x)
@@ -256,7 +256,7 @@ def _barker_sample(key, mean, a, scale, metric):
     key1, key2 = jax.random.split(key)
 
     z = generate_gaussian_noise(key1, mean, sigma=scale)
-    c = metric.scale(mean, a, False, True)
+    c = metric.scale(mean, a, inv=False, trans=True)
 
     # Sample b=1 with probability p and 0 with probability 1 - p where
     # p = 1 / (1 + exp(-a * (z - mean)))
@@ -267,7 +267,7 @@ def _barker_sample(key, mean, a, scale, metric):
     bz = jax.tree_util.tree_map(lambda x, y: x * y - (1 - x) * y, b, z)
 
     return jax.tree_util.tree_map(
-        lambda a, b: a + b, mean, metric.scale(mean, bz, False, False)
+        lambda a, b: a + b, mean, metric.scale(mean, bz, inv=False, trans=False)
     )
 
 

--- a/blackjax/mcmc/metrics.py
+++ b/blackjax/mcmc/metrics.py
@@ -65,8 +65,9 @@ class Scale(Protocol):
         self,
         position: ArrayLikeTree,
         element: ArrayLikeTree,
-        inv: ArrayLikeTree,
-        trans: ArrayLikeTree,
+        *,
+        inv: bool,
+        trans: bool,
     ) -> ArrayLikeTree:
         ...
 

--- a/blackjax/mcmc/metrics.py
+++ b/blackjax/mcmc/metrics.py
@@ -303,7 +303,7 @@ def gaussian_riemannian(
         position: ArrayLikeTree,
         element: ArrayLikeTree,
         inv: ArrayLikeTree,
-        trans: ArrayLikeTree = False,
+        trans: ArrayLikeTree,
     ) -> ArrayLikeTree:
         """Scale elements by the mass matrix.
 

--- a/blackjax/mcmc/metrics.py
+++ b/blackjax/mcmc/metrics.py
@@ -220,21 +220,14 @@ def gaussian_euclidean(
 
         ravelled_element, unravel_fn = ravel_pytree(element)
 
-        def _linear_map_transpose():
-            return jax.lax.cond(
-                inv,
-                lambda: linear_map(inv_mass_matrix_sqrt.T, ravelled_element),
-                lambda: linear_map(mass_matrix_sqrt.T, ravelled_element),
-            )
+        if inv:
+            left_hand_side_matrix = inv_mass_matrix_sqrt
+        else:
+            left_hand_side_matrix = mass_matrix_sqrt
+        if trans:
+            left_hand_side_matrix = left_hand_side_matrix.T
 
-        def _linear_map():
-            return jax.lax.cond(
-                inv,
-                lambda: linear_map(inv_mass_matrix_sqrt, ravelled_element),
-                lambda: linear_map(mass_matrix_sqrt, ravelled_element),
-            )
-
-        scaled = jax.lax.cond(trans, _linear_map_transpose, _linear_map)
+        scaled = linear_map(left_hand_side_matrix, ravelled_element)
 
         return unravel_fn(scaled)
 

--- a/tests/mcmc/test_barker.py
+++ b/tests/mcmc/test_barker.py
@@ -9,7 +9,7 @@ from absl.testing import absltest, parameterized
 
 import blackjax
 from blackjax.mcmc import metrics
-from blackjax.mcmc.barker import _barker_pdf, _barker_sample_nd
+from blackjax.mcmc.barker import _barker_pdf, _barker_sample
 from blackjax.util import run_inference_algorithm
 
 
@@ -27,7 +27,7 @@ class BarkerSamplingTest(chex.TestCase):
 
         metric = metrics.default_metric(jnp.eye(4))
         keys = jax.random.split(key, n_samples)
-        samples = jax.vmap(lambda k: _barker_sample_nd(k, m, a, scale, metric))(keys)
+        samples = jax.vmap(lambda k: _barker_sample(k, m, a, scale, metric))(keys)
         # Check that the emprical mean and the mean computed as sum(x * p(x) dx) are close
         _test_samples_vs_pdf(samples, lambda x: _barker_pdf(x, m, a, scale))
 

--- a/tests/mcmc/test_barker.py
+++ b/tests/mcmc/test_barker.py
@@ -1,9 +1,15 @@
+import functools
+
 import chex
 import jax
 import jax.numpy as jnp
+import jax.scipy.stats as stats
+import numpy as np
 from absl.testing import absltest, parameterized
 
+import blackjax
 from blackjax.mcmc.barker import _barker_pdf, _barker_sample_nd
+from blackjax.util import run_inference_algorithm
 
 
 class BarkerSamplingTest(chex.TestCase):
@@ -17,9 +23,13 @@ class BarkerSamplingTest(chex.TestCase):
             jnp.array([1.0, -2.0, 10.0, 0.0]),
             0.5,
         )
+        # will have no effect on original test with no preconditioning matrix
+        inv_mass_matrix = jnp.eye(4)
 
         keys = jax.random.split(key, n_samples)
-        samples = jax.vmap(lambda k: _barker_sample_nd(k, m, a, scale))(keys)
+        samples = jax.vmap(
+            lambda k: _barker_sample_nd(k, m, a, scale, inv_mass_matrix)
+        )(keys)
         # Check that the emprical mean and the mean computed as sum(x * p(x) dx) are close
         _test_samples_vs_pdf(samples, lambda x: _barker_pdf(x, m, a, scale))
 
@@ -49,6 +59,70 @@ def _test_samples_vs_pdf(samples, pdf):
     chex.assert_trees_all_close(
         samples_squrared_mean, pdf_squared_mean, atol=1e-2, rtol=1e-2
     )
+
+
+class BarkerPreconditioiningTest(chex.TestCase):
+    @parameterized.parameters([1234, 5678])
+    def test_preconditioning_matrix(self, seed):
+        """Test two different ways of using pre-conditioning matrix has exactly same effect.
+
+        We follow the discussion in Appendix G of the Barker 2020 paper.
+        """
+        from blackjax.mcmc.barker import _get_mass_matrix_sqrt
+
+        key = jax.random.key(seed)
+        init_key, inference_key = jax.random.split(key, 2)
+
+        # setup some 2D multivariate normal model
+        # setup sampling mean and cov
+        true_x = jnp.array([0.0, 1.0])
+        data = jax.random.normal(init_key, shape=(1000,)) * true_x[1] + true_x[0]
+        assert data.shape == (1000,)
+
+        # some non-diagonal positive-defininte matrix for pre-conditioning
+        inv_mass_matrix = jnp.array([[1, 0.1], [0.1, 1]])
+        C_t, C_t_inv = _get_mass_matrix_sqrt(inv_mass_matrix)
+
+        # define barker kernel two ways
+        # non-scaled, use pre-conditioning
+        def logdensity(x, data):
+            mu_prior = stats.norm.logpdf(x[0], loc=0, scale=1)
+            sigma_prior = stats.uniform.logpdf(x[1], 0.0, 3.0)
+            return mu_prior + sigma_prior + jnp.sum(stats.norm.logcdf(data, x[0], x[1]))
+
+        logposterior_fn1 = functools.partial(logdensity, data=data)
+        barker1 = blackjax.barker_proposal(logposterior_fn1, 1e-1, inv_mass_matrix)
+        state1 = barker1.init(true_x)
+
+        # scaled, trivial pre-conditioning
+        def scaled_logdensity(x_scaled, data, C_t):
+            return logdensity(C_t.dot(x_scaled), data)
+
+        logposterior_fn2 = functools.partial(scaled_logdensity, data=data, C_t=C_t)
+        barker2 = blackjax.barker_proposal(logposterior_fn2, 1e-1, jnp.eye(2))
+
+        true_x_trans = C_t_inv.dot(true_x)
+        state2 = barker2.init(true_x_trans)
+
+        _, states1 = run_inference_algorithm(
+            rng_key=inference_key,
+            initial_state=state1,
+            inference_algorithm=barker1,
+            transform=lambda state, info: state.position,
+            num_steps=1000,
+        )
+
+        _, states2 = run_inference_algorithm(
+            rng_key=inference_key,
+            initial_state=state2,
+            inference_algorithm=barker2,
+            transform=lambda state, info: state.position,
+            num_steps=1000,
+        )
+
+        # states should be the exact same with same random key after transforming
+        states2_trans = C_t.dot(states2.T).T
+        np.testing.assert_allclose(states1, states2_trans, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/tests/mcmc/test_barker.py
+++ b/tests/mcmc/test_barker.py
@@ -93,7 +93,7 @@ class BarkerPreconditioiningTest(chex.TestCase):
 
         # scaled, trivial pre-conditioning
         def scaled_logdensity(x_scaled, data, metric):
-            x = metric.scale(x_scaled, x_scaled, False, False)
+            x = metric.scale(x_scaled, x_scaled, inv=False, trans=False)
             return logdensity(x, data)
 
         logposterior_fn2 = functools.partial(
@@ -101,7 +101,7 @@ class BarkerPreconditioiningTest(chex.TestCase):
         )
         barker2 = blackjax.barker_proposal(logposterior_fn2, 1e-1, jnp.eye(2))
 
-        true_x_trans = metric.scale(true_x, true_x, True, True)
+        true_x_trans = metric.scale(true_x, true_x, inv=True, trans=True)
         state2 = barker2.init(true_x_trans)
 
         n_steps = 10
@@ -125,7 +125,7 @@ class BarkerPreconditioiningTest(chex.TestCase):
         states2_trans = []
         for ii in range(n_steps):
             s = states2[ii]
-            states2_trans.append(metric.scale(s, s, False, False))
+            states2_trans.append(metric.scale(s, s, inv=False, trans=False))
         states2_trans = jnp.array(states2_trans)
         assert jnp.allclose(states1, states2_trans)
 

--- a/tests/mcmc/test_metrics.py
+++ b/tests/mcmc/test_metrics.py
@@ -131,8 +131,12 @@ class GaussianEuclideanMetricsTest(chex.TestCase):
         assert momentum_val == expected_momentum_val
         assert kinetic_energy_val == expected_kinetic_energy_val
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
+        inv_scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=True, trans=False
+        )
+        scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=False, trans=False
+        )
 
         expected_scaled_momentum = momentum_val / jnp.sqrt(inverse_mass_matrix)
         expected_inv_scaled_momentum = momentum_val * jnp.sqrt(inverse_mass_matrix)
@@ -164,8 +168,12 @@ class GaussianEuclideanMetricsTest(chex.TestCase):
         np.testing.assert_allclose(expected_momentum_val, momentum_val)
         np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
+        inv_scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=True, trans=False
+        )
+        scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=False, trans=False
+        )
 
         expected_inv_scaled_momentum = jnp.linalg.inv(L_inv).T @ momentum_val
         expected_scaled_momentum = L_inv @ momentum_val
@@ -226,8 +234,12 @@ class GaussianRiemannianMetricsTest(chex.TestCase):
         np.testing.assert_allclose(expected_momentum_val, momentum_val)
         np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
+        inv_scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=True, trans=False
+        )
+        scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=False, trans=False
+        )
         expected_scaled_momentum = momentum_val / jnp.sqrt(inverse_mass_matrix)
         expected_inv_scaled_momentum = momentum_val * jnp.sqrt(inverse_mass_matrix)
 
@@ -265,8 +277,12 @@ class GaussianRiemannianMetricsTest(chex.TestCase):
         np.testing.assert_allclose(expected_momentum_val, momentum_val)
         np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
+        inv_scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=True, trans=False
+        )
+        scaled_momentum = scale(
+            arbitrary_position, momentum_val, inv=False, trans=False
+        )
         expected_inv_scaled_momentum = jnp.linalg.inv(L_inv).T @ momentum_val
         expected_scaled_momentum = L_inv @ momentum_val
 

--- a/tests/mcmc/test_metrics.py
+++ b/tests/mcmc/test_metrics.py
@@ -131,8 +131,8 @@ class GaussianEuclideanMetricsTest(chex.TestCase):
         assert momentum_val == expected_momentum_val
         assert kinetic_energy_val == expected_kinetic_energy_val
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False)
+        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
+        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
 
         expected_scaled_momentum = momentum_val / jnp.sqrt(inverse_mass_matrix)
         expected_inv_scaled_momentum = momentum_val * jnp.sqrt(inverse_mass_matrix)
@@ -164,8 +164,8 @@ class GaussianEuclideanMetricsTest(chex.TestCase):
         np.testing.assert_allclose(expected_momentum_val, momentum_val)
         np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False)
+        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
+        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
 
         expected_inv_scaled_momentum = jnp.linalg.inv(L_inv).T @ momentum_val
         expected_scaled_momentum = L_inv @ momentum_val
@@ -226,8 +226,8 @@ class GaussianRiemannianMetricsTest(chex.TestCase):
         np.testing.assert_allclose(expected_momentum_val, momentum_val)
         np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False)
+        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
+        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
         expected_scaled_momentum = momentum_val / jnp.sqrt(inverse_mass_matrix)
         expected_inv_scaled_momentum = momentum_val * jnp.sqrt(inverse_mass_matrix)
 
@@ -265,8 +265,8 @@ class GaussianRiemannianMetricsTest(chex.TestCase):
         np.testing.assert_allclose(expected_momentum_val, momentum_val)
         np.testing.assert_allclose(kinetic_energy_val, expected_kinetic_energy_val)
 
-        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True)
-        scaled_momentum = scale(arbitrary_position, momentum_val, False)
+        inv_scaled_momentum = scale(arbitrary_position, momentum_val, True, False)
+        scaled_momentum = scale(arbitrary_position, momentum_val, False, False)
         expected_inv_scaled_momentum = jnp.linalg.inv(L_inv).T @ momentum_val
         expected_scaled_momentum = L_inv @ momentum_val
 

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -496,9 +496,7 @@ class LinearRegressionTest(chex.TestCase):
         )
         logposterior_fn = lambda x: logposterior_fn_(**x)
 
-        inv_mass_matrix = jnp.eye(2)  # no effect on original test
-
-        barker = blackjax.barker_proposal(logposterior_fn, 1e-1, inv_mass_matrix)
+        barker = blackjax.barker_proposal(logposterior_fn, 1e-1)
         state = barker.init({"coefs": 1.0, "log_scale": 1.0})
 
         _, states = run_inference_algorithm(
@@ -889,7 +887,7 @@ class UnivariateNormalTest(chex.TestCase):
     @chex.all_variants(with_pmap=False)
     def test_barker(self):
         inference_algorithm = blackjax.barker_proposal(
-            self.normal_logprob, step_size=1.5, inverse_mass_matrix=jnp.eye(1)
+            self.normal_logprob, step_size=1.5
         )
         initial_state = inference_algorithm.init(jnp.array(1.0))
         self.univariate_normal_test_case(
@@ -926,7 +924,7 @@ mcse_test_cases = [
     },
     {
         "algorithm": blackjax.barker_proposal,
-        "parameters": {"step_size": 0.5, "inverse_mass_matrix": jnp.eye(2)},
+        "parameters": {"step_size": 0.5},
         "is_mass_matrix_diagonal": None,
     },
 ]

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -496,7 +496,7 @@ class LinearRegressionTest(chex.TestCase):
         )
         logposterior_fn = lambda x: logposterior_fn_(**x)
 
-        inv_mass_matrix = jnp.eye(1)  # no effect on original test
+        inv_mass_matrix = jnp.eye(2)  # no effect on original test
 
         barker = blackjax.barker_proposal(logposterior_fn, 1e-1, inv_mass_matrix)
         state = barker.init({"coefs": 1.0, "log_scale": 1.0})

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -889,7 +889,7 @@ class UnivariateNormalTest(chex.TestCase):
     @chex.all_variants(with_pmap=False)
     def test_barker(self):
         inference_algorithm = blackjax.barker_proposal(
-            self.normal_logprob, step_size=1.5
+            self.normal_logprob, step_size=1.5, inverse_mass_matrix=jnp.eye(1)
         )
         initial_state = inference_algorithm.init(jnp.array(1.0))
         self.univariate_normal_test_case(
@@ -926,7 +926,7 @@ mcse_test_cases = [
     },
     {
         "algorithm": blackjax.barker_proposal,
-        "parameters": {"step_size": 0.5},
+        "parameters": {"step_size": 0.5, "inverse_mass_matrix": jnp.eye(2)},
         "is_mass_matrix_diagonal": None,
     },
 ]

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -1,4 +1,5 @@
 """Test the accuracy of the MCMC kernels."""
+
 import functools
 import itertools
 
@@ -495,7 +496,9 @@ class LinearRegressionTest(chex.TestCase):
         )
         logposterior_fn = lambda x: logposterior_fn_(**x)
 
-        barker = blackjax.barker_proposal(logposterior_fn, 1e-1)
+        inv_mass_matrix = jnp.eye(1)  # no effect on original test
+
+        barker = blackjax.barker_proposal(logposterior_fn, 1e-1, inv_mass_matrix)
         state = barker.init({"coefs": 1.0, "log_scale": 1.0})
 
         _, states = run_inference_algorithm(


### PR DESCRIPTION
# Overview

This PR attempts to add a preconditioning matrix to the barker proposal implementation, as in appendix G of https://arxiv.org/abs/1908.11812

- Relevant discussion #723 
- Relevant issue #725 

# Discussion / Questions
- I changed the `_compute_acceptance_probability` to be flat given how it was necessary to matrix-multiply with the pre-conditioning matrix. Is that OK? 
- Do I need to update the PDF?  (not used anywhere in the codebase)
- It's not very clear in the Barker paper but the step_size (sigma) is a 'global scale' and the inverse mass matrix is separate.  See implementation from authors here (in R) - https://github.com/gzanella/barker/blob/master/functions.R

# Thank you for opening a PR!

 A few important guidelines and requirements before we can merge your PR:

 - [x] *If I add a new sampler*, there is an issue discussing it already;
 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [x] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [x] The doc is up-to-date;
 - [x] *If I add a new sampler** I added/updated related [examples](https://github.com/blackjax-devs/blackjax/tree/main/examples)

Consider opening a **Draft PR** if your work is still in progress but you would like some feedback from other contributors.
