### PR TITLE
Add build_sampling_algorithm helper to reduce boilerplate (7.7)

### DIFF
--- a/blackjax/adaptation/laps.py
+++ b/blackjax/adaptation/laps.py
@@ -262,17 +262,17 @@ def laps(
     if microcanonical:
         integrator = generate_isokinetic_integrator(_integrator_coefficients)
 
-        build_kernel = build_kernel_mclmc(
+        built_kernel = build_kernel_mclmc(
             integrator=integrator,
-            logdensity_fn=logdensity_fn,
-            inverse_mass_matrix=inverse_mass_matrix,
         )
 
-        kernel = lambda key, state, adap: build_kernel(
+        kernel = lambda key, state, adap: built_kernel(
             rng_key=key,
             state=state,
+            logdensity_fn=logdensity_fn,
             step_size=adap.step_size,
             num_integration_steps=adap.steps_per_sample,
+            inverse_mass_matrix=inverse_mass_matrix,
             L_proposal_factor=1.25,
         )
 

--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -265,7 +265,7 @@ def meads_adaptation(
 
     ghmc_kernel = mcmc.ghmc.build_kernel()
     adapt_init, _ = base(num_folds, step_size_multiplier, damping_slowdown)
-    batch_init = jax.vmap(lambda p, r: mcmc.ghmc.init(p, r, logdensity_fn))
+    batch_init = jax.vmap(lambda p, r: mcmc.ghmc.init(p, logdensity_fn, r))
 
     def one_step(carry, rng_key):
         states, adaptation_state = carry

--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -154,6 +154,7 @@ class AdaptationAlgorithm(NamedTuple):
 def build_sampling_algorithm(
     kernel: Callable,
     init_state: Callable,
+    logdensity_fn: Callable,
     init_args: tuple = (),
     kernel_args: tuple = (),
     *,
@@ -170,19 +171,21 @@ def build_sampling_algorithm(
     ----------
     kernel
         A kernel function with signature
-        ``(rng_key, state, *kernel_args) -> (state, info)``.
+        ``(rng_key, state, logdensity_fn, *kernel_args) -> (state, info)``.
     init_state
         An initialization function with signature
-        ``(position, *init_args) -> state`` (or
-        ``(position, *init_args, rng_key) -> state`` when
+        ``(position, logdensity_fn, *init_args) -> state`` (or
+        ``(position, logdensity_fn, *init_args, rng_key) -> state`` when
         ``pass_rng_key_to_init`` is True).
+    logdensity_fn
+        The log-density function of the target distribution.  Passed to both
+        ``init_state`` and ``kernel``.
     init_args
         Extra positional arguments forwarded to ``init_state`` after
-        ``position`` (e.g. ``(logdensity_fn,)``).
+        ``logdensity_fn`` (e.g. extra state needed for initialization).
     kernel_args
         Extra positional arguments forwarded to ``kernel`` after
-        ``(rng_key, state)`` on every step
-        (e.g. ``(logdensity_fn, step_size, metric)``).
+        ``logdensity_fn`` on every step (e.g. ``(step_size, metric)``).
     pass_rng_key_to_init
         If True, ``rng_key`` is appended to the ``init_state`` call
         (for algorithms like mclmc/ghmc that need it for initialization).
@@ -194,10 +197,10 @@ def build_sampling_algorithm(
 
     def init_fn(position: Position, rng_key: PRNGKey | None = None):
         if pass_rng_key_to_init:
-            return init_state(position, *init_args, rng_key)
-        return init_state(position, *init_args)
+            return init_state(position, logdensity_fn, *init_args, rng_key)
+        return init_state(position, logdensity_fn, *init_args)
 
     def step_fn(rng_key: PRNGKey, state: State) -> tuple[State, Info]:
-        return kernel(rng_key, state, *kernel_args)
+        return kernel(rng_key, state, logdensity_fn, *kernel_args)
 
     return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -149,3 +149,47 @@ class AdaptationAlgorithm(NamedTuple):
     """A function that implements an adaptation algorithm."""
 
     run: RunFn
+
+
+def build_sampling_algorithm(
+    logdensity_fn: Callable,
+    kernel: Callable,
+    init_state: Callable,
+    *kernel_parameters,
+) -> SamplingAlgorithm:
+    """Build a ``SamplingAlgorithm`` from standard components.
+
+    Most BlackJAX MCMC algorithms follow the same boilerplate in their
+    ``as_top_level_api`` functions: create an ``init_fn`` that delegates to the
+    module-level ``init`` and a ``step_fn`` that calls the built kernel with
+    fixed parameters.  This helper eliminates that repetition.
+
+    Parameters
+    ----------
+    logdensity_fn
+        The log-density function of the target distribution.  Passed to both
+        ``init_state`` (to compute the initial log-density) and ``kernel`` (as
+        the first argument after ``state``).
+    kernel
+        A kernel function with signature
+        ``(rng_key, state, logdensity_fn, *kernel_parameters) -> (state, info)``.
+    init_state
+        An initialization function with signature
+        ``(position, logdensity_fn) -> state``.
+    *kernel_parameters
+        Extra positional arguments forwarded to ``kernel`` after
+        ``logdensity_fn`` on every step (e.g. ``step_size``, ``metric``).
+
+    Returns
+    -------
+    A ``SamplingAlgorithm``.
+    """
+
+    def init_fn(position: Position, rng_key: PRNGKey | None = None):
+        del rng_key
+        return init_state(position, logdensity_fn)
+
+    def step_fn(rng_key: PRNGKey, state: State) -> tuple[State, Info]:
+        return kernel(rng_key, state, logdensity_fn, *kernel_parameters)
+
+    return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -152,10 +152,12 @@ class AdaptationAlgorithm(NamedTuple):
 
 
 def build_sampling_algorithm(
-    logdensity_fn: Callable,
     kernel: Callable,
     init_state: Callable,
-    *kernel_parameters,
+    init_args: tuple = (),
+    kernel_args: tuple = (),
+    *,
+    pass_rng_key_to_init: bool = False,
 ) -> SamplingAlgorithm:
     """Build a ``SamplingAlgorithm`` from standard components.
 
@@ -166,19 +168,24 @@ def build_sampling_algorithm(
 
     Parameters
     ----------
-    logdensity_fn
-        The log-density function of the target distribution.  Passed to both
-        ``init_state`` (to compute the initial log-density) and ``kernel`` (as
-        the first argument after ``state``).
     kernel
         A kernel function with signature
-        ``(rng_key, state, logdensity_fn, *kernel_parameters) -> (state, info)``.
+        ``(rng_key, state, *kernel_args) -> (state, info)``.
     init_state
         An initialization function with signature
-        ``(position, logdensity_fn) -> state``.
-    *kernel_parameters
+        ``(position, *init_args) -> state`` (or
+        ``(position, *init_args, rng_key) -> state`` when
+        ``pass_rng_key_to_init`` is True).
+    init_args
+        Extra positional arguments forwarded to ``init_state`` after
+        ``position`` (e.g. ``(logdensity_fn,)``).
+    kernel_args
         Extra positional arguments forwarded to ``kernel`` after
-        ``logdensity_fn`` on every step (e.g. ``step_size``, ``metric``).
+        ``(rng_key, state)`` on every step
+        (e.g. ``(logdensity_fn, step_size, metric)``).
+    pass_rng_key_to_init
+        If True, ``rng_key`` is appended to the ``init_state`` call
+        (for algorithms like mclmc/ghmc that need it for initialization).
 
     Returns
     -------
@@ -186,10 +193,11 @@ def build_sampling_algorithm(
     """
 
     def init_fn(position: Position, rng_key: PRNGKey | None = None):
-        del rng_key
-        return init_state(position, logdensity_fn)
+        if pass_rng_key_to_init:
+            return init_state(position, *init_args, rng_key)
+        return init_state(position, *init_args)
 
     def step_fn(rng_key: PRNGKey, state: State) -> tuple[State, Info]:
-        return kernel(rng_key, state, logdensity_fn, *kernel_parameters)
+        return kernel(rng_key, state, *kernel_args)
 
     return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/mcmc/adjusted_mclmc.py
+++ b/blackjax/mcmc/adjusted_mclmc.py
@@ -156,9 +156,8 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (
-            logdensity_fn,
+        logdensity_fn,
+        kernel_args=(
             step_size,
             num_integration_steps,
             inverse_mass_matrix,

--- a/blackjax/mcmc/adjusted_mclmc.py
+++ b/blackjax/mcmc/adjusted_mclmc.py
@@ -22,7 +22,7 @@ import jax
 import jax.numpy as jnp
 
 import blackjax.mcmc.integrators as integrators
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.hmc import HMCInfo, HMCState
 from blackjax.mcmc.proposal import static_binomial_sampling
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
@@ -50,24 +50,18 @@ def init(position: ArrayLikeTree, logdensity_fn: Callable) -> HMCState:
 
 
 def build_kernel(
-    logdensity_fn: Callable,
     integrator: Callable = integrators.isokinetic_mclachlan,
     divergence_threshold: float = 1000,
-    inverse_mass_matrix=1.0,
 ):
     """Build an MHMCHMC kernel.
 
     Parameters
     ----------
-    logdensity_fn
-        The log-density function of the target distribution.
     integrator
         The symplectic integrator to use to integrate the Hamiltonian dynamics.
     divergence_threshold
         Value of the difference in energy above which we consider that the
         transition is divergent.
-    inverse_mass_matrix
-        Inverse mass matrix for the isokinetic integrator. Scalar or array.
 
     Returns
     -------
@@ -79,8 +73,10 @@ def build_kernel(
     def kernel(
         rng_key: PRNGKey,
         state: HMCState,
+        logdensity_fn: Callable,
         step_size: float,
         num_integration_steps: int,
+        inverse_mass_matrix=1.0,
         L_proposal_factor: float = jnp.inf,
     ) -> tuple[HMCState, HMCInfo]:
         """Generate a new sample with the MHMCHMC kernel."""
@@ -154,26 +150,21 @@ def as_top_level_api(
     """
 
     kernel = build_kernel(
-        logdensity_fn=logdensity_fn,
         integrator=integrator,
-        inverse_mass_matrix=inverse_mass_matrix,
         divergence_threshold=divergence_threshold,
     )
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def update_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key=rng_key,
-            state=state,
-            step_size=step_size,
-            num_integration_steps=num_integration_steps,
-            L_proposal_factor=L_proposal_factor,
-        )
-
-    return SamplingAlgorithm(init_fn, update_fn)  # type: ignore[arg-type]
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (
+            logdensity_fn,
+            step_size,
+            num_integration_steps,
+            inverse_mass_matrix,
+            L_proposal_factor,
+        ),
+    )
 
 
 def adjusted_mclmc_proposal(

--- a/blackjax/mcmc/adjusted_mclmc_dynamic.py
+++ b/blackjax/mcmc/adjusted_mclmc_dynamic.py
@@ -170,8 +170,8 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, step_size, L_proposal_factor),
+        logdensity_fn,
+        kernel_args=(step_size, L_proposal_factor),
         pass_rng_key_to_init=True,
     )
 

--- a/blackjax/mcmc/adjusted_mclmc_dynamic.py
+++ b/blackjax/mcmc/adjusted_mclmc_dynamic.py
@@ -18,7 +18,7 @@ import jax
 import jax.numpy as jnp
 
 import blackjax.mcmc.integrators as integrators
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.dynamic_hmc import DynamicHMCState, halton_sequence
 from blackjax.mcmc.hmc import HMCInfo
 from blackjax.mcmc.proposal import static_binomial_sampling
@@ -167,19 +167,13 @@ def as_top_level_api(
         divergence_threshold=divergence_threshold,
     )
 
-    def init_fn(position: ArrayLikeTree, rng_key: Array):
-        return init(position, logdensity_fn, rng_key)
-
-    def update_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            L_proposal_factor,
-        )
-
-    return SamplingAlgorithm(init_fn, update_fn)  # type: ignore[arg-type]
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, step_size, L_proposal_factor),
+        pass_rng_key_to_init=True,
+    )
 
 
 def adjusted_mclmc_proposal(

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -220,7 +220,7 @@ def as_top_level_api(
         else None
     )
     return build_sampling_algorithm(
-        kernel, init, (logdensity_fn,), (logdensity_fn, step_size, metric)
+        kernel, init, logdensity_fn, kernel_args=(step_size, metric)
     )
 
 

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -219,7 +219,9 @@ def as_top_level_api(
         if inverse_mass_matrix is not None
         else None
     )
-    return build_sampling_algorithm(logdensity_fn, kernel, init, step_size, metric)
+    return build_sampling_algorithm(
+        kernel, init, (logdensity_fn,), (logdensity_fn, step_size, metric)
+    )
 
 
 def _generate_bernoulli(

--- a/blackjax/mcmc/barker.py
+++ b/blackjax/mcmc/barker.py
@@ -20,7 +20,7 @@ from jax.flatten_util import ravel_pytree
 from jax.scipy import stats
 
 import blackjax.mcmc.metrics as metrics
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.metrics import Metric
 from blackjax.mcmc.proposal import static_binomial_sampling
 from blackjax.types import ArrayLikeTree, ArrayTree, Numeric, PRNGKey
@@ -219,15 +219,7 @@ def as_top_level_api(
         if inverse_mass_matrix is not None
         else None
     )
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(rng_key, state, logdensity_fn, step_size, metric)
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(logdensity_fn, kernel, init, step_size, metric)
 
 
 def _generate_bernoulli(

--- a/blackjax/mcmc/dynamic_hmc.py
+++ b/blackjax/mcmc/dynamic_hmc.py
@@ -168,8 +168,8 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, step_size, inverse_mass_matrix),
+        logdensity_fn,
+        kernel_args=(step_size, inverse_mass_matrix),
         pass_rng_key_to_init=True,
     )
 

--- a/blackjax/mcmc/dynamic_hmc.py
+++ b/blackjax/mcmc/dynamic_hmc.py
@@ -19,7 +19,7 @@ import jax
 import jax.numpy as jnp
 
 import blackjax.mcmc.integrators as integrators
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.hmc import HMCInfo, HMCState
 from blackjax.mcmc.hmc import build_kernel as build_static_hmc_kernel
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
@@ -165,22 +165,13 @@ def as_top_level_api(
         integration_steps_fn,
     )
 
-    def init_fn(position: ArrayLikeTree, rng_key: Array):
-        # Note that rng_key here is not necessarily a PRNGKey, could be a Array that
-        # for generates a sequence of pseudo or quasi-random numbers (previously
-        # named as `random_generator_arg`)
-        return init(position, logdensity_fn, rng_key)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            inverse_mass_matrix,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, step_size, inverse_mass_matrix),
+        pass_rng_key_to_init=True,
+    )
 
 
 def halton_sequence(i: Array, max_bits: int = 10) -> float:

--- a/blackjax/mcmc/elliptical_slice.py
+++ b/blackjax/mcmc/elliptical_slice.py
@@ -157,9 +157,7 @@ def as_top_level_api(
     A ``SamplingAlgorithm``.
     """
     kernel = build_kernel(cov, mean)
-    return build_sampling_algorithm(
-        kernel, init, (loglikelihood_fn,), (loglikelihood_fn,)
-    )
+    return build_sampling_algorithm(kernel, init, loglikelihood_fn)
 
 
 def elliptical_proposal(

--- a/blackjax/mcmc/elliptical_slice.py
+++ b/blackjax/mcmc/elliptical_slice.py
@@ -157,7 +157,9 @@ def as_top_level_api(
     A ``SamplingAlgorithm``.
     """
     kernel = build_kernel(cov, mean)
-    return build_sampling_algorithm(loglikelihood_fn, kernel, init)
+    return build_sampling_algorithm(
+        kernel, init, (loglikelihood_fn,), (loglikelihood_fn,)
+    )
 
 
 def elliptical_proposal(

--- a/blackjax/mcmc/elliptical_slice.py
+++ b/blackjax/mcmc/elliptical_slice.py
@@ -17,7 +17,7 @@ from typing import Callable, NamedTuple
 import jax
 import jax.numpy as jnp
 
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 from blackjax.util import generate_gaussian_noise
 
@@ -157,19 +157,7 @@ def as_top_level_api(
     A ``SamplingAlgorithm``.
     """
     kernel = build_kernel(cov, mean)
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, loglikelihood_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            loglikelihood_fn,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(loglikelihood_fn, kernel, init)
 
 
 def elliptical_proposal(

--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -275,7 +275,7 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, step_size, momentum_inverse_scale, alpha, delta),
+        logdensity_fn,
+        kernel_args=(step_size, momentum_inverse_scale, alpha, delta),
         pass_rng_key_to_init=True,
     )

--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -21,7 +21,7 @@ from jax.flatten_util import ravel_pytree
 import blackjax.mcmc.hmc as hmc
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.proposal import nonreversible_slice_sampling
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
 from blackjax.util import generate_gaussian_noise
@@ -52,8 +52,8 @@ class GHMCState(NamedTuple):
 
 def init(
     position: ArrayLikeTree,
-    rng_key: PRNGKey,
     logdensity_fn: Callable,
+    rng_key: PRNGKey,
 ) -> GHMCState:
     logdensity, logdensity_grad = jax.value_and_grad(logdensity_fn)(position)
 
@@ -272,19 +272,10 @@ def as_top_level_api(
     """
 
     kernel = build_kernel(noise_fn, divergence_threshold)
-
-    def init_fn(position: ArrayLikeTree, rng_key: PRNGKey):
-        return init(position, rng_key, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            momentum_inverse_scale,
-            alpha,
-            delta,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, step_size, momentum_inverse_scale, alpha, delta),
+        pass_rng_key_to_init=True,
+    )

--- a/blackjax/mcmc/hmc.py
+++ b/blackjax/mcmc/hmc.py
@@ -238,8 +238,8 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, step_size, metric, num_integration_steps),
+        logdensity_fn,
+        kernel_args=(step_size, metric, num_integration_steps),
     )
 
 

--- a/blackjax/mcmc/hmc.py
+++ b/blackjax/mcmc/hmc.py
@@ -19,7 +19,7 @@ import jax
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
 import blackjax.mcmc.trajectory as trajectory
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.proposal import safe_energy_diff, static_binomial_sampling
 from blackjax.mcmc.trajectory import hmc_energy
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
@@ -235,22 +235,9 @@ def as_top_level_api(
 
     kernel = build_kernel(integrator, divergence_threshold)
     metric = metrics.default_metric(inverse_mass_matrix)
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            metric,
-            num_integration_steps,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        logdensity_fn, kernel, init, step_size, metric, num_integration_steps
+    )
 
 
 def hmc_proposal(

--- a/blackjax/mcmc/hmc.py
+++ b/blackjax/mcmc/hmc.py
@@ -236,7 +236,10 @@ def as_top_level_api(
     kernel = build_kernel(integrator, divergence_threshold)
     metric = metrics.default_metric(inverse_mass_matrix)
     return build_sampling_algorithm(
-        logdensity_fn, kernel, init, step_size, metric, num_integration_steps
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, step_size, metric, num_integration_steps),
     )
 
 

--- a/blackjax/mcmc/laplace_hmc.py
+++ b/blackjax/mcmc/laplace_hmc.py
@@ -231,6 +231,6 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (laplace,),
-        (laplace, step_size, inverse_mass_matrix, num_integration_steps),
+        laplace,
+        kernel_args=(step_size, inverse_mass_matrix, num_integration_steps),
     )

--- a/blackjax/mcmc/laplace_hmc.py
+++ b/blackjax/mcmc/laplace_hmc.py
@@ -37,7 +37,7 @@ import jax
 import blackjax.mcmc.hmc as hmc
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.laplace_marginal import LaplaceMarginal, laplace_marginal_factory
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
 
@@ -228,19 +228,6 @@ def as_top_level_api(
     """
     laplace = laplace_marginal_factory(log_joint_fn, theta_init, **optimizer_kwargs)
     kernel = build_kernel(integrator, divergence_threshold)
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, laplace)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            laplace,
-            step_size,
-            inverse_mass_matrix,
-            num_integration_steps,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        laplace, kernel, init, step_size, inverse_mass_matrix, num_integration_steps
+    )

--- a/blackjax/mcmc/laplace_hmc.py
+++ b/blackjax/mcmc/laplace_hmc.py
@@ -229,5 +229,8 @@ def as_top_level_api(
     laplace = laplace_marginal_factory(log_joint_fn, theta_init, **optimizer_kwargs)
     kernel = build_kernel(integrator, divergence_threshold)
     return build_sampling_algorithm(
-        laplace, kernel, init, step_size, inverse_mass_matrix, num_integration_steps
+        kernel,
+        init,
+        (laplace,),
+        (laplace, step_size, inverse_mass_matrix, num_integration_steps),
     )

--- a/blackjax/mcmc/mala.py
+++ b/blackjax/mcmc/mala.py
@@ -172,5 +172,5 @@ def as_top_level_api(
 
     kernel = build_kernel()
     return build_sampling_algorithm(
-        kernel, init, (logdensity_fn,), (logdensity_fn, step_size)
+        kernel, init, logdensity_fn, kernel_args=(step_size,)
     )

--- a/blackjax/mcmc/mala.py
+++ b/blackjax/mcmc/mala.py
@@ -20,7 +20,7 @@ import jax.numpy as jnp
 
 import blackjax.mcmc.diffusions as diffusions
 import blackjax.mcmc.proposal as proposal
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
 
 __all__ = ["MALAState", "MALAInfo", "init", "build_kernel", "as_top_level_api"]
@@ -171,12 +171,4 @@ def as_top_level_api(
     """
 
     kernel = build_kernel()
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(rng_key, state, logdensity_fn, step_size)
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(logdensity_fn, kernel, init, step_size)

--- a/blackjax/mcmc/mala.py
+++ b/blackjax/mcmc/mala.py
@@ -171,4 +171,6 @@ def as_top_level_api(
     """
 
     kernel = build_kernel()
-    return build_sampling_algorithm(logdensity_fn, kernel, init, step_size)
+    return build_sampling_algorithm(
+        kernel, init, (logdensity_fn,), (logdensity_fn, step_size)
+    )

--- a/blackjax/mcmc/marginal_latent_gaussian.py
+++ b/blackjax/mcmc/marginal_latent_gaussian.py
@@ -283,5 +283,5 @@ def as_top_level_api(
 
     kernel = build_kernel(cov_svd)
     return build_sampling_algorithm(
-        kernel, init, (logdensity_fn, U_t), (logdensity_fn, step_size)
+        kernel, init, logdensity_fn, init_args=(U_t,), kernel_args=(step_size,)
     )

--- a/blackjax/mcmc/marginal_latent_gaussian.py
+++ b/blackjax/mcmc/marginal_latent_gaussian.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 import jax.scipy.linalg as linalg
 from jax.flatten_util import ravel_pytree
 
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.proposal import static_binomial_sampling
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 
@@ -282,17 +282,6 @@ def as_top_level_api(
         logdensity_fn = generate_mean_shifted_logprob(logdensity_fn, mean, covariance)
 
     kernel = build_kernel(cov_svd)
-
-    def init_fn(position: Array, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn, U_t)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel, init, (logdensity_fn, U_t), (logdensity_fn, step_size)
+    )

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -192,8 +192,8 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, inverse_mass_matrix, L, step_size),
+        logdensity_fn,
+        kernel_args=(inverse_mass_matrix, L, step_size),
         pass_rng_key_to_init=True,
     )
 

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -17,7 +17,7 @@ from typing import Callable, NamedTuple
 import jax
 import jax.numpy as jnp
 
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.integrators import (
     IntegratorState,
     isokinetic_mclachlan,
@@ -189,14 +189,13 @@ def as_top_level_api(
         integrator=integrator,
         desired_energy_var_max_ratio=desired_energy_var_max_ratio,
     )
-
-    def init_fn(position: ArrayLike, rng_key: PRNGKey):
-        return init(position, logdensity_fn, rng_key)
-
-    def step_fn(rng_key, state):
-        return kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size)
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, inverse_mass_matrix, L, step_size),
+        pass_rng_key_to_init=True,
+    )
 
 
 def handle_nans(previous_state, next_state, info, key):

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -215,8 +215,8 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, step_size, metric, max_num_doublings),
+        logdensity_fn,
+        kernel_args=(step_size, metric, max_num_doublings),
     )
 
 

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -213,7 +213,10 @@ def as_top_level_api(
     kernel = build_kernel(integrator, divergence_threshold)
     metric = metrics.default_metric(inverse_mass_matrix)
     return build_sampling_algorithm(
-        logdensity_fn, kernel, init, step_size, metric, max_num_doublings
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, step_size, metric, max_num_doublings),
     )
 
 

--- a/blackjax/mcmc/nuts.py
+++ b/blackjax/mcmc/nuts.py
@@ -24,8 +24,8 @@ import blackjax.mcmc.metrics as metrics
 import blackjax.mcmc.proposal as proposal
 import blackjax.mcmc.termination as termination
 import blackjax.mcmc.trajectory as trajectory
-from blackjax.base import SamplingAlgorithm
-from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.types import ArrayTree, PRNGKey
 
 __all__ = ["NUTSInfo", "init", "build_kernel", "as_top_level_api"]
 
@@ -212,22 +212,9 @@ def as_top_level_api(
     """
     kernel = build_kernel(integrator, divergence_threshold)
     metric = metrics.default_metric(inverse_mass_matrix)
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            metric,
-            max_num_doublings,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        logdensity_fn, kernel, init, step_size, metric, max_num_doublings
+    )
 
 
 def iterative_nuts_proposal(

--- a/blackjax/mcmc/periodic_orbital.py
+++ b/blackjax/mcmc/periodic_orbital.py
@@ -270,8 +270,9 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn, period),
-        (logdensity_fn, step_size, inverse_mass_matrix, period),
+        logdensity_fn,
+        init_args=(period,),
+        kernel_args=(step_size, inverse_mass_matrix, period),
     )
 
 

--- a/blackjax/mcmc/periodic_orbital.py
+++ b/blackjax/mcmc/periodic_orbital.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
 __all__ = ["PeriodicOrbitalState", "init", "build_kernel", "as_top_level_api"]
@@ -267,22 +267,12 @@ def as_top_level_api(
     A ``SamplingAlgorithm``.
     """
     kernel = build_kernel(bijection)
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn, period)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            inverse_mass_matrix,
-            period,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn, period),
+        (logdensity_fn, step_size, inverse_mass_matrix, period),
+    )
 
 
 def periodic_orbital_proposal(

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -245,7 +245,7 @@ def additive_step_random_walk(
     """
     kernel = build_additive_step()
     return build_sampling_algorithm(
-        kernel, init, (logdensity_fn,), (logdensity_fn, random_step)
+        kernel, init, logdensity_fn, kernel_args=(random_step,)
     )
 
 
@@ -338,8 +338,8 @@ def irmh_as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, proposal_distribution, proposal_logdensity_fn),
+        logdensity_fn,
+        kernel_args=(proposal_distribution, proposal_logdensity_fn),
     )
 
 
@@ -445,8 +445,8 @@ def rmh_as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, proposal_generator, proposal_logdensity_fn),
+        logdensity_fn,
+        kernel_args=(proposal_generator, proposal_logdensity_fn),
     )
 
 

--- a/blackjax/mcmc/random_walk.py
+++ b/blackjax/mcmc/random_walk.py
@@ -65,7 +65,7 @@ from typing import Callable, NamedTuple
 import jax
 from jax import numpy as jnp
 
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc import proposal
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 from blackjax.util import generate_gaussian_noise
@@ -244,15 +244,9 @@ def additive_step_random_walk(
     A ``SamplingAlgorithm``.
     """
     kernel = build_additive_step()
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(rng_key, state, logdensity_fn, random_step)
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel, init, (logdensity_fn,), (logdensity_fn, random_step)
+    )
 
 
 def build_irmh() -> Callable:
@@ -341,21 +335,12 @@ def irmh_as_top_level_api(
 
     """
     kernel = build_irmh()
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            proposal_distribution,
-            proposal_logdensity_fn,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, proposal_distribution, proposal_logdensity_fn),
+    )
 
 
 def build_rmh():
@@ -457,21 +442,12 @@ def rmh_as_top_level_api(
     A ``SamplingAlgorithm``.
     """
     kernel = build_rmh()
-
-    def init_fn(position: ArrayLikeTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            proposal_generator,
-            proposal_logdensity_fn,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, proposal_generator, proposal_logdensity_fn),
+    )
 
 
 def build_rmh_transition_energy(proposal_logdensity_fn: Callable | None) -> Callable:

--- a/blackjax/mcmc/rmhmc.py
+++ b/blackjax/mcmc/rmhmc.py
@@ -73,6 +73,6 @@ def as_top_level_api(
     return build_sampling_algorithm(
         kernel,
         init,
-        (logdensity_fn,),
-        (logdensity_fn, step_size, mass_matrix, num_integration_steps),
+        logdensity_fn,
+        kernel_args=(step_size, mass_matrix, num_integration_steps),
     )

--- a/blackjax/mcmc/rmhmc.py
+++ b/blackjax/mcmc/rmhmc.py
@@ -16,9 +16,8 @@ from typing import Callable
 
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc import hmc
-from blackjax.types import ArrayTree, PRNGKey
 
 __all__ = ["init", "build_kernel", "as_top_level_api"]
 
@@ -71,19 +70,6 @@ def as_top_level_api(
     A ``SamplingAlgorithm``.
     """
     kernel = build_kernel(integrator, divergence_threshold)
-
-    def init_fn(position: ArrayTree, rng_key=None):
-        del rng_key
-        return init(position, logdensity_fn)
-
-    def step_fn(rng_key: PRNGKey, state):
-        return kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            step_size,
-            mass_matrix,
-            num_integration_steps,
-        )
-
-    return SamplingAlgorithm(init_fn, step_fn)
+    return build_sampling_algorithm(
+        logdensity_fn, kernel, init, step_size, mass_matrix, num_integration_steps
+    )

--- a/blackjax/mcmc/rmhmc.py
+++ b/blackjax/mcmc/rmhmc.py
@@ -71,5 +71,8 @@ def as_top_level_api(
     """
     kernel = build_kernel(integrator, divergence_threshold)
     return build_sampling_algorithm(
-        logdensity_fn, kernel, init, step_size, mass_matrix, num_integration_steps
+        kernel,
+        init,
+        (logdensity_fn,),
+        (logdensity_fn, step_size, mass_matrix, num_integration_steps),
     )

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -240,13 +240,13 @@ class LinearRegressionTest(chex.TestCase):
 
         kernel = lambda rng_key, state, avg_num_integration_steps, step_size, inverse_mass_matrix: blackjax.mcmc.adjusted_mclmc.build_kernel(
             integrator=integrator,
-            inverse_mass_matrix=inverse_mass_matrix,
-            logdensity_fn=logdensity_fn,
         )(
             rng_key=rng_key,
             state=state,
+            logdensity_fn=logdensity_fn,
             step_size=step_size,
             num_integration_steps=avg_num_integration_steps,
+            inverse_mass_matrix=inverse_mass_matrix,
         )
 
         target_acc_rate = 0.9


### PR DESCRIPTION
## Summary

- Add `build_sampling_algorithm()` helper to `base.py` with `init_args`/`kernel_args` tuples and `pass_rng_key_to_init` flag — covers all MCMC pattern variants
- Convert **all 14 MCMC** `as_top_level_api` functions to use the helper (mala, hmc, nuts, barker, rmhmc, elliptical_slice, laplace_hmc, ghmc, mclmc, dynamic_hmc, adjusted_mclmc, adjusted_mclmc_dynamic, periodic_orbital, marginal_latent_gaussian, plus 3 random_walk wrappers)
- **Refactor `ghmc.init`**: swap `(position, rng_key, logdensity_fn)` → `(position, logdensity_fn, rng_key)` for consistency with all other algorithms
- **Refactor `adjusted_mclmc.build_kernel`**: move `logdensity_fn` and `inverse_mass_matrix` from `build_kernel` to kernel call signature, matching the standard BlackJAX pattern (as done for mclmc in #862)
- Net: **-53 lines** of boilerplate removed

## Test plan

- [x] Pre-commit passes (all hooks including mypy)
- [x] Integration test: all converted algorithms produce correct output
- [x] Full `tests/mcmc/test_sampling.py` suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)