### PR TITLE
Deduplicate rescale() between dynamic_hmc and adjusted_mclmc (7.10)

### DIFF
--- a/blackjax/mcmc/dynamic_hmc.py
+++ b/blackjax/mcmc/dynamic_hmc.py
@@ -20,6 +20,7 @@ import jax.numpy as jnp
 
 import blackjax.mcmc.integrators as integrators
 from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.mcmc.adjusted_mclmc import rescale
 from blackjax.mcmc.hmc import HMCInfo, HMCState
 from blackjax.mcmc.hmc import build_kernel as build_static_hmc_kernel
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
@@ -185,13 +186,6 @@ def halton_sequence(i: Array, max_bits: int = 10) -> float:
         )
     bit_masks = 2 ** jnp.arange(max_bits, dtype=i.dtype)
     return jnp.einsum("i,i->", jnp.mod((i + 1) // bit_masks, 2), 0.5 / bit_masks)
-
-
-def rescale(mu):
-    # Returns s, such that `round(U(0, 1) * s + 0.5)` has expected value mu.
-    k = jnp.floor(2 * mu - 1)
-    x = k * (mu - 0.5 * (k + 1)) / (k + 1 - mu)
-    return k + x
 
 
 def halton_trajectory_length(


### PR DESCRIPTION
## Summary
- Remove duplicate `rescale()` from `dynamic_hmc.py`, now imported from `adjusted_mclmc.py`
- Both implementations were identical; `adjusted_mclmc` is the canonical location (established in Phase 7.9)
- No circular import: `adjusted_mclmc` does not import from `dynamic_hmc`

## Test plan
- [x] `pre-commit` passes
- [x] All 84 MCMC sampling tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)