### PR TITLE
Refactor adjusted_mclmc_dynamic build_kernel to standard pattern (7.8)

### DIFF
--- a/blackjax/mcmc/adjusted_mclmc_dynamic.py
+++ b/blackjax/mcmc/adjusted_mclmc_dynamic.py
@@ -56,21 +56,20 @@ def build_kernel(
     integrator: Callable = integrators.isokinetic_mclachlan,
     divergence_threshold: float = 1000,
     next_random_arg_fn: Callable = lambda key: jax.random.split(key)[1],
-    inverse_mass_matrix=1.0,
 ):
     """Build a Dynamic MHMCHMC kernel where the number of integration steps is chosen randomly.
 
     Parameters
     ----------
+    integration_steps_fn
+        Function that generates the next pseudo or quasi-random number of integration steps in the
+        sequence, given the current `random_generator_arg`. Needs to return an `int`.
     integrator
         The integrator to use to integrate the Hamiltonian dynamics.
     divergence_threshold
         Value of the difference in energy above which we consider that the transition is divergent.
     next_random_arg_fn
         Function that generates the next `random_generator_arg` from its previous value.
-    integration_steps_fn
-        Function that generates the next pseudo or quasi-random number of integration steps in the
-        sequence, given the current `random_generator_arg`. Needs to return an `int`.
 
     Returns
     -------
@@ -85,6 +84,7 @@ def build_kernel(
         logdensity_fn: Callable,
         step_size: float,
         L_proposal_factor: float = jnp.inf,
+        inverse_mass_matrix=1.0,
     ) -> tuple[DynamicHMCState, HMCInfo]:
         """Generate a new sample with the MHMCHMC kernel."""
 
@@ -163,7 +163,6 @@ def as_top_level_api(
         integration_steps_fn=integration_steps_fn,
         integrator=integrator,
         next_random_arg_fn=next_random_arg_fn,
-        inverse_mass_matrix=inverse_mass_matrix,
         divergence_threshold=divergence_threshold,
     )
 
@@ -171,7 +170,7 @@ def as_top_level_api(
         kernel,
         init,
         logdensity_fn,
-        kernel_args=(step_size, L_proposal_factor),
+        kernel_args=(step_size, L_proposal_factor, inverse_mass_matrix),
         pass_rng_key_to_init=True,
     )
 

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -171,12 +171,12 @@ class LinearRegressionTest(chex.TestCase):
             integration_steps_fn=lambda k: jnp.ceil(
                 jax.random.uniform(k) * rescale(avg_num_integration_steps)
             ),
-            inverse_mass_matrix=inverse_mass_matrix,
         )(
             rng_key=rng_key,
             state=state,
-            step_size=step_size,
             logdensity_fn=logdensity_fn,
+            step_size=step_size,
+            inverse_mass_matrix=inverse_mass_matrix,
         )
 
         target_acc_rate = 0.65


### PR DESCRIPTION
## Summary

- Move `inverse_mass_matrix` from `build_kernel()` closure to the kernel's call signature in `adjusted_mclmc_dynamic`
- Matches the convention established for `mclmc` (#862) and `adjusted_mclmc` (#864)
- `build_kernel` now only takes algorithmic config (integrator, divergence_threshold, etc.); model params (`logdensity_fn`, `inverse_mass_matrix`) are passed at call time

## Test plan

- [x] Pre-commit passes
- [ ] Full `tests/mcmc/test_sampling.py` (running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)