### PR TITLE
docs: fix funsor tutorial plot — replace az.plot_dist with matplotlib

### DIFF
--- a/docs/examples/howto_use_funsor.md
+++ b/docs/examples/howto_use_funsor.md
@@ -225,7 +225,7 @@ across runs with different random seeds.
 ```
 
 ```{code-cell} ipython3
-import arviz as az
+import matplotlib.pyplot as plt
 
 mu_samples = states.position["mu"]
 # Reconstruct full K-simplex from K-1 free logits.
@@ -233,11 +233,16 @@ pi_samples = jax.vmap(
     lambda lp: jax.nn.softmax(jnp.concatenate([jnp.zeros(1), lp]))
 )(states.position["log_pi"])
 
-idata = az.from_dict({"posterior": {
-    "mu": mu_samples[None, ...],    # shape (1, 1000, K)
-    "pi": pi_samples[None, ...],
-}})
-az.plot_dist(idata, var_names=["mu", "pi"]);
+fig, axes = plt.subplots(2, K, figsize=(9, 4), sharey="row")
+for k in range(K):
+    axes[0, k].hist(np.array(mu_samples[:, k]), bins=40, density=True)
+    axes[0, k].axvline(true_mu[k], color="red", linestyle="--", label="true")
+    axes[0, k].set_title(f"μ[{k}]")
+    axes[1, k].hist(np.array(pi_samples[:, k]), bins=40, density=True)
+    axes[1, k].axvline(true_pi[k], color="red", linestyle="--", label="true")
+    axes[1, k].set_title(f"π[{k}]")
+axes[0, 0].legend()
+plt.tight_layout();
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
## Summary

`az.plot_dist(..., var_names=...)` raises `TypeError` on the published docs
([howto_use_funsor.html](https://blackjax-devs.github.io/blackjax/examples/howto_use_funsor.html))
because the `var_names` kwarg is not available in all arviz 1.x minor versions.

Replace it with a plain `matplotlib` histogram grid (2 rows × K columns) with
dashed reference lines for the true parameter values. Removes the arviz
dependency from the results cell entirely.

## Test plan

- [x] Sphinx build produces no `CellExecutionError` for `howto_use_funsor.md`
- [x] Posterior histograms for `μ` and `π` render with true-value reference lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)