### PR TITLE
docs: fix label switching in Funsor GMM posterior plots

### DIFF
--- a/docs/examples/howto_use_funsor.md
+++ b/docs/examples/howto_use_funsor.md
@@ -229,6 +229,12 @@ pi_samples = jax.vmap(
     lambda lp: jax.nn.softmax(jnp.concatenate([jnp.zeros(1), lp]))
 )(states.position["log_pi"])
 
+# Resolve label switching: sort components by ascending mean value so the
+# plotting order matches true_mu = [-4, 0, 4].
+sort_idx   = jnp.argsort(mu_samples, axis=1)
+mu_samples = jnp.take_along_axis(mu_samples, sort_idx, axis=1)
+pi_samples = jnp.take_along_axis(pi_samples, sort_idx, axis=1)
+
 fig, axes = plt.subplots(2, K, figsize=(9, 4), sharey="row")
 for k in range(K):
     axes[0, k].hist(np.array(mu_samples[:, k]), bins=40, density=True)
@@ -360,6 +366,10 @@ from numpyro.distributions.transforms import StickBreakingTransform
 
 mu_samples_npy = states_npy.position["mu"]
 pi_samples_npy = jax.vmap(StickBreakingTransform())(states_npy.position["pi"])
+
+sort_idx_npy   = jnp.argsort(mu_samples_npy, axis=1)
+mu_samples_npy = jnp.take_along_axis(mu_samples_npy, sort_idx_npy, axis=1)
+pi_samples_npy = jnp.take_along_axis(pi_samples_npy, sort_idx_npy, axis=1)
 
 fig, axes = plt.subplots(2, K, figsize=(9, 4), sharey="row")
 for k in range(K):


### PR DESCRIPTION
## Summary

- After sampling, sort each posterior draw's components by ascending `μ` value before plotting. This aligns the K axes with `true_mu = [-4, 0, 4]` regardless of which of the K! symmetric modes NUTS converges to.
- Applied to both the pure Funsor section and the NumPyro+Funsor section.

```python
sort_idx   = jnp.argsort(mu_samples, axis=1)
mu_samples = jnp.take_along_axis(mu_samples, sort_idx, axis=1)
pi_samples = jnp.take_along_axis(pi_samples, sort_idx, axis=1)
```

The note about label switching in the `{note}` block is kept — this clarifies that the fix is cosmetic (sorting for display) and that the inference itself is unaffected.

## Test plan

- [x] `Posterior E[μ]` prints close to `[-4. 0. 4.]` in correct order
- [x] `Posterior E[π]` prints close to `[0.3 0.4 0.3]` in correct order
- [x] Both plot sections render with red dashed lines inside the posterior histograms

🤖 Generated with [Claude Code](https://claude.com/claude-code)