### PR TITLE
fix: refactor flaky SMC tuning test

### DIFF
--- a/.github/workflows/test_jax_nightly.yml
+++ b/.github/workflows/test_jax_nightly.yml
@@ -18,9 +18,9 @@ jobs:
     - name: Install JAX nightly and dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install --pre jax jaxlib -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         pip install chex pytest pytest-benchmark pytest-cov pytest-xdist
-        pip install --no-deps ".[progress]"
+        pip install ".[progress]"
+        pip install --pre --force-reinstall jax jaxlib -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
     - name: Run tests
       run: |
         pytest -n auto -vv --benchmark-disable tests

--- a/tests/smc/test_inner_kernel_tuning.py
+++ b/tests/smc/test_inner_kernel_tuning.py
@@ -143,25 +143,19 @@ class SMCParameterTuningTest(BlackJAXTest):
 
 class MeanAndStdFromParticlesTest(BlackJAXTest):
     def test_mean_and_std(self):
-        particles = np.array(
-            [
-                jnp.array([10]) + jax.random.normal(key) * jnp.array([0.5])
-                for key in jax.random.split(self.next_key(), 1000)
-            ]
-        )
+        particles = 10.0 + jax.random.normal(self.next_key(), shape=(2000, 1)) * 0.5
         mean = particles_means(particles)
         std = particles_stds(particles)
         cov = particles_covariance_matrix(particles)
         np.testing.assert_allclose(mean, 10.0, rtol=1e-1)
         np.testing.assert_allclose(std, 0.5, rtol=1e-1)
-        np.testing.assert_allclose(cov, 0.24, rtol=1e-1)
+        np.testing.assert_allclose(cov, 0.25, rtol=1e-1)
 
     def test_mean_and_std_multivariate_particles(self):
-        particles = np.array(
-            [
-                jnp.array([10.0, 15.0]) + jax.random.normal(key) * jnp.array([0.5, 0.7])
-                for key in jax.random.split(self.next_key(), 1000)
-            ]
+        # We use shape=(N, 1) to create perfectly correlated particles
+        particles = (
+            jnp.array([10.0, 15.0])
+            + jax.random.normal(self.next_key(), shape=(2000, 1)) * jnp.array([0.5, 0.7])
         )
 
         mean = particles_means(particles)
@@ -170,7 +164,7 @@ class MeanAndStdFromParticlesTest(BlackJAXTest):
         np.testing.assert_allclose(mean, np.array([10.0, 15.0]), rtol=1e-1)
         np.testing.assert_allclose(std, np.array([0.5, 0.7]), rtol=1e-1)
         np.testing.assert_allclose(
-            cov, np.array([[0.249529, 0.34934], [0.34934, 0.489076]]), atol=1e-1
+            cov, np.array([[0.25, 0.35], [0.35, 0.49]]), atol=1e-1
         )
 
     def test_mean_and_std_multivariable_particles(self):


### PR DESCRIPTION
Nightly builds were failing due to flakiness in MeanAndStdFromParticlesTest, which was sensitive to the daily rotating seed. This PR refactors the test to use theoretical values for comparison and improves statistical robustness by increasing the particle count to 2000 and using JAX's shape API for more efficient sampling.