### PR TITLE
Add nested Rhat diagnostic

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -13,6 +13,7 @@ from .adaptation.pathfinder_adaptation import pathfinder_adaptation
 from .adaptation.window_adaptation import window_adaptation
 from .base import SamplingAlgorithm, VIAlgorithm
 from .diagnostics import effective_sample_size as ess
+from .diagnostics import nested_rhat
 from .diagnostics import potential_scale_reduction as rhat
 from .mcmc import adjusted_mclmc as _adjusted_mclmc
 from .mcmc import adjusted_mclmc_dynamic as _adjusted_mclmc_dynamic
@@ -281,6 +282,7 @@ __all__ = [
     "fullrank_vi",
     "schrodinger_follmer",
     "ess",  # diagnostics
+    "nested_rhat",
     "rhat",
     "SamplingAlgorithm",  # base
     "VIAlgorithm",

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -21,6 +21,7 @@ from blackjax.types import Array, ArrayLike
 
 __all__ = [
     "potential_scale_reduction",
+    "nested_rhat",
     "effective_sample_size",
     "psis_weights",
 ]
@@ -77,6 +78,138 @@ def potential_scale_reduction(
         / (num_samples)
     )
     return rhat_value.squeeze()
+
+
+def nested_rhat(
+    input_array: ArrayLike,
+    superchain_axis: int = 0,
+    chain_axis: int = 1,
+    sample_axis: int = 2,
+) -> Array:
+    r"""Margossian et al. (2024)'s nested :math:`\hat{R}` for assessing MCMC
+    convergence when running many short chains.
+
+    Nested :math:`\hat{R}` generalises the potential scale reduction factor to
+    a *nested* design where chains are grouped into *superchains*.  It monitors
+    the nonstationary variance (related to warmup bias) while the persistent
+    variance shrinks with the number of chains, making it well-suited for the
+    many-short-chains regime common on GPUs.
+
+    Parameters
+    ----------
+    input_array
+        An array whose axes include a superchain dimension, a chain dimension,
+        and a sample dimension.  Any remaining axes are treated as parameter
+        dimensions and the diagnostic is computed element-wise over them.
+    superchain_axis
+        The axis indexing superchains (K).  Default 0.
+    chain_axis
+        The axis indexing chains within a superchain (M).  Default 1.
+    sample_axis
+        The axis indexing samples within a chain (N).  Default 2.
+
+    Returns
+    -------
+    Array
+        Nested :math:`\hat{R}_\nu` with the superchain, chain, and sample
+        dimensions squeezed out.
+
+    Notes
+    -----
+    Following Definition 2.2 in Margossian et al. (2024), we compute
+
+    .. math::
+
+        \hat{B}_\nu = \frac{1}{K-1}\sum_{k=1}^{K}
+            \bigl(\bar{f}^{(\cdot\cdot k)} - \bar{f}^{(\cdots)}\bigr)^2,
+
+    .. math::
+
+        \hat{W}_\nu = \frac{1}{K}\sum_{k=1}^{K}
+            \bigl(\hat{B}_k + \hat{W}_k\bigr),
+
+    where :math:`\hat{B}_k` is the between-chain variance within superchain
+    *k* (0 when *M* = 1) and :math:`\hat{W}_k` is the within-chain variance
+    (0 when *N* = 1).  Then
+
+    .. math::
+
+        \hat{R}_\nu = \sqrt{1 + \frac{\hat{B}_\nu}{\hat{W}_\nu}}.
+
+    When *M* = 1 the diagnostic reduces to the classical :math:`\hat{R}`.
+
+    References
+    ----------
+    Margossian, C. C., Hoffman, M. D., Sountsov, P., Riou-Durand, L.,
+    Vehtari, A., & Gelman, A. (2024). Nested Rhat: Assessing the convergence
+    of Markov chain Monte Carlo when running many short chains.
+    *Bayesian Analysis*.  https://arxiv.org/abs/2110.13017
+    """
+    K = input_array.shape[superchain_axis]
+    M = input_array.shape[chain_axis]
+    N = input_array.shape[sample_axis]
+
+    assert K > 1, (
+        "nested_rhat requires at least 2 superchains "
+        f"(got {K} along superchain_axis={superchain_axis})."
+    )
+    assert M > 1 or N > 1, (
+        "nested_rhat requires either M > 1 (chains per superchain) or "
+        "N > 1 (samples per chain)."
+    )
+
+    # --- means at each level ---
+    # chain mean: average over samples for each chain
+    # f_bar^(.mk) — shape keeps superchain and chain dims
+    chain_mean = jnp.mean(input_array, axis=sample_axis, keepdims=True)
+
+    # superchain mean: average chain means within each superchain
+    # f_bar^(..k) — shape keeps superchain dim
+    superchain_mean = jnp.mean(chain_mean, axis=chain_axis, keepdims=True)
+
+    # grand mean: average over superchains
+    # f_bar^(...)
+    grand_mean = jnp.mean(superchain_mean, axis=superchain_axis, keepdims=True)
+
+    # --- between-superchain variance B_hat_nu  (eq. 6) ---
+    # 1/(K-1) * sum_k (f_bar^(..k) - f_bar^(...))^2
+    B_nu = jnp.sum(
+        jnp.square(superchain_mean - grand_mean),
+        axis=superchain_axis,
+        keepdims=True,
+    ) / (K - 1)
+
+    # --- within-superchain components (per superchain k) ---
+    # B_hat_k: between-chain variance within superchain k
+    if M > 1:
+        # 1/(M-1) * sum_m (f_bar^(.mk) - f_bar^(..k))^2
+        B_k = jnp.sum(
+            jnp.square(chain_mean - superchain_mean),
+            axis=chain_axis,
+            keepdims=True,
+        ) / (M - 1)
+    else:
+        B_k = jnp.zeros_like(superchain_mean)
+
+    # W_hat_k: within-chain variance
+    if N > 1:
+        # 1/M * sum_m [ 1/(N-1) * sum_n (f^(nmk) - f_bar^(.mk))^2 ]
+        per_chain_var = jnp.sum(
+            jnp.square(input_array - chain_mean),
+            axis=sample_axis,
+            keepdims=True,
+        ) / (N - 1)
+        W_k = jnp.mean(per_chain_var, axis=chain_axis, keepdims=True)
+    else:
+        W_k = jnp.zeros_like(superchain_mean)
+
+    # W_hat_nu = 1/K * sum_k (B_hat_k + W_hat_k)   (eq. 7)
+    W_nu = jnp.mean(B_k + W_k, axis=superchain_axis, keepdims=True)
+
+    # R_hat_nu = sqrt(1 + B_hat_nu / W_hat_nu)      (eq. 8)
+    nested_rhat_value = jnp.sqrt(1.0 + B_nu / W_nu)
+
+    return nested_rhat_value.squeeze()
 
 
 def effective_sample_size(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -4,6 +4,7 @@ import itertools
 
 import chex
 import jax
+import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest, parameterized
 
@@ -83,6 +84,72 @@ class DiagnosticsTest(chex.TestCase):
         ess_val = effective_sample_size(mc_samples)
         np.testing.assert_array_equal(ess_val.shape, event_shape)
         np.testing.assert_allclose(ess_val, num_chains * self.num_samples, rtol=10)
+
+
+    @chex.all_variants(with_pmap=False)
+    @parameterized.parameters(
+        # (num_superchains, num_chains, num_samples, event_shape)
+        (4, 8, 100, ()),
+        (4, 8, 100, (3,)),
+        (8, 4, 50, (5,)),
+        (4, 1, 200, ()),  # M=1: reduces to classical Rhat
+    )
+    def test_nested_rhat_converged(
+        self, num_superchains, num_chains, num_samples, event_shape
+    ):
+        """Nested Rhat should be close to 1 for IID samples from the target."""
+        rng_key = jax.random.key(self.test_seed)
+        sample_shape = (num_superchains, num_chains, num_samples) + event_shape
+        mc_samples = jax.random.normal(rng_key, shape=sample_shape)
+
+        nested_rhat_fn = self.variant(diagnostics.nested_rhat)
+        nrhat_val = nested_rhat_fn(mc_samples)
+        np.testing.assert_array_equal(nrhat_val.shape, event_shape)
+        np.testing.assert_allclose(nrhat_val, 1.0, rtol=0.05)
+
+    @chex.all_variants(with_pmap=False)
+    def test_nested_rhat_detects_nonconvergence(self):
+        """Nested Rhat >> 1 when superchains have different means (bias)."""
+        rng_key = jax.random.key(self.test_seed)
+        K, M, N = 4, 8, 100
+        # Each superchain draws from a distribution with a different mean,
+        # simulating chains that haven't converged from their initial points.
+        means = jnp.array([0.0, 5.0, -5.0, 10.0]).reshape(K, 1, 1)
+        samples = means + jax.random.normal(rng_key, shape=(K, M, N))
+
+        nested_rhat_fn = self.variant(diagnostics.nested_rhat)
+        nrhat_val = nested_rhat_fn(samples)
+        # Should be well above 1 since superchains haven't converged
+        self.assertGreater(float(nrhat_val), 2.0)
+
+    @chex.all_variants(with_pmap=False)
+    def test_nested_rhat_m1_matches_classical(self):
+        """When M=1, nested Rhat should approximate classical Rhat.
+
+        Per Remark 2.3 in Margossian et al. (2024), nested Rhat reduces to the
+        classical Rhat when each superchain contains a single chain (M=1).
+        """
+        rng_key = jax.random.key(self.test_seed)
+        K, N = 10, 500
+        # IID samples: both should be close to 1
+        samples_nested = jax.random.normal(rng_key, shape=(K, 1, N))
+        samples_classical = samples_nested.squeeze(axis=1)  # (K, N)
+
+        nested_rhat_fn = self.variant(diagnostics.nested_rhat)
+        classical_rhat_fn = self.variant(diagnostics.potential_scale_reduction)
+
+        nrhat_val = nested_rhat_fn(samples_nested)
+        rhat_val = classical_rhat_fn(samples_classical)
+        np.testing.assert_allclose(nrhat_val, rhat_val, rtol=0.01)
+
+    @chex.all_variants(with_pmap=False)
+    def test_nested_rhat_requires_multiple_superchains(self):
+        """Nested Rhat should raise when K < 2."""
+        rng_key = jax.random.key(self.test_seed)
+        samples = jax.random.normal(rng_key, shape=(1, 4, 100))
+        nested_rhat_fn = self.variant(diagnostics.nested_rhat)
+        with self.assertRaises(AssertionError):
+            nested_rhat_fn(samples)
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -85,7 +85,6 @@ class DiagnosticsTest(chex.TestCase):
         np.testing.assert_array_equal(ess_val.shape, event_shape)
         np.testing.assert_allclose(ess_val, num_chains * self.num_samples, rtol=10)
 
-
     @chex.all_variants(with_pmap=False)
     @parameterized.parameters(
         # (num_superchains, num_chains, num_samples, event_shape)


### PR DESCRIPTION
Closes #278.

Implements the nested $\hat{R}$ diagnostic from Margossian et al. (2024,
*Bayesian Analysis*), Definition 2.2 (equations 6-8). Useful for
hierarchical models where chains are grouped into superchains — catches
convergence failures that classical Rhat misses when between-superchain
variance is high.

When `M=1` (single superchain), reduces to classical Rhat per Remark 2.3.

Prior work: #752 implemented the core logic but was abandoned before tests
were added (Oct 2024). This is a fresh implementation with full test coverage.

Tests: 28 new test cases (172/172 diagnostics tests pass).