### PR TITLE
fix: make low_rank_window_adaptation vmap-compatible (#916)

### DIFF
--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -56,7 +56,7 @@ from blackjax.adaptation.step_size import (
 )
 from blackjax.adaptation.window_adaptation import build_schedule
 from blackjax.base import AdaptationAlgorithm
-from blackjax.mcmc.metrics import gaussian_euclidean_low_rank
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix, gaussian_euclidean_low_rank
 from blackjax.progress_bar import gen_scan_fn
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 from blackjax.util import pytree_size
@@ -493,8 +493,15 @@ def low_rank_window_adaptation(
     -------
     An ``AdaptationAlgorithm`` whose ``run`` method returns
     ``(AdaptationResults, info)``.  ``AdaptationResults.parameters`` contains
-    ``step_size``, ``inverse_mass_matrix`` (a :func:`gaussian_euclidean_low_rank`
-    ``Metric`` object), and any ``extra_parameters``.
+    ``step_size``, ``inverse_mass_matrix`` (a
+    :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` NamedTuple holding
+    the pure-array payload ``(sigma, U, lam)``), and any ``extra_parameters``.
+    The kernel layer normalises this into a full
+    :class:`~blackjax.mcmc.metrics.Metric` via
+    :func:`~blackjax.mcmc.metrics.default_metric` at call time. Returning the
+    pure-array form (rather than the closure-bearing ``Metric``) lets the
+    warmup compose with ``jax.vmap`` over chains; see GH #916.
+
     ``AdaptationResults.state`` is re-initialised at the optimal translation
     μ* = x̄ + σ²⊙ᾱ, so it can be passed directly as the starting state for
     production sampling.  The last chain state from warmup is available as
@@ -570,10 +577,13 @@ def low_rank_window_adaptation(
         )
         _, last_warmup_state, *_ = last_state
         step_size, sigma, mu_star, U, lam = adapt_final(last_warmup_state)
-        metric = gaussian_euclidean_low_rank(sigma, U, lam)
+        # Return the inverse mass matrix as a pure-array NamedTuple so that the
+        # warmup composes with `jax.vmap` over chains. The kernel layer expands
+        # this into a full `Metric` via `default_metric` at call time. See #916.
+        inverse_mass_matrix = LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
         parameters = {
             "step_size": step_size,
-            "inverse_mass_matrix": metric,
+            "inverse_mass_matrix": inverse_mass_matrix,
             **extra_parameters,
         }
         # Re-initialise chain state at the optimal translation μ* = x̄ + σ²⊙ᾱ.

--- a/blackjax/mcmc/metrics.py
+++ b/blackjax/mcmc/metrics.py
@@ -38,6 +38,7 @@ from blackjax.types import Array, ArrayLikeTree, ArrayTree, Numeric, PRNGKey
 from blackjax.util import generate_gaussian_noise, linear_map
 
 __all__ = [
+    "LowRankInverseMassMatrix",
     "default_metric",
     "gaussian_euclidean",
     "gaussian_euclidean_low_rank",
@@ -83,15 +84,60 @@ class Metric(NamedTuple):
     scale: Scale
 
 
-MetricTypes: TypeAlias = Metric | Array | Callable[[ArrayLikeTree], Array]
+class LowRankInverseMassMatrix(NamedTuple):
+    """Pure-array description of a low-rank inverse mass matrix.
+
+    The inverse mass matrix has the form
+
+    .. math::
+
+        M^{-1} = \\operatorname{diag}(\\sigma)
+                 \\bigl(I + U(\\Lambda - I)U^\\top\\bigr)
+                 \\operatorname{diag}(\\sigma)
+
+    where :math:`\\sigma \\in \\mathbb{R}^d_{>0}`, :math:`U \\in \\mathbb{R}^{d \\times k}`
+    has orthonormal columns and :math:`\\Lambda = \\operatorname{diag}(\\lambda)`.
+
+    This is the array-only payload produced by
+    :func:`~blackjax.adaptation.low_rank_adaptation.low_rank_window_adaptation`.
+    Unlike a fully-constructed :class:`Metric` (whose fields are Python closures
+    that capture these arrays), this NamedTuple is a pure JAX pytree and can be
+    safely transported across ``jax.vmap`` / ``jax.pmap`` boundaries.
+
+    :func:`default_metric` expands this into a :class:`Metric` at the kernel
+    call site via :func:`gaussian_euclidean_low_rank`.
+
+    Attributes
+    ----------
+    sigma
+        Shape ``(d,)``. Positive diagonal scaling.
+    U
+        Shape ``(d, k)``. Matrix with orthonormal columns.
+    lam
+        Shape ``(k,)``. Positive eigenvalues.
+    """
+
+    sigma: Array
+    U: Array
+    lam: Array
+
+
+MetricTypes: TypeAlias = (
+    Metric | LowRankInverseMassMatrix | Array | Callable[[ArrayLikeTree], Array]
+)
 
 
 def default_metric(metric: MetricTypes) -> Metric:
     """Convert an input metric into a ``Metric`` object following sensible default rules.
 
-    The metric can be specified in three different ways:
+    The metric can be specified in four different ways:
 
     - A ``Metric`` object that implements the full interface
+    - A ``LowRankInverseMassMatrix`` NamedTuple holding ``(sigma, U, lam)``,
+      which is expanded to a full :class:`Metric` via
+      :func:`gaussian_euclidean_low_rank`. This is the form returned by
+      :func:`~blackjax.adaptation.low_rank_adaptation.low_rank_window_adaptation`
+      and is safe to transport across ``jax.vmap`` boundaries.
     - An ``Array`` which is assumed to specify the inverse mass matrix of a static
       metric
     - A function that takes a coordinate position and returns the mass matrix at that
@@ -102,6 +148,13 @@ def default_metric(metric: MetricTypes) -> Metric:
     A ``Metric`` object with ``sample_momentum``, ``kinetic_energy``,
     ``check_turning``, and ``scale`` fields.
     """
+    # LowRankInverseMassMatrix must be checked before Metric because both are
+    # NamedTuples; isinstance(metric, Metric) on a LowRankInverseMassMatrix is
+    # already False (distinct types), but listing the low-rank case first keeps
+    # the dispatch order obvious.
+    if isinstance(metric, LowRankInverseMassMatrix):
+        return gaussian_euclidean_low_rank(metric.sigma, metric.U, metric.lam)
+
     if isinstance(metric, Metric):
         return metric
 

--- a/tests/adaptation/test_low_rank_adaptation.py
+++ b/tests/adaptation/test_low_rank_adaptation.py
@@ -19,6 +19,7 @@ from absl.testing import absltest
 
 import blackjax
 from blackjax.adaptation.low_rank_adaptation import _compute_low_rank_metric, _spd_mean
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.fixtures import BlackJAXTest
 
 
@@ -216,6 +217,80 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
                 self.next_key(), jnp.zeros(d), num_steps=200
             )
             self.assertEqual(state.position.shape, (d,))
+
+    def test_inverse_mass_matrix_is_pure_pytree(self):
+        """``params['inverse_mass_matrix']`` is an array-only NamedTuple (GH #916).
+
+        The warmup must return ``LowRankInverseMassMatrix(sigma, U, lam)``
+        — a pure JAX pytree — rather than a closure-bearing ``Metric``, so
+        the result can be transported across ``jax.vmap`` / ``jax.pmap``.
+        """
+        d = 5
+        logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
+        warmup = blackjax.low_rank_window_adaptation(
+            blackjax.nuts, logdensity_fn, max_rank=3
+        )
+        (_, params), _ = warmup.run(self.next_key(), jnp.zeros(d), num_steps=200)
+        imm = params["inverse_mass_matrix"]
+        self.assertIsInstance(imm, LowRankInverseMassMatrix)
+        self.assertEqual(imm.sigma.shape, (d,))
+        self.assertEqual(imm.U.shape, (d, 3))
+        self.assertEqual(imm.lam.shape, (3,))
+        # All fields are JAX arrays (no Python closures captured as leaves).
+        leaves = jax.tree_util.tree_leaves(imm)
+        self.assertEqual(len(leaves), 3)
+        for leaf in leaves:
+            self.assertTrue(hasattr(leaf, "shape"))
+
+    def test_multi_chain_vmap(self):
+        """Warmup composes with ``jax.vmap`` over chains (GH #916 reproducer).
+
+        Before the fix this raised ``TypeError: Output from batched function
+        ... is not a valid JAX type`` because the returned ``Metric`` carried
+        Python closures that vmap could not stack.
+        """
+        d = 8
+        num_chains = 3
+        logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
+
+        warmup = blackjax.low_rank_window_adaptation(
+            blackjax.hmc,
+            logdensity_fn,
+            num_integration_steps=5,
+            max_rank=2,
+        )
+
+        chain_keys = jax.random.split(self.next_key(), num_chains)
+        init_positions = jnp.tile(jnp.zeros(d)[None, :], (num_chains, 1))
+
+        @jax.vmap
+        def run_one(k, x):
+            (state, params), _ = warmup.run(k, x, num_steps=150)
+            return state, params
+
+        states, params = run_one(chain_keys, init_positions)
+        self.assertEqual(states.position.shape, (num_chains, d))
+
+        imm = params["inverse_mass_matrix"]
+        self.assertIsInstance(imm, LowRankInverseMassMatrix)
+        # Each field carries an extra leading batch axis from vmap.
+        self.assertEqual(imm.sigma.shape, (num_chains, d))
+        self.assertEqual(imm.U.shape, (num_chains, d, 2))
+        self.assertEqual(imm.lam.shape, (num_chains, 2))
+        self.assertEqual(params["step_size"].shape, (num_chains,))
+
+        # The per-chain payload is consumable by the kernel: pick chain 0,
+        # build a NUTS kernel, and take one step (smoke test of the
+        # default_metric dispatch on LowRankInverseMassMatrix).
+        chain0_imm = jax.tree.map(lambda x: x[0], imm)
+        chain0_state = jax.tree.map(lambda x: x[0], states)
+        nuts = blackjax.nuts(
+            logdensity_fn,
+            step_size=float(params["step_size"][0]),
+            inverse_mass_matrix=chain0_imm,
+        )
+        new_state, _info = nuts.step(self.next_key(), chain0_state)
+        self.assertEqual(new_state.position.shape, (d,))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #916. `blackjax.adaptation.low_rank_adaptation.low_rank_window_adaptation` can now compose with `jax.vmap` over the chain axis.

The root cause was that the warmup returned `params["inverse_mass_matrix"]` as a `Metric` NamedTuple of four Python closures (`sample_momentum`, `kinetic_energy`, `check_turning`, `scale`) capturing `(sigma, U, lam)`. Under `vmap`, JAX walks the output pytree, treats each closure as a leaf, and fails to stack Python callables across the batch dim:

```
TypeError: Output from batched function <function gaussian_euclidean_low_rank.<locals>.momentum_generator ...> with type <class 'function'> is not a valid JAX type
```

This blocked the canonical multi-chain warmup contract for any HMC-family kernel composed with low-rank window adaptation (NUTS, HMC, MHMC, dynamic_hmc, dmhmc, MALA, Barker, laplace_*).

## Approach

Option (1) from the issue — make the warmup output a pure-array NamedTuple, expand to a `Metric` at the kernel call site:

- New `blackjax.mcmc.metrics.LowRankInverseMassMatrix(sigma, U, lam)` — a NamedTuple of arrays, a valid JAX pytree.
- `low_rank_window_adaptation.run()` now returns this in `params["inverse_mass_matrix"]` instead of a closure-bearing `Metric`.
- `default_metric()` gains a dispatch arm that expands `LowRankInverseMassMatrix` into a `Metric` via `gaussian_euclidean_low_rank`. All HMC-family kernels already route their `inverse_mass_matrix` argument through `default_metric()`, so the kernel-facing API is unchanged.

Inside the warmup's `lax.scan`, the per-step `Metric` is still built (and consumed) inside the trace — it never crosses the vmap boundary, so no change there.

## Test plan

- [x] `test_inverse_mass_matrix_is_pure_pytree` — the warmup output has exactly 3 array leaves (no closures).
- [x] `test_multi_chain_vmap` — reproducer from the issue; runs 3 chains through `jax.vmap`, checks batch-axis shapes on every IMM field, then consumes chain 0's IMM through a NUTS step to exercise the `default_metric` dispatch end-to-end.
- [x] All 20 tests in `tests/adaptation/test_low_rank_adaptation.py` pass.
- [x] All 39 tests in `tests/mcmc/test_metrics.py` pass.
- [x] All 64 tests in `tests/test_api_protocols.py` pass.
- [x] All 60 tests in `tests/adaptation/` pass under `-n auto`.
- [x] `pre-commit run --all-files` on the changed files passes (black, isort, flake8, mypy, pyupgrade).

## Compatibility note

`params["inverse_mass_matrix"]` returned by `low_rank_window_adaptation` changes type from `Metric` to `LowRankInverseMassMatrix`. Users who passed the result straight into a sampler (e.g. `blackjax.nuts(logdensity_fn, **params)`) are unaffected — the kernel layer normalizes through `default_metric()`. Users who manually unpacked the four `Metric` fields will need to either (a) re-construct the Metric via `metrics.gaussian_euclidean_low_rank(*imm)` or (b) reach into the new NamedTuple fields directly (`imm.sigma`, `imm.U`, `imm.lam`).