### PR TITLE
Refactor mclmc build_kernel to standard pattern (Phase 7.2)

### DIFF
--- a/blackjax/adaptation/laps_burn_in.py
+++ b/blackjax/adaptation/laps_burn_in.py
@@ -45,18 +45,18 @@ def build_kernel(logdensity_fn, ndims, microcanonical=True):
     """MCLMC kernel (with nan rejection)"""
 
     if microcanonical:
-        kernel = mclmc.build_kernel(
-            integrator=isokinetic_velocity_verlet,
-            logdensity_fn=logdensity_fn,
-            inverse_mass_matrix=jnp.ones(ndims),
-        )
+        kernel = mclmc.build_kernel(integrator=isokinetic_velocity_verlet)
     else:
         raise ValueError("Only microcanonical mode is supported for LAPS burn-in.")
+
+    inverse_mass_matrix = jnp.ones(ndims)
 
     def sequential_kernel(key, state, adap):
         new_state, info = kernel(
             key,
             state,
+            logdensity_fn,
+            inverse_mass_matrix,
             adap.L,
             adap.step_size,
         )

--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -44,6 +44,7 @@ def mclmc_find_L_and_step_size(
     num_steps,
     state,
     rng_key,
+    logdensity_fn=None,
     frac_tune1=0.1,
     frac_tune2=0.1,
     frac_tune3=0.1,
@@ -60,13 +61,17 @@ def mclmc_find_L_and_step_size(
     Parameters
     ----------
     mclmc_kernel
-        The kernel function used for the MCMC algorithm.
+        The kernel function built by ``mclmc.build_kernel``.  Its call signature
+        must be ``kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L,
+        step_size)``, matching the standard BlackJAX kernel pattern.
     num_steps
         The number of MCMC steps that will subsequently be run, after tuning.
     state
         The initial state of the MCMC algorithm.
     rng_key
         The random number generator key.
+    logdensity_fn
+        The log-density function of the target distribution.
     frac_tune1
         The fraction of tuning for the first step of the adaptation.
     frac_tune2
@@ -93,23 +98,26 @@ def mclmc_find_L_and_step_size(
     Example
     -------
     .. code::
-        kernel = lambda inverse_mass_matrix : blackjax.mcmc.mclmc.build_kernel(
-        logdensity_fn=logdensity_fn,
-        integrator=integrator,
-        inverse_mass_matrix=inverse_mass_matrix,
-        )
+        kernel = blackjax.mcmc.mclmc.build_kernel(integrator=integrator)
 
         (
             blackjax_state_after_tuning,
             blackjax_mclmc_sampler_params,
         ) = blackjax.mclmc_find_L_and_step_size(
             mclmc_kernel=kernel,
+            logdensity_fn=logdensity_fn,
             num_steps=num_steps,
             state=initial_state,
             rng_key=tune_key,
             diagonal_preconditioning=preconditioning,
         )
     """
+    if logdensity_fn is None:
+        raise ValueError(
+            "logdensity_fn is required. Pass the log-density function of the "
+            "target distribution."
+        )
+
     dim = pytree_size(state.position)
     if params is None:
         params = MCLMCAdaptationState(
@@ -127,6 +135,7 @@ def mclmc_find_L_and_step_size(
 
     state, params = make_L_step_size_adaptation(
         kernel=mclmc_kernel,
+        logdensity_fn=logdensity_fn,
         dim=dim,
         frac_tune1=frac_tune1,
         frac_tune2=frac_tune2,
@@ -139,7 +148,7 @@ def mclmc_find_L_and_step_size(
 
     if num_steps3 >= 2:  # at least 2 samples for ESS estimation
         state, params = make_adaptation_L(
-            mclmc_kernel(params.inverse_mass_matrix), frac=frac_tune3, l_factor=l_factor
+            mclmc_kernel, logdensity_fn, frac=frac_tune3, l_factor=l_factor
         )(state, params, num_steps, part2_key)
         total_num_tuning_integrator_steps += num_steps3
 
@@ -148,6 +157,7 @@ def mclmc_find_L_and_step_size(
 
 def make_L_step_size_adaptation(
     kernel,
+    logdensity_fn,
     dim,
     frac_tune1,
     frac_tune2,
@@ -169,9 +179,11 @@ def make_L_step_size_adaptation(
         rng_key, nan_key = jax.random.split(rng_key)
 
         # dynamics
-        next_state, info = kernel(params.inverse_mass_matrix)(
+        next_state, info = kernel(
             rng_key=rng_key,
             state=previous_state,
+            logdensity_fn=logdensity_fn,
+            inverse_mass_matrix=params.inverse_mass_matrix,
             L=params.L,
             step_size=params.step_size,
         )
@@ -294,7 +306,7 @@ def make_L_step_size_adaptation(
     return L_step_size_adaptation
 
 
-def make_adaptation_L(kernel, frac, l_factor):
+def make_adaptation_L(kernel, logdensity_fn, frac, l_factor):
     """determine L by the autocorrelations (around 10 effective samples are needed for this to be accurate)"""
 
     def adaptation_L(state, params, num_steps, key):
@@ -305,6 +317,8 @@ def make_adaptation_L(kernel, frac, l_factor):
             next_state, _ = kernel(
                 rng_key=key,
                 state=state,
+                logdensity_fn=logdensity_fn,
+                inverse_mass_matrix=params.inverse_mass_matrix,
                 L=params.L,
                 step_size=params.step_size,
             )

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -63,9 +63,7 @@ def init(position: ArrayLike, logdensity_fn, rng_key):
 
 
 def build_kernel(
-    logdensity_fn: Callable,
-    inverse_mass_matrix: ArrayLike,
-    integrator: Callable,
+    integrator: Callable = isokinetic_mclachlan,
     desired_energy_var_max_ratio: float = jnp.inf,
     desired_energy_var: float = 5e-4,
 ):
@@ -73,10 +71,6 @@ def build_kernel(
 
     Parameters
     ----------
-    logdensity_fn
-        The log-density function we wish to draw samples from.
-    inverse_mass_matrix
-        A matrix used for preconditioning.
     integrator
         The isokinetic integrator to use.
     desired_energy_var_max_ratio
@@ -93,13 +87,20 @@ def build_kernel(
 
     """
 
-    step = with_isokinetic_maruyama(
-        integrator(logdensity_fn=logdensity_fn, inverse_mass_matrix=inverse_mass_matrix)
-    )
-
     def kernel(
-        rng_key: PRNGKey, state: IntegratorState, L: float, step_size: float
+        rng_key: PRNGKey,
+        state: IntegratorState,
+        logdensity_fn: Callable,
+        inverse_mass_matrix: ArrayLike,
+        L: float,
+        step_size: float,
     ) -> tuple[IntegratorState, MCLMCInfo]:
+        step = with_isokinetic_maruyama(
+            integrator(
+                logdensity_fn=logdensity_fn, inverse_mass_matrix=inverse_mass_matrix
+            )
+        )
+
         kernel_key, energy_cutoff_key, nan_key = jax.random.split(rng_key, 3)
 
         (position, momentum, logdensity, logdensity_grad), kinetic_change = step(
@@ -187,15 +188,13 @@ def as_top_level_api(
     kernel = build_kernel(
         integrator=integrator,
         desired_energy_var_max_ratio=desired_energy_var_max_ratio,
-        inverse_mass_matrix=inverse_mass_matrix,
-        logdensity_fn=logdensity_fn,
     )
 
     def init_fn(position: ArrayLike, rng_key: PRNGKey):
         return init(position, logdensity_fn, rng_key)
 
     def step_fn(rng_key, state):
-        return kernel(rng_key, state, L, step_size)
+        return kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size)
 
     return SamplingAlgorithm(init_fn, step_fn)
 

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -424,11 +424,9 @@ def thin_kernel(
                     rng_key=init_key
                     )
 
-        kernel = lambda inverse_mass_matrix: thin_kernel(
+        kernel = thin_kernel(
             blackjax.mcmc.mclmc.build_kernel(
-                                logdensity_fn=logdf,
                                 integrator=isokinetic_mclachlan,
-                                inverse_mass_matrix=inverse_mass_matrix,
                                 ),
 
             # Return every 16th state, especially decreasing computation and memory cost
@@ -441,6 +439,7 @@ def thin_kernel(
 
         state, params, n_steps = blackjax.mclmc_find_L_and_step_size(
             mclmc_kernel=kernel,
+            logdensity_fn=logdf,
             num_steps=100,
             state=state,
             rng_key=tune_key,

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -114,10 +114,8 @@ class LinearRegressionTest(chex.TestCase):
             position=initial_position, logdensity_fn=logdensity_fn, rng_key=init_key
         )
 
-        kernel = lambda inverse_mass_matrix: blackjax.mcmc.mclmc.build_kernel(
-            logdensity_fn=logdensity_fn,
+        kernel = blackjax.mcmc.mclmc.build_kernel(
             integrator=blackjax.mcmc.mclmc.isokinetic_mclachlan,
-            inverse_mass_matrix=inverse_mass_matrix,
         )
 
         (
@@ -126,6 +124,7 @@ class LinearRegressionTest(chex.TestCase):
             _,
         ) = blackjax.mclmc_find_L_and_step_size(
             mclmc_kernel=kernel,
+            logdensity_fn=logdensity_fn,
             num_steps=num_steps,
             state=initial_state,
             rng_key=tune_key,
@@ -536,14 +535,11 @@ class LinearRegressionTest(chex.TestCase):
                 rng_key=init_key,
             )
 
-            kernel = lambda inverse_mass_matrix: blackjax.mcmc.mclmc.build_kernel(
-                logdensity_fn=model.logdensity_fn,
-                inverse_mass_matrix=inverse_mass_matrix,
-                integrator=integrator,
-            )
+            kernel = blackjax.mcmc.mclmc.build_kernel(integrator=integrator)
 
             (_, blackjax_mclmc_sampler_params, _) = blackjax.mclmc_find_L_and_step_size(
                 mclmc_kernel=kernel,
+                logdensity_fn=model.logdensity_fn,
                 num_steps=num_steps,
                 state=initial_state,
                 rng_key=tune_key,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -141,17 +141,13 @@ class ThinInferenceAlgorithmTest(chex.TestCase):
         )
 
         if thinning == 1:
-            kernel = lambda inverse_mass_matrix: blackjax.mcmc.mclmc.build_kernel(
+            kernel = blackjax.mcmc.mclmc.build_kernel(
                 integrator=isokinetic_mclachlan,
-                logdensity_fn=self.logdf,
-                inverse_mass_matrix=inverse_mass_matrix,
             )
         else:
-            kernel = lambda inverse_mass_matrix: thin_kernel(
+            kernel = thin_kernel(
                 blackjax.mcmc.mclmc.build_kernel(
                     integrator=isokinetic_mclachlan,
-                    logdensity_fn=self.logdf,
-                    inverse_mass_matrix=inverse_mass_matrix,
                 ),
                 thinning=thinning,
                 info_transform=lambda info: tree.map(
@@ -161,6 +157,7 @@ class ThinInferenceAlgorithmTest(chex.TestCase):
 
         state, config, n_steps = blackjax.mclmc_find_L_and_step_size(
             mclmc_kernel=kernel,
+            logdensity_fn=self.logdf,
             num_steps=num_steps,
             state=state,
             rng_key=tune_key,


### PR DESCRIPTION
## Summary
- Moves `logdensity_fn` and `inverse_mass_matrix` from `build_kernel()` parameters to the kernel's call signature, matching the HMC/NUTS convention
- **Before**: `kernel = lambda imm: mclmc.build_kernel(logdensity_fn, imm, integrator)` then `kernel(imm)(rng_key, state, L, step_size)`
- **After**: `kernel = mclmc.build_kernel(integrator=integrator)` then `kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size)`
- Eliminates the factory-lambda indirection in adaptation code
- `mclmc_find_L_and_step_size` now takes `logdensity_fn` as an explicit parameter
- Updated: `mclmc.py`, `mclmc_adaptation.py`, `laps_burn_in.py`, `util.py` docstring, tests

**Breaking change**: `mclmc.build_kernel` signature changed. Users who call `build_kernel` directly need to update (the `as_top_level_api` / `blackjax.mclmc(...)` interface is unchanged).

## Test plan
- [x] All 20 `test_util.py` tests pass (including thinning tests)
- [x] All 4 mclmc sampling tests pass
- [x] All 12 mclmc protocol tests pass
- [x] `pre-commit` passes
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)