### PR TITLE
fix(smc): correct sign in ess_solver to match tempered SMC weight update

### DIFF
--- a/blackjax/smc/ess.py
+++ b/blackjax/smc/ess.py
@@ -87,7 +87,13 @@ def ess_solver(
     target_val = jnp.log(n_particles * target_ess)
 
     def fun_to_solve(delta: float | Array) -> Array:
-        log_weights = jnp.nan_to_num(-delta * logdensity)
+        # NOTE: sign must match the SMC weight update in
+        # ``blackjax.smc.tempered`` (`log_weights_fn` uses
+        # ``delta * loglikelihood_fn(position)``). A sign mismatch makes the
+        # bisection find a δ that targets the wrong distribution, which is
+        # silent for symmetric log-likelihoods but breaks adaptive tempering
+        # on asymmetric ones. See issue #914.
+        log_weights = jnp.nan_to_num(delta * logdensity)
         ess_val = log_ess(log_weights)
 
         return ess_val - target_val

--- a/tests/smc/test_smc_ess.py
+++ b/tests/smc/test_smc_ess.py
@@ -28,11 +28,16 @@ class SMCEffectiveSampleSizeTest(chex.TestCase):
     @chex.all_variants(with_pmap=False)
     @parameterized.parameters([0.2, 0.95])
     def test_ess_solver(self, target_ess):
+        # NOTE: ``ess_solver`` expects a log-density (positive sign — same as
+        # the log-likelihood passed by ``adaptive_tempered_smc``), NOT a
+        # potential. Passing ``-logpdf`` here would silently work for
+        # symmetric distributions and mask the sign bug in #914.
         num_particles = 1000
-        potential_fn = lambda pytree: -univariate_logpdf(pytree, scale=0.1)
-        potential = jax.vmap(lambda x: potential_fn(x), in_axes=[0])
+        logdensity_fn = jax.vmap(lambda x: univariate_logpdf(x, scale=0.1), in_axes=[0])
         particles = np.random.normal(0, 1, size=(num_particles, 1))
-        self.ess_solver_test_case(potential, particles, target_ess, num_particles, 1.0)
+        self.ess_solver_test_case(
+            logdensity_fn, particles, target_ess, num_particles, 1.0
+        )
 
     @chex.all_variants(with_pmap=False)
     @parameterized.parameters([0.2, 0.95])
@@ -45,11 +50,13 @@ class SMCEffectiveSampleSizeTest(chex.TestCase):
         mean = jnp.zeros((1, 2))
         cov = jnp.diag(jnp.array([1, 1]))
         _logdensity_fn = lambda pytree: multivariate_logpdf(pytree, mean=mean, cov=cov)
-        potential = jax.vmap(_logdensity_fn, in_axes=[0], out_axes=0)
+        logdensity_fn = jax.vmap(_logdensity_fn, in_axes=[0], out_axes=0)
         particles = np.random.multivariate_normal(
             mean=[0.0, 0.0], cov=[[1.0, 0.0], [0.0, 1.0]], size=num_particles
         )
-        self.ess_solver_test_case(potential, particles, target_ess, num_particles, 10.0)
+        self.ess_solver_test_case(
+            logdensity_fn, particles, target_ess, num_particles, 10.0
+        )
 
     @chex.all_variants(with_pmap=False)
     @parameterized.parameters([0.2, 0.95])
@@ -67,7 +74,7 @@ class SMCEffectiveSampleSizeTest(chex.TestCase):
                 pytree[0], mean=mean, cov=cov
             ) + multivariate_logpdf(pytree[1], mean=mean, cov=cov)
 
-        potential = jax.vmap(_logdensity_fn, in_axes=[0], out_axes=0)
+        logdensity_fn = jax.vmap(_logdensity_fn, in_axes=[0], out_axes=0)
         particles = [
             np.random.multivariate_normal(
                 mean=[0.0, 0.0], cov=[[1.0, 0.0], [0.0, 1.0]], size=num_particles
@@ -76,12 +83,14 @@ class SMCEffectiveSampleSizeTest(chex.TestCase):
                 mean=[0.0, 0.0], cov=[[1.0, 0.0], [0.0, 1.0]], size=num_particles
             ),
         ]
-        self.ess_solver_test_case(potential, particles, target_ess, num_particles, 10.0)
+        self.ess_solver_test_case(
+            logdensity_fn, particles, target_ess, num_particles, 10.0
+        )
 
-    def ess_solver_test_case(self, potential, particles, target_ess, N, max_delta):
+    def ess_solver_test_case(self, logdensity_fn, particles, target_ess, N, max_delta):
         ess_solver_fn = functools.partial(
             ess.ess_solver,
-            potential,
+            logdensity_fn,
             target_ess=target_ess,
             max_delta=max_delta,
             root_solver=solver.dichotomy,
@@ -90,8 +99,62 @@ class SMCEffectiveSampleSizeTest(chex.TestCase):
         delta = self.variant(ess_solver_fn)(particles)
         assert delta > 0
 
-        ess_val = ess.ess(-delta * potential(particles))
+        # Verify the solver's solution against the same weight expression
+        # the SMC kernel uses (``delta * loglikelihood``, see
+        # blackjax/smc/tempered.py:log_weights_fn). Using the wrong sign
+        # here would re-introduce the silent #914 cancellation.
+        ess_val = ess.ess(delta * logdensity_fn(particles))
         np.testing.assert_allclose(ess_val, target_ess * N, atol=1e-1, rtol=1e-2)
+
+    @chex.all_variants(with_pmap=False)
+    def test_ess_solver_asymmetric_loglikelihood_issue_914(self):
+        """Regression test for the sign bug in #914.
+
+        With a Cauchy prior and a sharply concentrated Gaussian likelihood
+        centred away from 0, the prior-IS estimator already achieves an ESS
+        well above the target with ``delta=1.0`` (one-step IS suffices, no
+        tempering needed). The bisection must therefore return
+        ``delta = max_delta = 1.0``. Before the #914 fix, the wrong sign
+        made the bisection report ``delta ~ 5e-8``, which caused
+        ``adaptive_tempered_smc`` to stall at ``lambda ~ 0``.
+
+        We choose ``max_delta = 1.0`` so the boundary case ``delta == 1.0``
+        is in-range; the asymmetric log-likelihood values (chi-squared-like,
+        not invariant under sign flip) ensure the bug cannot hide.
+        """
+        N = 8192
+        target_ess = 0.9 * 1024 / N  # ~0.1125
+
+        key = jax.random.key(0)
+        u = jax.random.uniform(key, (N,))
+        # Cauchy prior via inverse-CDF.
+        particles = jnp.tan(jnp.pi * (u - 0.5))
+        # Gaussian log-likelihood centred at mu=2, sigma=0.5 — asymmetric in
+        # the particle index, with a long left tail of very negative values.
+        loglikelihood_fn = lambda x: -0.5 * ((x - 2.0) / 0.5) ** 2
+
+        delta = self.variant(
+            functools.partial(
+                ess.ess_solver,
+                lambda _particles: loglikelihood_fn(_particles),
+                target_ess=target_ess,
+                max_delta=1.0,
+                root_solver=solver.dichotomy,
+            )
+        )(particles)
+
+        # Cross-check via the closed-form posterior IS ESS estimator
+        # (one-step reweighting from prior to posterior).
+        from jax.scipy.special import logsumexp
+
+        ll = loglikelihood_fn(particles)
+        ess_posterior = float(jnp.exp(2 * logsumexp(ll) - logsumexp(2 * ll)))
+        assert (
+            ess_posterior > target_ess * N
+        ), "Test premise broken: prior-IS ESS must already exceed target."
+
+        # The bisection should return (close to) max_delta.
+        np.testing.assert_allclose(float(delta), 1.0, atol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #914 — sign bug in `blackjax/smc/ess.py:ess_solver` that made `adaptive_tempered_smc` stall at `λ ≈ 0` for asymmetric log-likelihoods.

- `blackjax/smc/ess.py:90` formed bisection weights as `-delta * logdensity`, while the actual SMC weight update in `blackjax/smc/tempered.py:161` uses `+delta * loglikelihood_fn(position)`. The two must agree for adaptive tempering to be self-consistent.
- For symmetric log-likelihoods `|δ|` is invariant under sign — that's why the existing tests (Gaussian-only) all passed despite the bug.
- One-character fix in `ess.py`; the existing tests had a compensating sign convention (passing a "potential" = `-logdensity` and verifying with `ess(-delta * potential)`) that was masking the bug — updated to use the same expression as `tempered.log_weights_fn` so future sign drift is caught.

## Commits

1. `fix(smc): correct sign in ess_solver to match tempered SMC weight update` — the one-character fix + an inline NOTE referencing `tempered.py` and #914.
2. `tests(smc): fix masked sign convention in ess tests + regression test for #914` — drop the negation from the existing parameterised tests, rename `potential` → `logdensity_fn` to match the function signature and the consumer (`adaptive_tempered.py`), and add `test_ess_solver_asymmetric_loglikelihood_issue_914` (the issue's MRE: Cauchy prior + sharp Gaussian likelihood centred at μ=2 where prior-IS already exceeds the ESS target, so the solver must return `δ = max_delta`).

## Test plan

- [x] `JAX_PLATFORM_NAME=cpu uv run pytest tests/smc/test_smc_ess.py -vv` — 32 passed (28 pre-existing + 4 variants of the new regression test).
- [x] `JAX_PLATFORM_NAME=cpu uv run pytest tests/smc/ -n 2 --benchmark-disable` — 154 passed, no regressions in `test_tempered_smc.py`, `test_pretuning.py`, `test_inner_kernel_tuning.py`, `test_waste_free_smc.py`, `test_kernel_compatibility.py`.
- [x] `uv run pre-commit run --files blackjax/smc/ess.py tests/smc/test_smc_ess.py`.

Closes #914.