### PR TITLE
tests(vi): robustify test_elbo_decreases_over_steps against PRNG noise

### DIFF
--- a/tests/vi/test_fullrank_vi.py
+++ b/tests/vi/test_fullrank_vi.py
@@ -87,23 +87,28 @@ class FRVIUnitTest(BlackJAXTest):
         self.assertEqual(state.chol_params.shape, new_state.chol_params.shape)
 
     def test_elbo_decreases_over_steps(self):
-        """ELBO (KL divergence) should decrease after several optimization steps."""
+        """ELBO should decrease over Adam optimization steps (windowed-mean comparison).
+
+        We compare mean(elbos[-20:]) < mean(elbos[:20]) to reduce single-sample MC
+        noise variance (~4.5× reduction from window averaging). Direct comparison of
+        step-50 vs step-1 single-sample estimates is too flaky on low-dimensional
+        problems at standard learning rates.
+        """
         position = jnp.zeros(2)
         state = init(position, self.optimizer)
 
         def logdensity_fn(x):
             return -0.5 * jnp.sum((x - 3.0) ** 2)
 
-        initial_elbo = None
-        for i in range(50):
+        elbos = []
+        for i in range(200):
             subkey = jax.random.fold_in(self.next_key(), i)
             state, info = jax.jit(step, static_argnums=(2, 3))(
                 subkey, state, logdensity_fn, self.optimizer
             )
-            if initial_elbo is None:
-                initial_elbo = float(info.elbo)
+            elbos.append(float(info.elbo))
 
-        assert float(info.elbo) < initial_elbo
+        assert jnp.mean(jnp.array(elbos[-20:])) < jnp.mean(jnp.array(elbos[:20]))
 
     def test_sample_shape(self):
         """sample returns (num_samples, dim) shaped output."""


### PR DESCRIPTION
## Summary

Fixes flaky test `test_elbo_decreases_over_steps` in nightly JAX CI run 25660509612 (job 75319564037). The test compared single-sample MC ELBO estimates between step 1 and step 50, which fails whenever per-step noise exceeds the deterministic Adam descent signal.

## Root Cause

- Single-sample ELBO at low dim (d=2) with standard learning rate (lr=1e-2) has noise variance that dominates 50-step descent
- Raw PRNG noise can make step-50 ELBO appear higher than step-1, causing nondeterministic failure

## Solution

Replace direct step-1 vs step-50 comparison with windowed-mean:
- Extend run from 50 to 200 steps
- Collect all ELBO values into an array
- Assert `mean(elbos[-20:]) < mean(elbos[:20])` — the mean of the last 20 steps vs mean of the first 20 steps
- Window averaging provides ~4.5× variance reduction via √20 factor, making the test statistically robust

No changes to the algorithm itself.

## Test Plan

- [x] Focused test passes: `test_elbo_decreases_over_steps` (PASSED)
- [x] Full FRVI suite passes: 16/16 tests (PASSED)
- [x] Pre-commit clean: all formatters + type checks pass
- [x] No algorithm regression: integration tests `test_recover_diagonal_posterior` and `test_recover_correlated_posterior` pass

🤖 Generated with Claude Code