### PR TITLE
docs: add algorithm index and standard inference loop (issue #890)

### DIFF
--- a/docs/examples/quickstart.md
+++ b/docs/examples/quickstart.md
@@ -87,7 +87,8 @@ The HMC kernel is easy to obtain:
 hmc_kernel = jax.jit(hmc.step)
 ```
 
-BlackJAX does not provide a default inference loop, but it easy to implement with JAX's `lax.scan`:
+BlackJAX provides `run_inference_algorithm` as a convenience wrapper, or you can
+write the loop manually with `jax.lax.scan`. The manual pattern is:
 
 ```{code-cell}
 def inference_loop(rng_key, kernel, initial_state, num_samples):

--- a/docs/examples/speed_up_guide.md
+++ b/docs/examples/speed_up_guide.md
@@ -21,6 +21,48 @@ and on benchmarks run against other JAX-based PPLs such as NumPyro.
 
 ---
 
+## 0. Use the standard inference loop
+
+`run_inference_algorithm` is the recommended way to run a sampler. It wraps
+`jax.lax.scan` and `jax.jit` correctly, giving O(1) compile time and a single
+compiled kernel regardless of step count:
+
+```python
+import blackjax
+from blackjax.util import run_inference_algorithm
+
+nuts = blackjax.nuts(logdensity_fn, step_size, inv_mass_matrix)
+
+final_state, (states, infos) = run_inference_algorithm(
+    rng_key,
+    nuts,
+    num_steps=1_000,
+    initial_position=initial_position,
+    transform=lambda state, info: (state.position, info),
+)
+```
+
+If you need custom control flow (early stopping, per-step callbacks, adaptive
+hyperparameter updates), write the loop manually using the canonical form:
+
+```python
+@jax.jit
+def run(rng_key, initial_state, n_steps):
+    def step(state, key):
+        state, info = kernel(key, state)
+        return state, info
+
+    return jax.lax.scan(step, initial_state, jax.random.split(rng_key, n_steps))
+
+final_state, (states, infos) = run(rng_key, initial_state, 1_000)
+```
+
+Both patterns compile the kernel **once** regardless of step count. The most
+common mistake — calling `.step` in a Python `for` loop without `jax.jit` — is
+covered in §1 below.
+
+---
+
 ## 1. Always JIT the step function at the outermost scope
 
 BlackJAX kernels are plain Python callables.  Calling them without `jax.jit`

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,6 +78,103 @@ run on CPU only. **If you want to use BlackJAX on GPU/TPU** we recommend you fol
 with the relevant hardware acceleration support.
 :::
 
+# Algorithm Reference
+
+Every public algorithm in `blackjax` is listed below. **Guide** links point to
+a worked example; **API** links go to the generated reference. Algorithms
+marked *Sampling Book* are covered in depth at
+[blackjax-devs.github.io/sampling-book](https://blackjax-devs.github.io/sampling-book).
+
+## MCMC
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `hmc` | Hamiltonian Monte Carlo (static trajectory) | [Quickstart](examples/quickstart.md) | [API](autoapi/blackjax/mcmc/hmc/index) |
+| `nuts` | No-U-Turn Sampler (dynamic trajectory) | [Quickstart](examples/quickstart.md) | [API](autoapi/blackjax/mcmc/nuts/index) |
+| `dhmc` / `dynamic_hmc` | Dynamic HMC (alias of `nuts` trajectory logic, fixed integration) | — | [API](autoapi/blackjax/mcmc/dynamic_hmc/index) |
+| `mhmc` / `multinomial_hmc` | HMC with multinomial trajectory proposal | — | [API](autoapi/blackjax/mcmc/hmc/index) |
+| `dmhmc` | Dynamic HMC with multinomial proposal | — | [API](autoapi/blackjax/mcmc/dynamic_hmc/index) |
+| `rmhmc` | Riemannian Manifold HMC | — | [API](autoapi/blackjax/mcmc/rmhmc/index) |
+| `mala` | Metropolis-Adjusted Langevin Algorithm | — | [API](autoapi/blackjax/mcmc/mala/index) |
+| `ghmc` | Generalised HMC (persistent momentum) | — | [API](autoapi/blackjax/mcmc/ghmc/index) |
+| `barker` | Barker proposal (gradient-based MH) | — | [API](autoapi/blackjax/mcmc/barker/index) |
+| `rmh` | Random-walk Metropolis-Hastings | — | [API](autoapi/blackjax/mcmc/random_walk/index) |
+| `irmh` | Independent Random-walk MH | — | [API](autoapi/blackjax/mcmc/random_walk/index) |
+| `additive_step_random_walk` / `normal_random_walk` | Additive-step random walk (Gaussian or custom) | — | [API](autoapi/blackjax/mcmc/random_walk/index) |
+| `mgrad_gaussian` | Marginal latent Gaussian sampler | — | [API](autoapi/blackjax/mcmc/marginal_latent_gaussian/index) |
+| `elliptical_slice` | Elliptical slice sampling | — | [API](autoapi/blackjax/mcmc/elliptical_slice/index) |
+| `orbital_hmc` | Periodic orbital / periodic HMC | — | [API](autoapi/blackjax/mcmc/periodic_orbital/index) |
+
+## MCMC — MCLMC family
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `mclmc` | Microcanonical Langevin Monte Carlo | [Sampling Book](https://blackjax-devs.github.io/sampling-book) | [API](autoapi/blackjax/mcmc/mclmc/index) |
+| `adjusted_mclmc` | Adjusted MCLMC (MH correction) | [Sampling Book](https://blackjax-devs.github.io/sampling-book) | [API](autoapi/blackjax/mcmc/adjusted_mclmc/index) |
+| `adjusted_mclmc_dynamic` | Adjusted MCLMC with dynamic step-size | [Sampling Book](https://blackjax-devs.github.io/sampling-book) | [API](autoapi/blackjax/mcmc/adjusted_mclmc/index) |
+
+## MCMC — Laplace-preconditioned family
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `laplace_hmc` | HMC with Laplace approximation preconditioning | — | [API](autoapi/blackjax/mcmc/laplace/index) |
+| `laplace_dhmc` | Dynamic HMC with Laplace preconditioning | — | [API](autoapi/blackjax/mcmc/laplace_dynamic_hmc/index) |
+| `laplace_mhmc` | Multinomial HMC with Laplace preconditioning | — | [API](autoapi/blackjax/mcmc/laplace/index) |
+| `laplace_dmhmc` | Dynamic multinomial HMC with Laplace preconditioning | — | [API](autoapi/blackjax/mcmc/laplace_dynamic_hmc/index) |
+
+## Stochastic Gradient MCMC
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `sgld` | Stochastic Gradient Langevin Dynamics | — | [API](autoapi/blackjax/sgmcmc/sgld/index) |
+| `sghmc` | Stochastic Gradient HMC | — | [API](autoapi/blackjax/sgmcmc/sghmc/index) |
+| `sgnht` | Stochastic Gradient Nosé–Hoover Thermostat | — | [API](autoapi/blackjax/sgmcmc/sgnht/index) |
+| `csgld` | Cyclical SGLD | — | [API](autoapi/blackjax/sgmcmc/csgld/index) |
+| `svgd` | Stein Variational Gradient Descent | — | [API](autoapi/blackjax/vi/svgd/index) |
+
+## Sequential Monte Carlo
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `tempered_smc` | Tempered (annealed) SMC | — | [API](autoapi/blackjax/smc/tempered/index) |
+| `adaptive_tempered_smc` | Adaptive tempering schedule SMC | — | [API](autoapi/blackjax/smc/adaptive_tempered/index) |
+| `partial_posteriors_smc` | SMC over a sequence of partial posteriors | — | [API](autoapi/blackjax/smc/partial_posteriors_path/index) |
+| `persistent_sampling_smc` | Persistent-particle SMC | — | [API](autoapi/blackjax/smc/persistent_sampling/index) |
+| `adaptive_persistent_sampling_smc` | Adaptive persistent-particle SMC | — | [API](autoapi/blackjax/smc/adaptive_persistent_sampling/index) |
+| `inner_kernel_tuning` | SMC with per-step inner-kernel tuning | — | [API](autoapi/blackjax/smc/inner_kernel_tuning/index) |
+| `pretuning` | SMC pretuning step | — | [API](autoapi/blackjax/smc/pretuning/index) |
+
+## Variational Inference
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `meanfield_vi` | Mean-field (diagonal) ADVI | — | [API](autoapi/blackjax/vi/meanfield_vi/index) |
+| `fullrank_vi` | Full-rank (dense covariance) ADVI | — | [API](autoapi/blackjax/vi/fullrank_vi/index) |
+| `pathfinder` | Pathfinder variational inference | — | [API](autoapi/blackjax/vi/pathfinder/index) |
+| `multipathfinder` | Multi-path Pathfinder | — | [API](autoapi/blackjax/vi/multipathfinder/index) |
+| `schrodinger_follmer` | Schrödinger–Föllmer sampler | — | [API](autoapi/blackjax/vi/schrodinger_follmer/index) |
+
+## Adaptation / Warmup
+
+| `blackjax.X` | Description | Guide | API |
+|---|---|---|---|
+| `window_adaptation` | Dual-averaging step-size + mass-matrix warmup (HMC/NUTS) | [Quickstart](examples/quickstart.md) | [API](autoapi/blackjax/adaptation/window_adaptation/index) |
+| `mclmc_find_L_and_step_size` | MCLMC trajectory-length + step-size tuning | [Sampling Book](https://blackjax-devs.github.io/sampling-book) | [API](autoapi/blackjax/adaptation/mclmc_adaptation/index) |
+| `adjusted_mclmc_find_L_and_step_size` | Adjusted MCLMC tuning | [Sampling Book](https://blackjax-devs.github.io/sampling-book) | [API](autoapi/blackjax/adaptation/adjusted_mclmc_adaptation/index) |
+| `chees_adaptation` | CHEES (chain-ensemble adaptation) | — | [API](autoapi/blackjax/adaptation/chees_adaptation/index) |
+| `meads_adaptation` | MEADS (mass-matrix via ensemble) | — | [API](autoapi/blackjax/adaptation/meads_adaptation/index) |
+| `pathfinder_adaptation` | Pathfinder-based warmup | — | [API](autoapi/blackjax/adaptation/pathfinder_adaptation/index) |
+| `low_rank_window_adaptation` | Window adaptation with low-rank mass matrix | — | [API](autoapi/blackjax/adaptation/low_rank_adaptation/index) |
+
+## Diagnostics & Utilities
+
+| Name | Description | Guide | API |
+|---|---|---|---|
+| `blackjax.ess` | Effective Sample Size | [Diagnostics Guide](examples/diagnostics.md) | [API](autoapi/blackjax/diagnostics/index) |
+| `blackjax.rhat` | Potential Scale Reduction (R̂) | [Diagnostics Guide](examples/diagnostics.md) | [API](autoapi/blackjax/diagnostics/index) |
+| `run_inference_algorithm` | `lax.scan`-based inference loop utility | [Speed-up Guide](examples/speed_up_guide.md) | [API](autoapi/blackjax/util/index) |
+| `store_only_expectation_values` | Memory-efficient streaming expectations | — | [API](autoapi/blackjax/util/index) |
+
 ```{toctree}
 ---
 maxdepth: 1


### PR DESCRIPTION
## Summary

- **Algorithm Reference table** added to `index.md`: all 40+ public algorithms in `blackjax.__init__` grouped by family (MCMC, MCLMC, Laplace, SGMCMC, SMC, VI, Adaptation, Utilities), each with a one-line description, guide link (Quickstart / Diagnostics Guide / Sampling Book), and autoapi link. Addresses the "invisible algorithms" gap (`ghmc`, `barker`, `rmhmc`, `svgd`, `schrodinger_follmer`, Laplace family, SMC variants).
- **§0 Standard Inference Loop** added to `speed_up_guide.md`: shows `run_inference_algorithm` as the recommended path, and the canonical `lax.scan + @jax.jit` form for custom control flow. Completes the last open Phase 1 item.
- **Quickstart** (`quickstart.md`): fixes outdated "BlackJAX does not provide a default inference loop" sentence.

Closes Phase 1 (performance guide update) and the Algorithm Index item from Phase 2 of the documentation audit plan tracked in #890.

## Test plan

- [x] `python -m pre_commit run --all-files` — passes (verified locally)
- [x] Docs build: `make build-docs` renders tables and new section without errors
- [x] Spot-check: `index.md` Algorithm Reference section visible in rendered HTML sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)