### PR TITLE
docs(smc): correct adaptive_persistent_sampling step signature in docstring

### DIFF
--- a/blackjax/smc/adaptive_persistent_sampling.py
+++ b/blackjax/smc/adaptive_persistent_sampling.py
@@ -223,8 +223,12 @@ def as_top_level_api(
         The init method has signature
         (position: ArrayLikeTree) -> PersistentSMCState
         The step method has signature
-        (rng_key: PRNGKey, state: PersistentSMCState, lmbda: float | Array) ->
+        (rng_key: PRNGKey, state: PersistentSMCState) ->
         (new_state: PersistentSMCState, info: PersistentStateInfo)
+
+        Note: unlike `blackjax.smc.persistent_sampling`, the adaptive variant
+        does NOT take `lmbda` as a step argument — the next tempering value
+        is computed internally by the root solver to hit `target_ess`.
     """
 
     kernel = build_kernel(


### PR DESCRIPTION
## Summary

`blackjax.smc.adaptive_persistent_sampling.as_top_level_api`'s docstring describes the returned `SamplingAlgorithm`'s step method as 3-arg (taking `lmbda`), but the actual implementation (line 244 of the same file) is 2-arg. The kernel computes `lmbda` internally via the dichotomy root-solver (or whatever `root_solver` is supplied) to hit `target_ess`. Passing `lmbda` from the caller raises a TypeError.

This is a pure docstring fix — no behavior change.

## What changed

```diff
         The step method has signature
-        (rng_key: PRNGKey, state: PersistentSMCState, lmbda: float | Array) ->
+        (rng_key: PRNGKey, state: PersistentSMCState) ->
         (new_state: PersistentSMCState, info: PersistentStateInfo)
+
+        Note: unlike ``blackjax.smc.persistent_sampling``, the adaptive variant
+        does NOT take ``lmbda`` as a step argument — the next tempering value
+        is computed internally by the root solver to hit ``target_ess``.
```

## Why

Discovered while wrapping the algorithm in a downstream benchmark library that initially trusted the docstring and tried to pass `lmbda`; the test failure surfaced the drift.

Same class of drift as #906 (`mclmc_find_L_and_step_size` documented a 2-tuple return while the implementation returns 3-tuple). Pattern: any adapter that internally computes a value but advertises it as a caller-supplied arg/return slot tends to drift in its docstring as the implementation evolves.

## Test plan

- [x] Pre-commit (black, isort, flake8, mypy, pyupgrade) clean
- [x] No code change — only docstring; no test rerun needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)