### PR TITLE
docs: improve Funsor tutorial (idiomatic API, NumPyro section, ArviZ fix)

### DIFF
--- a/docs/examples/howto_use_funsor.md
+++ b/docs/examples/howto_use_funsor.md
@@ -45,7 +45,6 @@ example:
 ```{code-cell} ipython3
 :tags: [remove-output]
 
-import math
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -59,6 +58,7 @@ funsor.set_backend("jax")          # must be called before Tensor/Variable are u
 from funsor.domains import Bint
 from funsor.tensor import Tensor
 from funsor.terms import Variable
+from funsor.jax.distributions import Categorical, Normal
 
 from datetime import date
 rng_key = jax.random.key(int(date.today().strftime("%Y%m%d")))
@@ -107,6 +107,11 @@ do all the work:
   over `{0, …, K-1}`.
 - `f(k=z)` — substitution: renames the `"k"` axis to `"z"`, transferring the
   name so that expressions over different named axes broadcast correctly.
+- `Normal(loc=..., scale=..., value=x)` / `Categorical(probs=..., value=z)` —
+  distribution objects from `funsor.jax.distributions` that accept a Funsor as
+  `value` and return the log-probability as a Funsor over that variable's named
+  dimensions. Distinct named dimensions in `loc` and `value` broadcast as an
+  outer product automatically.
 
 The mixing weights `π` live on the K-simplex. Rather than sampling all K
 components of `log_pi` (which leaves a constant-shift null direction that
@@ -115,54 +120,45 @@ K−1 free parameters. The map `ℝ^{K-1} → Δ^{K-1}` is bijective, so no
 Jacobian correction is needed.
 
 ```{code-cell} ipython3
-LOG_2PI = math.log(2.0 * math.pi)   # Python float — treated as a Funsor Number
-
 def gmm_logdensity(position):
     mu     = position["mu"]          # (K,)   component means
     log_pi = position["log_pi"]      # (K-1,) unconstrained free logits
     # Prepend a fixed zero so softmax maps K-1 reals bijectively onto Δ^{K-1}.
     pi = jax.nn.softmax(jnp.concatenate([jnp.zeros(1), log_pi]))   # (K,)
 
-    # ── μ prior: μ_k ~ Normal(0, 5) ─────────────────────────────────────────
-    log_mu_prior = jnp.sum(-0.5 * (mu / 5.0) ** 2 - math.log(5.0) - 0.5 * LOG_2PI)
-
-    # ── Wrap JAX arrays as named Funsor tensors ──────────────────────────────
+    # ── Named Funsor tensors ─────────────────────────────────────────────────
     # Tensor(arr, inputs): arr is indexed by the dimensions named in inputs.
+    # pi_f has no named dim: Categorical indexes it internally via value=z.
     mu_f = Tensor(mu,   {"k": Bint[K]})   # mu_f[k]  for k ∈ {0, …, K-1}
-    pi_f = Tensor(pi,   {"k": Bint[K]})   # pi_f[k]
+    pi_f = Tensor(pi,   {})               # (K,) simplex, no named dim
     x_f  = Tensor(data, {"n": Bint[N]})   # x_f[n]   for n ∈ {0, …, N-1}
 
     # ── Discrete variable: component assignment ──────────────────────────────
     z = Variable("z", Bint[K])
 
-    # ── log p(z | π): Funsor with named dim "z" ─────────────────────────────
-    # pi_f(k=z) substitutes k→z, renaming the axis.
-    # .log() applies element-wise: log π[z].
-    log_cat_prior = pi_f(k=z).log()       # inputs: {"z": Bint[K]}
+    # ── log p(z | π) — Categorical, Funsor over {"z"} ───────────────────────
+    log_cat_prior = Categorical(probs=pi_f, value=z)              # inputs: {"z": Bint[K]}
 
-    # ── log p(x_n | z): Funsor over {"z", "n"} ──────────────────────────────
-    # mu_f(k=z) has inputs {"z": Bint[K]}.
-    # x_f       has inputs {"n": Bint[N]}.
-    # Their difference creates an outer product automatically:
-    #   inputs {"z": Bint[K], "n": Bint[N]}, underlying shape (K, N).
-    mu_z   = mu_f(k=z)
-    sq_err = (x_f - mu_z) ** 2           # inputs: {"z": Bint[K], "n": Bint[N]}
-    log_lik = -0.5 * sq_err - 0.5 * LOG_2PI   # Normal(μ[z], σ=1) log-prob at x[n]
-
-    # ── Joint log p(x_n, z): broadcast log_cat_prior over "n" ───────────────
-    log_joint = log_cat_prior + log_lik   # inputs: {"z": Bint[K], "n": Bint[N]}
+    # ── log p(x_n | z) — Normal likelihood, Funsor over {"z", "n"} ──────────
+    # mu_f(k=z) substitutes k→z: Funsor over {"z": Bint[K]}.
+    # Normal's loc depends on "z" and value depends on "n", so the result
+    # spans both dimensions automatically as an outer product.
+    mu_z    = mu_f(k=z)
+    log_lik = Normal(loc=mu_z, scale=1.0, value=x_f)             # inputs: {"z": Bint[K], "n": Bint[N]}
 
     # ── Exact marginalisation of z ───────────────────────────────────────────
     # reduce(logaddexp, "z") computes log Σ_z exp(log_joint) for every n.
-    # This is exact variable elimination: Funsor evaluates all K states and
-    # combines them with logsumexp entirely inside JAX — no sampling, no
-    # approximation, and the result is differentiable w.r.t. mu and pi.
-    log_marginal_n = log_joint.reduce(ops.logaddexp, "z")  # inputs: {"n": Bint[N]}
+    # Funsor evaluates all K states and combines with logsumexp inside JAX —
+    # the result is fully differentiable w.r.t. mu and pi.
+    log_joint      = log_cat_prior + log_lik                      # inputs: {"z": Bint[K], "n": Bint[N]}
+    log_marginal_n = log_joint.reduce(ops.logaddexp, "z")         # inputs: {"n": Bint[N]}
 
-    # ── Sum over observations + μ prior ─────────────────────────────────────
-    log_p = log_marginal_n.reduce(ops.add, "n")            # scalar Funsor, inputs: {}
+    # ── μ prior: μ_k ~ Normal(0, 5), summed over K components ───────────────
+    log_mu_prior = Normal(loc=0., scale=5., value=mu_f).reduce(ops.add, "k")
 
-    return log_p.data + log_mu_prior
+    # ── Total log-density ────────────────────────────────────────────────────
+    log_p = log_marginal_n.reduce(ops.add, "n")                   # scalar Funsor, inputs: {}
+    return log_p.data + log_mu_prior.data
 ```
 
 Let us verify that the log-density is finite at a sensible initialisation and

--- a/docs/examples/howto_use_funsor.md
+++ b/docs/examples/howto_use_funsor.md
@@ -250,3 +250,143 @@ print("Posterior E[π]:", pi_samples.mean(0).round(2), "  true:", true_pi)
 accept = float(infos.acceptance_rate.mean())
 print(f"Mean acceptance rate: {accept:.2f}")
 ```
+
+## Alternative: NumPyro model syntax
+
+The pure Funsor approach above requires writing the factor graph explicitly. If
+you already use NumPyro, you can write the model in the familiar `numpyro.sample`
+/ `numpyro.plate` style and let Funsor handle the discrete marginalisation
+transparently via the `@config_enumerate` decorator.
+
+Under the hood, `initialize_model` detects the decorated discrete sites and
+wires in Funsor's variable elimination automatically. The continuous parameters
+are reparameterised (e.g. `π` via a stick-breaking transform onto the simplex),
+and the returned `potential_fn` is fully JAX-differentiable — no changes to the
+BlackJax call site are required.
+
+```{admonition} Before you start
+You will need [NumPyro](https://github.com/pyro-ppl/numpyro) in addition to
+Funsor:
+
+    pip install numpyro "funsor>=0.4.7"
+```
+
+```{code-cell} ipython3
+:tags: [remove-output]
+
+import numpyro
+import numpyro.distributions as dist
+from numpyro.contrib.funsor import config_enumerate
+from numpyro.infer.util import initialize_model
+```
+
+The model is written identically to a standard NumPyro model. The only
+addition is `@config_enumerate`, which marks the discrete site `z` for
+enumeration. Priors and the likelihood are expressed with NumPyro distributions;
+no manual log-prob arithmetic is needed.
+
+```{code-cell} ipython3
+@config_enumerate
+def gmm_model_npy(data, K):
+    # Continuous parameters — sampled by BlackJax NUTS
+    pi = numpyro.sample("pi", dist.Dirichlet(jnp.ones(K)))
+    with numpyro.plate("components", K):
+        mu = numpyro.sample("mu", dist.Normal(0.0, 5.0))
+
+    # Discrete assignment — Funsor marginalises this out
+    with numpyro.plate("obs", len(data)):
+        z = numpyro.sample("z", dist.Categorical(pi))
+        numpyro.sample("x", dist.Normal(mu[z], 1.0), obs=data)
+```
+
+`initialize_model` returns an initial position containing only the continuous
+variables (in unconstrained space) and a `potential_fn_gen` that already wraps
+the Funsor enumeration — the same pattern used in the plain NumPyro tutorial.
+
+```{code-cell} ipython3
+rng_key, init_key_npy = jax.random.split(rng_key)
+
+init_params_npy, potential_fn_gen_npy, *_ = initialize_model(
+    init_key_npy,
+    gmm_model_npy,
+    model_args=(data, K),
+    dynamic_args=True,
+)
+initial_position_npy = init_params_npy.z
+print("Sites and shapes:", {k: v.shape for k, v in initial_position_npy.items()})
+```
+
+```{note}
+`pi` has shape `(K-1,)` here because NumPyro automatically applies a
+stick-breaking transform, mapping the (K-1)-dimensional unconstrained space
+bijectively onto the K-simplex.
+```
+
+```{code-cell} ipython3
+logdensity_fn_npy = lambda position: -potential_fn_gen_npy(data, K)(position)
+
+print("log p(data | init):", logdensity_fn_npy(initial_position_npy))
+print("grad w.r.t. mu    :", jax.grad(logdensity_fn_npy)(initial_position_npy)["mu"])
+```
+
+Window adaptation and the inference loop are identical to before.
+
+```{code-cell} ipython3
+%%time
+
+rng_key, warmup_key_npy = jax.random.split(rng_key)
+
+adapt_npy = blackjax.window_adaptation(blackjax.nuts, logdensity_fn_npy)
+(last_state_npy, params_npy), _ = adapt_npy.run(
+    warmup_key_npy, initial_position_npy, num_steps=1000
+)
+kernel_npy = blackjax.nuts(logdensity_fn_npy, **params_npy).step
+```
+
+```{code-cell} ipython3
+%%time
+
+rng_key, sample_key_npy = jax.random.split(rng_key)
+states_npy, infos_npy = inference_loop(
+    sample_key_npy, kernel_npy, last_state_npy, num_samples=1000
+)
+```
+
+To recover `π` on the simplex, apply the stick-breaking transform to the
+unconstrained samples.
+
+```{code-cell} ipython3
+from numpyro.distributions.transforms import StickBreakingTransform
+
+mu_samples_npy = states_npy.position["mu"]
+pi_samples_npy = jax.vmap(StickBreakingTransform())(states_npy.position["pi"])
+
+fig, axes = plt.subplots(2, K, figsize=(9, 4), sharey="row")
+for k in range(K):
+    axes[0, k].hist(np.array(mu_samples_npy[:, k]), bins=40, density=True)
+    axes[0, k].axvline(true_mu[k], color="red", linestyle="--", label="true")
+    axes[0, k].set_title(f"μ[{k}]")
+    axes[1, k].hist(np.array(pi_samples_npy[:, k]), bins=40, density=True)
+    axes[1, k].axvline(true_pi[k], color="red", linestyle="--", label="true")
+    axes[1, k].set_title(f"π[{k}]")
+axes[0, 0].legend()
+plt.tight_layout();
+```
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+print("Posterior E[μ]:", mu_samples_npy.mean(0).round(2), "  true:", true_mu)
+print("Posterior E[π]:", pi_samples_npy.mean(0).round(2), "  true:", true_pi)
+print(f"Mean acceptance rate: {float(infos_npy.acceptance_rate.mean()):.2f}")
+```
+
+## Which approach to use
+
+| | Pure Funsor | NumPyro + Funsor |
+|---|---|---|
+| Model syntax | Explicit named-tensor algebra | `numpyro.sample` / `numpyro.plate` |
+| Priors and transforms | Manual | Automatic |
+| Discrete marginalisation | `reduce(logaddexp, "z")` | `@config_enumerate` + `initialize_model` |
+| Requires NumPyro | No | Yes |
+| Best for | Understanding Funsor internals | Production models, complex plate structure |

--- a/docs/examples/howto_use_funsor.md
+++ b/docs/examples/howto_use_funsor.md
@@ -225,7 +225,7 @@ across runs with different random seeds.
 ```
 
 ```{code-cell} ipython3
-import arviz as az
+import matplotlib.pyplot as plt
 
 mu_samples = states.position["mu"]
 # Reconstruct full K-simplex from K-1 free logits.
@@ -233,11 +233,16 @@ pi_samples = jax.vmap(
     lambda lp: jax.nn.softmax(jnp.concatenate([jnp.zeros(1), lp]))
 )(states.position["log_pi"])
 
-idata = az.from_dict({"posterior": {
-    "mu": mu_samples[None, ...],    # shape (1, 1000, K)
-    "pi": pi_samples[None, ...],
-}})
-az.plot_dist(idata, var_names=["mu", "pi"]);
+fig, axes = plt.subplots(2, K, figsize=(9, 4), sharey="row")
+for k in range(K):
+    axes[0, k].hist(np.array(mu_samples[:, k]), bins=40, density=True)
+    axes[0, k].axvline(true_mu[k], color="red", linestyle="--", label="true")
+    axes[0, k].set_title(f"μ[{k}]")
+    axes[1, k].hist(np.array(pi_samples[:, k]), bins=40, density=True)
+    axes[1, k].axvline(true_pi[k], color="red", linestyle="--", label="true")
+    axes[1, k].set_title(f"π[{k}]")
+axes[0, 0].legend()
+plt.tight_layout();
 ```
 
 ```{code-cell} ipython3


### PR DESCRIPTION
## Summary

Follow-up to #896. Three improvements to `docs/examples/howto_use_funsor.md`:

- **Use `funsor.jax.distributions` API** — replace hand-written Normal log-prob formula (`-0.5 * sq_err - 0.5 * LOG_2PI`) with `Categorical(probs=..., value=z)` and `Normal(loc=..., scale=..., value=x_f)` from `funsor.jax.distributions`. The μ prior is now a one-liner using the same API. Removes `import math` and the `LOG_2PI` constant.

- **Add NumPyro model syntax section** — shows the same GMM using `@config_enumerate` + `initialize_model` (the standard NumPyro–BlackJax bridge pattern). Funsor marginalises discrete variables internally; users write a plain NumPyro model. Includes `StickBreakingTransform` to recover π samples on the simplex, and a comparison table (pure Funsor vs NumPyro+Funsor).

- **Fix ArviZ 1.x API** — replace `az.plot_dist` on an InferenceData object with `matplotlib` histograms, which avoids ArviZ version sensitivity entirely.

## Test plan

- [x] `gmm_logdensity` returns a finite scalar and `jax.grad` produces finite gradients at init (both approaches)
- [x] `logdensity_fn_npy` with `potential_fn_gen` produces finite logp and gradients
- [x] Both approaches recover posterior means close to `true_mu = [-4, 0, 4]` and `true_pi = [0.3, 0.4, 0.3]`
- [x] Notebook executes without error under `mystnb` / `jupyter-execute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)