### PR TITLE
tests: improve SMC test stability

### DIFF
--- a/tests/smc/test_smc.py
+++ b/tests/smc/test_smc.py
@@ -29,8 +29,8 @@ def _weighted_avg_and_std(values, weights):
 class SMCTest(BlackJAXTest):
     @chex.variants(with_jit=True)
     def test_smc(self):
-        num_mcmc_steps = 10
-        num_particles = 1000
+        num_mcmc_steps = 20
+        num_particles = 2000
 
         same_for_all_params = dict(
             step_size=1e-2, inverse_mass_matrix=jnp.eye(1), num_integration_steps=50
@@ -64,8 +64,8 @@ class SMCTest(BlackJAXTest):
 
     @chex.variants(with_jit=True)
     def test_smc_waste_free(self):
-        p = 500
-        num_particles = 1000
+        p = 100
+        num_particles = 2000
         num_resampled = num_particles // p
         init_key, sample_key = jax.random.split(self.next_key())
 


### PR DESCRIPTION
This PR improves the stability of SMC tests which were occasionally failing in JAX nightly builds due to seed sensitivity.

Changes:
- In `test_smc`, increased `num_particles` from 1000 to 2000 and `num_mcmc_steps` from 10 to 20 to ensure better convergence and lower variance.
- In `test_smc_waste_free`, increased `num_particles` from 1000 to 2000 and decreased `p` from 500 to 100 (increasing `num_resampled` from 2 to 20). This significantly increases the diversity of the ensemble and reduces the standard error of the mean estimate.

Verified with 100 different seeds, resulting in 0 failures for the new configuration.