### PR TITLE
Fix incorrect citation: Sountsov → Seyboldt et al.

### DIFF
--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Adaptation of the low-rank-modified mass matrix for HMC-family samplers.
 
-Implements Algorithm 1 of :cite:p:`sountsov2025preconditioning`, following the
+Implements Algorithm 1 of :cite:p:`seyboldt2026preconditioning`, following the
 nutpie reference implementation.  The mass matrix has the form
 
 .. math::
@@ -147,7 +147,7 @@ def _compute_low_rank_metric(
 ) -> tuple[Array, Array, Array, Array]:
     """Compute the low-rank metric from a buffer of draws and gradients.
 
-    Implements Algorithm 1 of :cite:p:`sountsov2025preconditioning`, following
+    Implements Algorithm 1 of :cite:p:`seyboldt2026preconditioning`, following
     the nutpie reference implementation.
 
     Parameters
@@ -272,7 +272,7 @@ def base(
 
     Mirrors Stan's three-phase schedule but replaces Welford covariance
     estimation with the Fisher-divergence-minimising low-rank metric of
-    :cite:p:`sountsov2025preconditioning`, following nutpie's implementation.
+    :cite:p:`seyboldt2026preconditioning`, following nutpie's implementation.
 
     Parameters
     ----------
@@ -453,7 +453,7 @@ def low_rank_window_adaptation(
 
     Uses the three-phase Stan-style warmup schedule while replacing Welford
     covariance estimation with the Fisher-divergence-minimising low-rank
-    metric of :cite:p:`sountsov2025preconditioning`.
+    metric of :cite:p:`seyboldt2026preconditioning`.
 
     The returned ``AdaptationAlgorithm`` has a single ``run`` method::
 

--- a/blackjax/mcmc/metrics.py
+++ b/blackjax/mcmc/metrics.py
@@ -248,7 +248,7 @@ def gaussian_euclidean_low_rank(
     U: Array,
     lam: Array,
 ) -> Metric:
-    r"""Euclidean metric with low-rank-modified mass matrix :cite:p:`sountsov2025preconditioning`.
+    r"""Euclidean metric with low-rank-modified mass matrix :cite:p:`seyboldt2026preconditioning`.
 
     The inverse mass matrix has the form
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,10 @@
+@article{seyboldt2026preconditioning,
+  title={Preconditioning Hamiltonian Monte Carlo by minimizing Fisher Divergence},
+  author={Seyboldt, Adrian and Carlson, Eliot L. and Carpenter, Bob},
+  journal={arXiv preprint arXiv:2603.18845},
+  year={2026}
+}
+
 @article{gelman1992inference,
   title={Inference from iterative simulation using multiple sequences},
   author={Gelman, Andrew and Rubin, Donald B},


### PR DESCRIPTION
## Summary
- Fix misattribution of the low-rank mass matrix preconditioning paper (arXiv:2603.18845)
- The paper is by **Seyboldt, Carlson, and Carpenter**, not Sountsov
- Updated citation key in `low_rank_adaptation.py` (4 occurrences) and `metrics.py` (1 occurrence)
- Added correct BibTeX entry to `docs/refs.bib`

Fixes #866

## Test plan
- [x] `pre-commit` passes
- No code logic changes, only docstring citations and bib entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)