### PR TITLE
ENH: Nested rhat MCMC diagnostic

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -162,5 +162,6 @@ __all__ = [
     "pathfinder_adaptation",
     "mclmc_find_L_and_step_size",  # mclmc adaptation
     "ess",  # diagnostics
+    "nested_rhat",
     "rhat",
 ]

--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -10,6 +10,7 @@ from .adaptation.pathfinder_adaptation import pathfinder_adaptation
 from .adaptation.window_adaptation import window_adaptation
 from .base import SamplingAlgorithm, VIAlgorithm
 from .diagnostics import effective_sample_size as ess
+from .diagnostics import nested_rhat as nested_rhat
 from .diagnostics import potential_scale_reduction as rhat
 from .mcmc import barker
 from .mcmc import dynamic_hmc as _dynamic_hmc


### PR DESCRIPTION
Implement nested R-hat for Markov chain Monte Carlo (MCMC) diagnostic.

The potential scale reduction factor, also known as R-hat, is a popular MCMC diagnostic from [Gelman and Rubin](https://wwwusers.ts.infn.it/~milotti/Didattica/Bayes/pdfs/Gelman&Rubin_1992.pdf).
R-hat detects convergence of MCMC chains by comparing within chain variance to between chain variance.

Nested r-hat from [Margossian et al.](https://arxiv.org/pdf/2110.13017) better predicts convergence when running thousands of _short_ chains on modern hardware. Nested r-hat uses _superchains_, collections of MCMC chains, and compares within and between chain and superchain variance.

I am seeking feedback on the code style + API design. The code is somewhat complicated by requiring `input_array` to have 4 dimensions -- `num_superchains`, `num_chains`, `num_samples`, and `num_params` -- where most users may expect only 3 (or 2). Tests are also still needed, as well as a brief doc explanation of the math.

Quick nit: why does the existing R-hat function return the potential scale factor after _flattening_ along the sample and chain dimensions? I followed this convention for my implementation.

Addresses issue #278 .