### PR TITLE
Refactor lambda-assigned run_steps to named function in mclmc_adaptation

### DIFF
--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -235,16 +235,18 @@ def make_L_step_size_adaptation(
 
         return (state, params, adaptive_state, streaming_avg), None
 
-    run_steps = lambda xs, state, params: jax.lax.scan(
-        step,
-        init=(
-            state,
-            params,
-            (0.0, 0.0, jnp.inf),
-            (0.0, jnp.array([jnp.zeros(dim), jnp.zeros(dim)])),
-        ),
-        xs=xs,
-    )[0]
+    def run_steps(xs, state, params):
+        """Run adaptation steps via scan, returning final carry state."""
+        return jax.lax.scan(
+            step,
+            init=(
+                state,
+                params,
+                (0.0, 0.0, jnp.inf),
+                (0.0, jnp.array([jnp.zeros(dim), jnp.zeros(dim)])),
+            ),
+            xs=xs,
+        )[0]
 
     def L_step_size_adaptation(state, params, num_steps, rng_key):
         num_steps1, num_steps2 = round(num_steps * frac_tune1), round(


### PR DESCRIPTION
## Summary

- Convert lambda-assigned `run_steps` in `mclmc_adaptation.py` to a proper `def` with docstring
- Lambda assignments violate PEP 8 (E731) and make the code harder to read/debug
- Phase 7.5 of the code quality review

## Test plan
- [x] mclmc-related tests pass locally
- [x] Pre-commit passes
- [x] CI passes