### PR TITLE
MCLMC adaptation total num steps and initial guess

### DIFF
--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -116,7 +116,9 @@ def mclmc_find_L_and_step_size(
     part1_key, part2_key = jax.random.split(rng_key, 2)
     total_num_tuning_integrator_steps = 0
 
-    num_steps1, num_steps2 = round(num_steps * frac_tune1), round(num_steps * frac_tune2)
+    num_steps1, num_steps2 = round(num_steps * frac_tune1), round(
+        num_steps * frac_tune2
+    )
     num_steps2 += diagonal_preconditioning * (num_steps2 // 3)
     num_steps3 = round(num_steps * frac_tune3)
 
@@ -132,7 +134,7 @@ def mclmc_find_L_and_step_size(
     )(state, params, num_steps, part1_key)
     total_num_tuning_integrator_steps += num_steps1 + num_steps2
 
-    if num_steps3 >= 2: # at least 2 samples for ESS estimation
+    if num_steps3 >= 2:  # at least 2 samples for ESS estimation
         state, params = make_adaptation_L(
             mclmc_kernel(params.inverse_mass_matrix), frac=frac_tune3, Lfactor=0.4
         )(state, params, num_steps, part2_key)
@@ -237,7 +239,9 @@ def make_L_step_size_adaptation(
     )[0]
 
     def L_step_size_adaptation(state, params, num_steps, rng_key):
-        num_steps1, num_steps2 = round(num_steps * frac_tune1), round(num_steps * frac_tune2)
+        num_steps1, num_steps2 = round(num_steps * frac_tune1), round(
+            num_steps * frac_tune2
+        )
 
         L_step_size_adaptation_keys = jax.random.split(
             rng_key, num_steps1 + num_steps2 + 1

--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -51,6 +51,7 @@ def mclmc_find_L_and_step_size(
     trust_in_estimate=1.5,
     num_effective_samples=150,
     diagonal_preconditioning=True,
+    params=None,
 ):
     """
     Finds the optimal value of the parameters for the MCLMC algorithm.
@@ -79,6 +80,8 @@ def mclmc_find_L_and_step_size(
         The number of effective samples for the MCMC algorithm.
     diagonal_preconditioning
         Whether to do diagonal preconditioning (i.e. a mass matrix)
+    params
+        Initial params to start tuning from (optional)
 
     Returns
     -------
@@ -105,10 +108,17 @@ def mclmc_find_L_and_step_size(
         )
     """
     dim = pytree_size(state.position)
-    params = MCLMCAdaptationState(
-        jnp.sqrt(dim), jnp.sqrt(dim) * 0.25, inverse_mass_matrix=jnp.ones((dim,))
-    )
+    if params is None:
+        params = MCLMCAdaptationState(
+            jnp.sqrt(dim), jnp.sqrt(dim) * 0.25, inverse_mass_matrix=jnp.ones((dim,))
+        )
+
     part1_key, part2_key = jax.random.split(rng_key, 2)
+    total_num_tuning_integrator_steps = 0
+
+    num_steps1, num_steps2 = round(num_steps * frac_tune1), round(num_steps * frac_tune2)
+    num_steps2 += diagonal_preconditioning * (num_steps2 // 3)
+    num_steps3 = round(num_steps * frac_tune3)
 
     state, params = make_L_step_size_adaptation(
         kernel=mclmc_kernel,
@@ -120,13 +130,15 @@ def mclmc_find_L_and_step_size(
         num_effective_samples=num_effective_samples,
         diagonal_preconditioning=diagonal_preconditioning,
     )(state, params, num_steps, part1_key)
+    total_num_tuning_integrator_steps += num_steps1 + num_steps2
 
-    if frac_tune3 != 0:
+    if num_steps3 >= 2: # at least 2 samples for ESS estimation
         state, params = make_adaptation_L(
             mclmc_kernel(params.inverse_mass_matrix), frac=frac_tune3, Lfactor=0.4
         )(state, params, num_steps, part2_key)
+        total_num_tuning_integrator_steps += num_steps3
 
-    return state, params, num_steps * (frac_tune1 + frac_tune2 + frac_tune3)
+    return state, params, total_num_tuning_integrator_steps
 
 
 def make_L_step_size_adaptation(
@@ -225,10 +237,8 @@ def make_L_step_size_adaptation(
     )[0]
 
     def L_step_size_adaptation(state, params, num_steps, rng_key):
-        num_steps1, num_steps2 = (
-            int(num_steps * frac_tune1) + 1,
-            int(num_steps * frac_tune2) + 1,
-        )
+        num_steps1, num_steps2 = round(num_steps * frac_tune1), round(num_steps * frac_tune2)
+
         L_step_size_adaptation_keys = jax.random.split(
             rng_key, num_steps1 + num_steps2 + 1
         )
@@ -259,7 +269,7 @@ def make_L_step_size_adaptation(
                 L = jnp.sqrt(dim)
 
                 # readjust the stepsize
-                steps = num_steps2 // 3  # we do some small number of steps
+                steps = round(num_steps2 / 3)  # we do some small number of steps
                 keys = jax.random.split(final_key, steps)
                 state, params, _, (_, average) = run_steps(
                     xs=(jnp.ones(steps), keys), state=state, params=params
@@ -274,7 +284,7 @@ def make_adaptation_L(kernel, frac, Lfactor):
     """determine L by the autocorrelations (around 10 effective samples are needed for this to be accurate)"""
 
     def adaptation_L(state, params, num_steps, key):
-        num_steps_3 = int(num_steps * frac)
+        num_steps_3 = round(num_steps * frac)
         adaptation_L_keys = jax.random.split(key, num_steps_3)
 
         def step(state, key):

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -115,6 +115,7 @@ def effective_sample_size(
     sample_axis = sample_axis if sample_axis >= 0 else len(input_shape) + sample_axis
     num_chains = input_shape[chain_axis]
     num_samples = input_shape[sample_axis]
+    assert num_samples > 1, f"The input array must have at least 2 samples, got only {num_samples}."
 
     mean_across_chain = input_array.mean(axis=sample_axis, keepdims=True)
     # Compute autocovariance estimates for every lag for the input array using FFT.

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -115,7 +115,9 @@ def effective_sample_size(
     sample_axis = sample_axis if sample_axis >= 0 else len(input_shape) + sample_axis
     num_chains = input_shape[chain_axis]
     num_samples = input_shape[sample_axis]
-    assert num_samples > 1, f"The input array must have at least 2 samples, got only {num_samples}."
+    assert (
+        num_samples > 1
+    ), f"The input array must have at least 2 samples, got only {num_samples}."
 
     mean_across_chain = input_array.mean(axis=sample_axis, keepdims=True)
     # Compute autocovariance estimates for every lag for the input array using FFT.


### PR DESCRIPTION
PR for https://github.com/blackjax-devs/blackjax/issues/777

Fix MCLMC number of integration steps for tuning, and allow initial guess for parameters.

 - [x] We should be able to understand what the PR does from its title only;
 - [x] There is a high-level description of the changes;
 - [x] There are links to *all* the relevant issues, discussions and PRs;
 - [x] The branch is rebased on the latest `main` commit;
 - [ ] Commit messages follow these [guidelines](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html);
 - [x] The code respects the current naming conventions;
 - [x] Docstrings follow the [numpy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 - [x] `pre-commit` is installed and configured on your machine, and you ran it before opening the PR;
 - [x] There are tests covering the changes;
 - [x] The doc is up-to-date;

I just don't know @reubenharry if you prefer `make_L_step_size_adaptation` to also return the number of steps as in `adjusted_mclmc_make_L_step_size_adaptation`, or to compute it outside the function. I opted for latter as the least modifying update.