### PR TITLE
Align Pathfinder with VIAlgorithm and fix VIAlgorithm docstring

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -46,7 +46,6 @@ from .vi import meanfield_vi as _meanfield_vi
 from .vi import pathfinder as _pathfinder
 from .vi import schrodinger_follmer as _schrodinger_follmer
 from .vi import svgd as _svgd
-from .vi.pathfinder import PathFinderAlgorithm
 
 """
 The above three classes exist as a backwards compatible way of exposing both the high level, differentiable
@@ -85,7 +84,7 @@ class GeneratePathfinderAPI:
     approximate: Callable
     sample: Callable
 
-    def __call__(self, *args, **kwargs) -> PathFinderAlgorithm:
+    def __call__(self, *args, **kwargs) -> VIAlgorithm:
         return self.differentiable(*args, **kwargs)
 
 

--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -114,20 +114,22 @@ class SamplingAlgorithm(NamedTuple):
 
 
 class VIAlgorithm(NamedTuple):
-    """A pair of functions that represents a Variational Inference algorithm.
+    """A trio of functions that represents a Variational Inference algorithm.
 
-    Blackjax variational inference algorithms are implemented as a pair of pure
-    functions: an approximator, which takes a target probability density (and
-    potentially a guide), and a sampling function that uses the approximation to
-    draw samples.
+    Blackjax variational inference algorithms are implemented as three pure
+    functions: an initializer, an update step, and a sampler.
 
-    approximate
-        A pure function, which when called with an initial position (and
-        potentially a guide function) returns a state that allows to build
-        an approximation to the target probability density function.
+    init
+        A pure function which initializes the VI state from an initial position.
+        For iterative algorithms (e.g. mean-field VI) this sets up the optimizer
+        state. For one-shot algorithms (e.g. Pathfinder) this builds the full
+        approximation.
+    step
+        A pure function that advances the VI approximation by one step, taking
+        a rng key and the current state and returning an updated state and
+        diagnostic info. For one-shot algorithms this is a no-op.
     sample
-        A pure function which returns samples from the approximation computed
-        by `approximate`.
+        A pure function that draws samples from the current approximation.
 
     """
 

--- a/blackjax/vi/pathfinder.py
+++ b/blackjax/vi/pathfinder.py
@@ -18,6 +18,7 @@ import jax.numpy as jnp
 import jax.random
 from jax.flatten_util import ravel_pytree
 
+from blackjax.base import VIAlgorithm
 from blackjax.optimizers.lbfgs import (
     _minimize_lbfgs,
     bfgs_sample,
@@ -61,11 +62,6 @@ class PathfinderInfo(NamedTuple):
     """Extra information returned by the Pathfinder algorithm."""
 
     path: PathfinderState
-
-
-class PathFinderAlgorithm(NamedTuple):
-    approximate: Callable
-    sample: Callable
 
 
 def approximate(
@@ -242,7 +238,7 @@ def sample(
         return jax.vmap(unravel_fn)(phi), logq
 
 
-def as_top_level_api(logdensity_fn: Callable) -> PathFinderAlgorithm:
+def as_top_level_api(logdensity_fn: Callable) -> VIAlgorithm:
     """Implements the (basic) user interface for the pathfinder kernel.
 
     Pathfinder locates normal approximations to the target density along a
@@ -251,8 +247,8 @@ def as_top_level_api(logdensity_fn: Callable) -> PathFinderAlgorithm:
     Pathfinder returns draws from the approximation with the lowest estimated
     Kullback-Leibler (KL) divergence to the true posterior.
 
-    Note: all the heavy processing in performed in the init function, step
-    function is just a drawing a sample from a normal distribution
+    As Pathfinder is a one-shot algorithm, the returned ``VIAlgorithm.step``
+    is a no-op; all computation happens inside ``VIAlgorithm.init``.
 
     Parameters
     ----------
@@ -262,11 +258,11 @@ def as_top_level_api(logdensity_fn: Callable) -> PathFinderAlgorithm:
 
     Returns
     -------
-    A ``VISamplingAlgorithm``.
+    A ``VIAlgorithm``.
 
     """
 
-    def approximate_fn(
+    def init_fn(
         rng_key: PRNGKey,
         position: ArrayLikeTree,
         num_samples: int = 200,
@@ -276,7 +272,11 @@ def as_top_level_api(logdensity_fn: Callable) -> PathFinderAlgorithm:
             rng_key, logdensity_fn, position, num_samples, **lbfgs_parameters
         )
 
+    def step_fn(rng_key: PRNGKey, state: PathfinderState):
+        """Pathfinder is one-shot; this is a no-op for API compatibility."""
+        return state, PathfinderInfo(path=state)
+
     def sample_fn(rng_key: PRNGKey, state: PathfinderState, num_samples: int):
         return sample(rng_key, state, num_samples)
 
-    return PathFinderAlgorithm(approximate_fn, sample_fn)
+    return VIAlgorithm(init_fn, step_fn, sample_fn)

--- a/tests/optimizers/test_pathfinder.py
+++ b/tests/optimizers/test_pathfinder.py
@@ -70,7 +70,7 @@ class PathfinderTest(chex.TestCase):
 
         x0 = jnp.ones(ndim)
         pathfinder = blackjax.pathfinder(logp_model)
-        out, _ = self.variant(pathfinder.approximate)(rng_key_pathfinder, x0)
+        out, _ = self.variant(pathfinder.init)(rng_key_pathfinder, x0)
 
         sim_p, log_p = bfgs_sample(
             rng_key_pathfinder,


### PR DESCRIPTION
## Summary

- **Fix `VIAlgorithm` docstring** (`base.py`): the docstring described `approximate` and `sample` fields that don't exist; the actual fields are `init`, `step`, and `sample`. Updated to accurately describe each field, with notes on how one-shot vs iterative algorithms differ.

- **Remove `PathFinderAlgorithm`** (`pathfinder.py`): `as_top_level_api` now returns the standard `VIAlgorithm(init, step, sample)` instead of the custom `PathFinderAlgorithm(approximate, sample)`. The mapping is:
  - `init` ← former `approximate` (runs L-BFGS + ELBO selection, all in one call)
  - `step` ← no-op (Pathfinder is one-shot; field exists for API consistency with iterative VI)
  - `sample` ← unchanged

- **Update `__init__.py`**: `GeneratePathfinderAPI.__call__` return type updated to `VIAlgorithm`.

- **Update test**: `pathfinder.approximate(...)` → `pathfinder.init(...)`.

Note: `blackjax.pathfinder.approximate` (direct function access on the `GeneratePathfinderAPI` object) is unchanged and still works.

Closes #700
Closes #465

## Test plan

- [x] `pytest tests/optimizers/test_pathfinder.py tests/vi/` — 12 passed, 1 skipped
- [x] `pre-commit run --all-files` — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)