### PR TITLE
Fix missing dependencies in JAX nightly CI

### DIFF
--- a/.github/workflows/test_jax_nightly.yml
+++ b/.github/workflows/test_jax_nightly.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Install JAX nightly and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --pre jax jaxlib -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         pip install chex pytest pytest-benchmark pytest-cov pytest-xdist
-        pip install --no-deps ".[progress]"
+        pip install ".[progress]"
+        pip install --pre --force-reinstall jax jaxlib -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
     - name: Run tests
       run: |
         pytest -n auto -vv --benchmark-disable tests


### PR DESCRIPTION
The --no-deps flag was preventing essential dependencies like optax and fastprogress from being installed, causing ModuleNotFoundError during tests. This PR removes --no-deps and ensures JAX nightly is re-installed last to maintain the nightly version.