### PR TITLE
Add laplace_multinomial_hmc and dynamic_multinomial_hmc aliases

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -135,6 +135,26 @@ multinomial_hmc = GenerateSamplingAPI(
     functools.partial(_hmc.build_kernel, build_proposal=_hmc.multinomial_hmc_proposal),
 )
 
+dynamic_multinomial_hmc = GenerateSamplingAPI(
+    functools.partial(
+        _dynamic_hmc.as_top_level_api, build_proposal=_hmc.multinomial_hmc_proposal
+    ),
+    _dynamic_hmc.init,  # shares DynamicHMCState with standard dynamic_hmc
+    functools.partial(
+        _dynamic_hmc.build_kernel, build_proposal=_hmc.multinomial_hmc_proposal
+    ),
+)
+
+laplace_multinomial_hmc = GenerateSamplingAPI(
+    functools.partial(
+        _laplace_hmc.as_top_level_api, build_proposal=_hmc.multinomial_hmc_proposal
+    ),
+    _laplace_hmc.init,  # shares LaplaceHMCState with standard laplace_hmc
+    functools.partial(
+        _laplace_hmc.build_kernel, build_proposal=_hmc.multinomial_hmc_proposal
+    ),
+)
+
 hmc_family = [hmc, nuts, multinomial_hmc]
 
 # SMC
@@ -205,5 +225,7 @@ __all__ = [
     "ess",  # diagnostics
     "rhat",
     "multinomial_hmc",
+    "dynamic_multinomial_hmc",
+    "laplace_multinomial_hmc",
     "multipathfinder",
 ]

--- a/blackjax/mcmc/laplace_hmc.py
+++ b/blackjax/mcmc/laplace_hmc.py
@@ -19,6 +19,15 @@ in a standard BlackJAX three-layer sampler that carries the MAP latent variables
 warm-start hint for the L-BFGS solver at every leapfrog evaluation, so the
 optimizer needs only a handful of iterations when ``phi`` moves by a small amount.
 
+The proposal strategy is swappable via ``build_proposal``, giving two usable variants:
+
++---------------------------+------------------+------------------------------+
+| Alias                     | Proposal         | Notes                        |
++===========================+==================+==============================+
+| ``blackjax.laplace_hmc``  | endpoint + M-H   | default, standard HMC        |
+| ``blackjax.laplace_multinomial_hmc`` | full trajectory | better ESS per gradient |
++---------------------------+------------------+------------------------------+
+
 Typical usage::
 
     sampler = blackjax.laplace_hmc(
@@ -29,6 +38,13 @@ Typical usage::
     state = sampler.init(phi_init)
     new_state, info = jax.jit(sampler.step)(rng_key, state)
     # new_state.theta_star: MAP of theta at the accepted phi
+
+    # Multinomial variant (no rejection step, samples from full trajectory):
+    sampler = blackjax.laplace_multinomial_hmc(
+        log_joint, theta_init=jnp.zeros(n),
+        step_size=0.1, inverse_mass_matrix=jnp.ones(d),
+        num_integration_steps=10,
+    )
 """
 from typing import Callable, NamedTuple
 
@@ -97,6 +113,7 @@ def init(
 def build_kernel(
     integrator: Callable = integrators.velocity_verlet,
     divergence_threshold: float = 1000,
+    build_proposal: Callable = hmc.hmc_proposal,
 ) -> Callable:
     """Build the Laplace-HMC kernel.
 
@@ -106,12 +123,16 @@ def build_kernel(
         Symplectic integrator used for the HMC trajectory.
     divergence_threshold
         Energy difference above which a transition is declared divergent.
+    build_proposal
+        Proposal builder.  Defaults to :func:`~blackjax.mcmc.hmc.hmc_proposal`
+        (endpoint + M-H).  Pass :func:`~blackjax.mcmc.hmc.multinomial_hmc_proposal`
+        for multinomial trajectory sampling (``blackjax.laplace_multinomial_hmc``).
 
     Returns
     -------
     A kernel ``(rng_key, state, laplace, step_size, inverse_mass_matrix, num_integration_steps) -> (LaplaceHMCState, HMCInfo)``.
     """
-    hmc_kernel = hmc.build_kernel(integrator, divergence_threshold)
+    hmc_kernel = hmc.build_kernel(integrator, divergence_threshold, build_proposal)
 
     def kernel(
         rng_key: PRNGKey,
@@ -171,6 +192,7 @@ def as_top_level_api(
     *,
     divergence_threshold: int = 1000,
     integrator: Callable = integrators.velocity_verlet,
+    build_proposal: Callable = hmc.hmc_proposal,
     **optimizer_kwargs,
 ) -> SamplingAlgorithm:
     """HMC on the Laplace-approximated marginal log-density.
@@ -202,6 +224,11 @@ def as_top_level_api(
         Default 1000.
     integrator
         Symplectic integrator.  Default: velocity Verlet.
+    build_proposal
+        Proposal builder.  Defaults to :func:`~blackjax.mcmc.hmc.hmc_proposal`
+        (endpoint + M-H).  Pass :func:`~blackjax.mcmc.hmc.multinomial_hmc_proposal`
+        for multinomial trajectory sampling; this is what
+        ``blackjax.laplace_multinomial_hmc`` uses.
     **optimizer_kwargs
         Forwarded to :func:`~blackjax.optimizers.lbfgs.minimize_lbfgs`.
         Useful keys: ``maxiter`` (default 30), ``gtol``, ``ftol``.
@@ -226,7 +253,7 @@ def as_top_level_api(
         print(new_state.theta_star)   # MAP latent at the new phi
     """
     laplace = laplace_marginal_factory(log_joint_fn, theta_init, **optimizer_kwargs)
-    kernel = build_kernel(integrator, divergence_threshold)
+    kernel = build_kernel(integrator, divergence_threshold, build_proposal)
     return build_sampling_algorithm(
         kernel,
         init,

--- a/tests/mcmc/test_laplace_hmc.py
+++ b/tests/mcmc/test_laplace_hmc.py
@@ -390,5 +390,77 @@ class TestLaplaceHMCFunnel(BlackJAXTest):
         )
 
 
+class TestLaplaceMultinomialHMC(BlackJAXTest):
+    """Smoke tests for blackjax.laplace_multinomial_hmc.
+
+    Checks that the multinomial proposal variant of Laplace-HMC:
+    - produces valid LaplaceHMCState
+    - always accepts (is_accepted is True)
+    - matches explicit build_proposal=multinomial_hmc_proposal
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.n = 4
+        self.y = jax.random.normal(self.next_key(), (self.n,))
+        self.theta_init = jnp.zeros(self.n)
+        self.log_joint, _ = make_gaussian_model(self.y)
+        self.kwargs = dict(
+            step_size=0.1,
+            inverse_mass_matrix=jnp.ones(1),
+            num_integration_steps=3,
+            maxiter=200,
+        )
+
+    def test_alias_returns_laplace_hmc_state(self):
+        sampler = blackjax.laplace_multinomial_hmc(
+            self.log_joint, self.theta_init, **self.kwargs
+        )
+        state = sampler.init(jnp.array(0.0))
+        self.assertIsInstance(state, LaplaceHMCState)
+        new_state, _ = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertIsInstance(new_state, LaplaceHMCState)
+
+    def test_is_accepted_always_true(self):
+        """Multinomial proposal has no M-H rejection step."""
+        from blackjax.mcmc.hmc import multinomial_hmc_proposal
+
+        sampler = blackjax.laplace_hmc(
+            self.log_joint,
+            self.theta_init,
+            build_proposal=multinomial_hmc_proposal,
+            **self.kwargs,
+        )
+        state = sampler.init(jnp.array(0.0))
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertTrue(bool(info.is_accepted))
+
+    def test_alias_matches_explicit_build_proposal(self):
+        """laplace_multinomial_hmc produces the same result as
+        laplace_hmc(build_proposal=multinomial_hmc_proposal)."""
+        from blackjax.mcmc.hmc import multinomial_hmc_proposal
+
+        sampler_alias = blackjax.laplace_multinomial_hmc(
+            self.log_joint, self.theta_init, **self.kwargs
+        )
+        sampler_explicit = blackjax.laplace_hmc(
+            self.log_joint,
+            self.theta_init,
+            build_proposal=multinomial_hmc_proposal,
+            **self.kwargs,
+        )
+        phi_init = jnp.array(0.0)
+        state = sampler_alias.init(phi_init)
+        key = self.next_key()
+
+        new_alias, info_alias = jax.jit(sampler_alias.step)(key, state)
+        new_explicit, info_explicit = jax.jit(sampler_explicit.step)(key, state)
+
+        self.assertEqual(float(new_alias.logdensity), float(new_explicit.logdensity))
+        self.assertEqual(
+            float(info_alias.acceptance_rate), float(info_explicit.acceptance_rate)
+        )
+
+
 if __name__ == "__main__":
     absltest.main()

--- a/tests/mcmc/test_multinomial_hmc.py
+++ b/tests/mcmc/test_multinomial_hmc.py
@@ -3,6 +3,8 @@
 Tests exercise both the top-level ``blackjax.multinomial_hmc`` alias and the
 refactored API where multinomial HMC is constructed by passing
 ``build_proposal=multinomial_hmc_proposal`` to the HMC kernel builder.
+
+Also covers ``blackjax.dynamic_multinomial_hmc``.
 """
 
 import jax
@@ -10,6 +12,7 @@ import jax.numpy as jnp
 from absl.testing import absltest
 
 import blackjax
+from blackjax.mcmc.dynamic_hmc import DynamicHMCState
 from blackjax.mcmc.hmc import HMCInfo, HMCState, multinomial_hmc_proposal
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
@@ -141,6 +144,57 @@ class MultinomialHMCTest(BlackJAXTest):
         self.assertEqual(
             float(info_alias.acceptance_rate),
             float(info_direct.acceptance_rate),
+        )
+
+
+class DynamicMultinomialHMCTest(BlackJAXTest):
+    """Smoke tests for blackjax.dynamic_multinomial_hmc."""
+
+    def test_alias_returns_dynamic_hmc_state(self):
+        sampler = blackjax.dynamic_multinomial_hmc(
+            std_normal_logdensity,
+            step_size=0.1,
+            inverse_mass_matrix=jnp.array([1.0]),
+        )
+        state = sampler.init(jnp.array(0.0), self.next_key())
+        self.assertIsInstance(state, DynamicHMCState)
+        new_state, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertIsInstance(new_state, DynamicHMCState)
+        self.assertIsInstance(info, HMCInfo)
+
+    def test_is_accepted_always_true(self):
+        """Multinomial proposal has no M-H rejection step."""
+        sampler = blackjax.dynamic_multinomial_hmc(
+            std_normal_logdensity,
+            step_size=0.1,
+            inverse_mass_matrix=jnp.array([1.0]),
+        )
+        state = sampler.init(jnp.array(0.0), self.next_key())
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertTrue(bool(info.is_accepted))
+
+    def test_alias_matches_explicit_build_proposal(self):
+        """dynamic_multinomial_hmc produces the same result as
+        dynamic_hmc(build_proposal=multinomial_hmc_proposal)."""
+        kwargs = dict(step_size=0.1, inverse_mass_matrix=jnp.array([1.0]))
+        sampler_alias = blackjax.dynamic_multinomial_hmc(
+            std_normal_logdensity, **kwargs
+        )
+        sampler_explicit = blackjax.dynamic_hmc(
+            std_normal_logdensity,
+            build_proposal=multinomial_hmc_proposal,
+            **kwargs,
+        )
+        init_key = self.next_key()
+        state = sampler_alias.init(jnp.array(0.0), init_key)
+        key = self.next_key()
+
+        new_alias, info_alias = jax.jit(sampler_alias.step)(key, state)
+        new_explicit, info_explicit = jax.jit(sampler_explicit.step)(key, state)
+
+        self.assertEqual(float(new_alias.logdensity), float(new_explicit.logdensity))
+        self.assertEqual(
+            float(info_alias.acceptance_rate), float(info_explicit.acceptance_rate)
         )
 
 


### PR DESCRIPTION
## Summary

After #854 added `multinomial_hmc`, two natural combinations were missing from the top-level API:

- **`blackjax.laplace_multinomial_hmc`** — Laplace-approximated marginal over hyperparameters (`LaplaceHMCState`) with multinomial trajectory sampling (no M-H rejection step). Requires threading `build_proposal` through `laplace_hmc.build_kernel` and `as_top_level_api`; default is unchanged so this is fully backward-compatible.
- **`blackjax.dynamic_multinomial_hmc`** — quasi-random integration steps (`DynamicHMCState`) with multinomial trajectory sampling. `dynamic_hmc` already had `build_proposal`; this just registers the alias.

The full proposal matrix is now:

| | Endpoint + M-H | Multinomial |
|---|---|---|
| Fixed steps | `hmc` | `multinomial_hmc` |
| Random steps | `dynamic_hmc` | `dynamic_multinomial_hmc` ✨ |
| Laplace marginal, fixed steps | `laplace_hmc` | `laplace_multinomial_hmc` ✨ |

Note: `laplace_dynamic_*` variants require a new state type (`theta_star` + `random_generator_arg`) and are deferred — the periodic-orbit benefit is minimal on the low-dimensional Laplace marginal.

## Changes

- `blackjax/mcmc/laplace_hmc.py`: add `build_proposal` param to `build_kernel` and `as_top_level_api`; update module docstring with variant table
- `blackjax/__init__.py`: register `laplace_multinomial_hmc` and `dynamic_multinomial_hmc`; add to `__all__`
- `tests/mcmc/test_laplace_hmc.py`: `TestLaplaceMultinomialHMC` — state type, always-accepted, alias==explicit
- `tests/mcmc/test_multinomial_hmc.py`: `DynamicMultinomialHMCTest` — same three checks

## Test plan

- [x] `mamba run -n blackjax python -m pytest tests/mcmc/test_multinomial_hmc.py tests/mcmc/test_laplace_hmc.py` — 26 passed
- [x] `mamba run -n blackjax pre-commit run --all-files` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)