### PR TITLE
Standardize JAX patterns (jax.tree)

### DIFF
--- a/blackjax/eca.py
+++ b/blackjax/eca.py
@@ -18,7 +18,6 @@ import jax.numpy as jnp
 from jax import device_put, lax, shard_map, vmap
 from jax.random import split
 from jax.sharding import NamedSharding, PartitionSpec
-from jax.tree_util import tree_map
 
 from blackjax.diagnostics import splitR
 
@@ -54,7 +53,7 @@ def eca_step(
         summary_statistics = vmap(summary_statistics_fn, (0, 0, None))(
             state, info, key_adaptation
         )
-        expected_value_summary_statistics = tree_map(
+        expected_value_summary_statistics = jax.tree.map(
             lambda summary_statistics: lax.psum(
                 jnp.sum(summary_statistics, axis=0), axis_name="chains"
             )

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -3,11 +3,11 @@
 from functools import partial
 from typing import Callable, NamedTuple
 
+import jax
 import jax.numpy as jnp
 from jax import jit, lax
 from jax.flatten_util import ravel_pytree
 from jax.random import normal, split
-from jax.tree_util import tree_leaves, tree_map
 
 from blackjax.base import SamplingAlgorithm, VIAlgorithm
 from blackjax.diagnostics import psis_weights as psis_weights  # noqa: F401
@@ -116,7 +116,7 @@ def generate_unit_vector(
 
 def pytree_size(pytree: ArrayLikeTree) -> int:
     """Return the dimension of the flatten PyTree."""
-    return sum(jnp.size(value) for value in tree_leaves(pytree))
+    return sum(jnp.size(value) for value in jax.tree.leaves(pytree))
 
 
 def index_pytree(input_pytree: ArrayLikeTree) -> ArrayTree:
@@ -312,7 +312,7 @@ def incremental_value_update(
     """
 
     total, average = incremental_val
-    average = tree_map(
+    average = jax.tree.map(
         lambda exp, av: safediv(
             total * av + weight * exp, (total + weight + zero_prevention)
         ),

--- a/blackjax/vi/schrodinger_follmer.py
+++ b/blackjax/vi/schrodinger_follmer.py
@@ -18,7 +18,6 @@ import jax
 import jax.numpy as jnp
 import jax.random
 from jax.flatten_util import ravel_pytree
-from jax.tree_util import tree_leaves
 from jax.typing import ArrayLike
 
 from blackjax.base import VIAlgorithm
@@ -177,7 +176,7 @@ def _log_fn_corrected(position, logdensity_fn):
     """
     log_pdf_val = logdensity_fn(position)
     norm = jax.tree.map(lambda a: 0.5 * jnp.sum(a**2), position)
-    norm = sum(tree_leaves(norm))
+    norm = sum(jax.tree.leaves(norm))
     return log_pdf_val + norm
 
 

--- a/docs/examples/howto_use_oryx.md
+++ b/docs/examples/howto_use_oryx.md
@@ -128,7 +128,7 @@ print(initial_weights.keys())
 ```{code-cell} ipython3
 :tags: [hide-input]
 
-num_parameters = sum([layer.size for layer in jax.tree_util.tree_flatten(initial_weights)[0]])
+num_parameters = sum([layer.size for layer in jax.tree.flatten(initial_weights)[0]])
 print(f"Number of parameters in the model: {num_parameters}")
 ```
 


### PR DESCRIPTION
This PR updates the codebase and examples to use modern JAX patterns:
- Use `jax.tree.*` everywhere

This is part of the Documentation Audit & Visibility Improvement Plan #890.