### PR TITLE
Modernize jax.lax.cond: remove legacy operand=None (4.5)

### DIFF
--- a/blackjax/adaptation/laps_burn_in.py
+++ b/blackjax/adaptation/laps_burn_in.py
@@ -299,9 +299,8 @@ class Adaptation:
         history_stopping = update_history_scalar(
             jax.lax.cond(
                 adaptation_state.step_count > len(history_weights),
-                lambda _: fluctuations[0],
-                lambda _: jnp.nan,
-                operand=None,
+                lambda: fluctuations[0],
+                lambda: jnp.nan,
             ),
             adaptation_state.history.stopping,
         )

--- a/blackjax/mcmc/periodic_orbital.py
+++ b/blackjax/mcmc/periodic_orbital.py
@@ -326,9 +326,8 @@ def periodic_orbital_proposal(
         def orbit_fn(state, i):
             state = jax.lax.cond(
                 i != 0,
-                lambda _: bijection(state, jnp.sign(i) * step_size),
-                lambda _: init_state,
-                operand=None,
+                lambda: bijection(state, jnp.sign(i) * step_size),
+                lambda: init_state,
             )
             kinetic_energy = kinetic_energy_fn(state.momentum)
             weight = state.logdensity - kinetic_energy

--- a/blackjax/mcmc/proposal.py
+++ b/blackjax/mcmc/proposal.py
@@ -128,19 +128,18 @@ def progressive_uniform_sampling(
 
     return jax.lax.cond(
         do_accept,
-        lambda _: Proposal(
+        lambda: Proposal(
             new_proposal.state,
             new_proposal.energy,
             new_weight,
             new_sum_log_p_accept,
         ),
-        lambda _: Proposal(
+        lambda: Proposal(
             proposal.state,
             proposal.energy,
             new_weight,
             new_sum_log_p_accept,
         ),
-        operand=None,
     )
 
 
@@ -162,19 +161,18 @@ def progressive_biased_sampling(
 
     return jax.lax.cond(
         do_accept,
-        lambda _: Proposal(
+        lambda: Proposal(
             new_proposal.state,
             new_proposal.energy,
             new_weight,
             new_sum_log_p_accept,
         ),
-        lambda _: Proposal(
+        lambda: Proposal(
             proposal.state,
             proposal.energy,
             new_weight,
             new_sum_log_p_accept,
         ),
-        operand=None,
     )
 
 
@@ -230,9 +228,8 @@ def static_binomial_sampling(
     return (
         jax.lax.cond(
             do_accept,
-            lambda _: new_proposal,
-            lambda _: proposal,
-            operand=None,
+            lambda: new_proposal,
+            lambda: proposal,
         ),
         info,
     )
@@ -260,9 +257,8 @@ def nonreversible_slice_sampling(
     return (
         jax.lax.cond(
             do_accept,
-            lambda _: new_proposal,
-            lambda _: proposal,
-            operand=None,
+            lambda: new_proposal,
+            lambda: proposal,
         ),
         info,
     )

--- a/blackjax/mcmc/trajectory.py
+++ b/blackjax/mcmc/trajectory.py
@@ -88,15 +88,14 @@ def reorder_trajectories(
     """
     return jax.lax.cond(
         direction > 0,
-        lambda _: (
+        lambda: (
             trajectory,
             new_trajectory,
         ),
-        lambda _: (
+        lambda: (
             new_trajectory,
             trajectory,
         ),
-        operand=None,
     )
 
 
@@ -266,15 +265,14 @@ def dynamic_progressive_integration(
             # take one step to get the leftmost state of the tree.
             (new_trajectory, sampled_proposal) = jax.lax.cond(
                 step == 0,
-                lambda _: (
+                lambda: (
                     Trajectory(new_state, new_state, new_state.momentum, 1),
                     new_proposal,
                 ),
-                lambda _: (
+                lambda: (
                     append_to_trajectory(trajectory, new_state),
                     sample_proposal(proposal_key, proposal, new_proposal),
                 ),
-                operand=None,
             )
 
             new_termination_state = update_termination_state(
@@ -314,14 +312,13 @@ def dynamic_progressive_integration(
         # In the while_loop we always extend on the right most direction.
         new_trajectory = jax.lax.cond(
             direction > 0,
-            lambda _: trajectory,
-            lambda _: Trajectory(
+            lambda: trajectory,
+            lambda: Trajectory(
                 trajectory.rightmost_state,
                 trajectory.leftmost_state,
                 trajectory.momentum_sum,
                 trajectory.num_states,
             ),
-            operand=None,
         )
 
         return (
@@ -438,9 +435,8 @@ def dynamic_recursive_integration(
             if (not is_diverging) & (not is_turning):
                 start_state = jax.lax.cond(
                     direction > 0,
-                    lambda _: trajectory.rightmost_state,
-                    lambda _: trajectory.leftmost_state,
-                    operand=None,
+                    lambda: trajectory.rightmost_state,
+                    lambda: trajectory.leftmost_state,
                 )
                 (
                     rng_key,
@@ -593,9 +589,8 @@ def dynamic_multiplicative_expansion(
             direction = jnp.where(jax.random.bernoulli(direction_key), 1, -1)
             start_state = jax.lax.cond(
                 direction > 0,
-                lambda _: trajectory.rightmost_state,
-                lambda _: trajectory.leftmost_state,
-                operand=None,
+                lambda: trajectory.rightmost_state,
+                lambda: trajectory.leftmost_state,
             )
             (
                 new_proposal,

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -66,16 +66,14 @@ def progress_bar_scan(num_samples, print_rate=None):
         chain_id = lax.cond(
             # update every multiple of `print_rate` except at the end
             (iter_num % print_rate == 0) | (iter_num == (num_samples - 1)),
-            lambda _: io_callback(_update_bar, array(0), iter_num, chain_id),
-            lambda _: chain_id,
-            operand=None,
+            lambda: io_callback(_update_bar, array(0), iter_num, chain_id),
+            lambda: chain_id,
         )
 
         _ = lax.cond(
             iter_num == num_samples - 1,
-            lambda _: io_callback(_close_bar, None, iter_num + 1, chain_id),
-            lambda _: None,
-            operand=None,
+            lambda: io_callback(_close_bar, None, iter_num + 1, chain_id),
+            lambda: None,
         )
         return chain_id
 


### PR DESCRIPTION
## Summary

- Remove all 13 remaining `jax.lax.cond(..., lambda _: ..., operand=None)` calls, replacing with the modern `jax.lax.cond(..., lambda: ...)` form
- Files: `proposal.py` (4), `trajectory.py` (5), `periodic_orbital.py` (1), `laps_burn_in.py` (1), `progress_bar.py` (2)
- Zero `operand=None` instances remain in the codebase after this PR

Part of the code quality review (item 4.5, tracked in #871). This completes all MCMC-layer modernization items.

## Test plan

- [x] `tests/mcmc/test_trajectory.py` + `tests/mcmc/test_proposal.py` — 28 tests pass
- [x] `tests/mcmc/test_sampling.py -k "nuts or hmc or ghmc or periodic"` — 22 integration tests pass
- [x] `pre-commit run` on all changed files — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)