### PR TITLE
pathfinder_adaptation: add num_chains + n_paths for multi-chain via multipathfinder dispatch

### DIFF
--- a/blackjax/adaptation/pathfinder_adaptation.py
+++ b/blackjax/adaptation/pathfinder_adaptation.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Implementation of the Pathfinder warmup for the HMC family of sampling algorithms."""
-from typing import Callable, NamedTuple
+import warnings
+from typing import Callable, Literal, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -27,7 +28,11 @@ from blackjax.adaptation.step_size import (
 from blackjax.base import AdaptationAlgorithm
 from blackjax.optimizers.lbfgs import lbfgs_inverse_hessian_formula_1
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
-from blackjax.vi.multipathfinder import multi_approximate, psis_weights
+from blackjax.vi.multipathfinder import (
+    MultipathfinderState,
+    multi_approximate,
+    psis_weights,
+)
 
 __all__ = ["PathfinderAdaptationState", "base", "pathfinder_adaptation"]
 
@@ -36,6 +41,90 @@ class PathfinderAdaptationState(NamedTuple):
     ss_state: DualAveragingAdaptationState
     step_size: float
     inverse_mass_matrix: Array
+
+
+def _psis_weighted_mixture_covariance(
+    mpf_state: MultipathfinderState,
+    log_weights: Array,
+) -> Array:
+    """Compute the PSIS-weighted mixture covariance of the multipathfinder approximation.
+
+    Implements the law-of-total-variance for a mixture of Laplace approximations:
+    ``p(theta) approx sum_i w_i * N(mu_i, Sigma_i)`` where ``w_i`` are aggregate
+    PSIS weights.
+
+    The mixture covariance is:
+
+    .. math::
+
+        \\Sigma_{\\text{mix}} = \\underbrace{\\sum_i w_i \\Sigma_i}_{\\text{within}}
+            + \\underbrace{\\sum_i w_i (\\mu_i - \\bar{\\mu})(\\mu_i - \\bar{\\mu})^T}_{\\text{between}}
+
+        \\bar{\\mu} = \\sum_i w_i \\mu_i
+
+    Parameters
+    ----------
+    mpf_state
+        Output of :func:`blackjax.vi.multipathfinder.multi_approximate`.
+        ``mpf_state.path_states`` are ELBO-argmax-selected states with shape
+        ``(n_paths, ...)``.
+    log_weights
+        Normalised log PSIS weights, shape ``(n_paths * num_samples_per_path,)``,
+        as returned by :func:`blackjax.vi.multipathfinder.psis_weights`.
+
+    Returns
+    -------
+    Array
+        Dense ``(d, d)`` positive-definite mixture covariance.
+
+    Notes
+    -----
+    When ``n_paths=1`` the between-component term is zero and the result
+    equals the single path's L-BFGS inverse Hessian exactly.
+    """
+    path_states = mpf_state.path_states
+    # path_states.position: (n_paths, d)
+    # path_states.alpha:    (n_paths, d)
+    # path_states.beta:     (n_paths, d, 2*maxcor)
+    # path_states.gamma:    (n_paths, 2*maxcor, 2*maxcor)
+    # logp has shape (n_paths, num_samples_per_path) and is typed as Array.
+    num_samples_per_path = mpf_state.logp.shape[1]
+    n_paths = log_weights.shape[0] // num_samples_per_path
+
+    # Reshape log_weights from (n_paths * num_samples,) to (n_paths, num_samples)
+    log_weights_per_path = log_weights.reshape(n_paths, num_samples_per_path)
+
+    # Aggregate to per-path weights via logsumexp then softmax-normalise.
+    # log_path_weights[i] = log sum_j exp(log_weights_per_path[i, j])
+    log_path_weights = jax.scipy.special.logsumexp(log_weights_per_path, axis=1)
+    # Normalise so sum(w_i) = 1
+    log_path_weights_norm = log_path_weights - jax.scipy.special.logsumexp(
+        log_path_weights
+    )
+    w = jnp.exp(log_path_weights_norm)  # (n_paths,)
+
+    # Per-path means: mu_i = path_states.position[i], shape (n_paths, d)
+    # (These are already flat arrays since PathfinderState.position is an Array
+    # after the ravel_pytree unravelling inside approximate().)
+    mu_per_path = path_states.position  # (n_paths, d)
+
+    # Per-path covariance Sigma_i = lbfgs_inverse_hessian_formula_1(alpha_i, beta_i, gamma_i)
+    # Returns (d, d) per path; vmap over paths gives (n_paths, d, d)
+    sigmas = jax.vmap(lbfgs_inverse_hessian_formula_1)(
+        path_states.alpha, path_states.beta, path_states.gamma
+    )  # (n_paths, d, d)
+
+    # Mixture mean: mu_mix = sum_i w_i mu_i
+    mu_mix = jnp.einsum("i,id->d", w, mu_per_path)  # (d,)
+
+    # Within-component term: sum_i w_i Sigma_i
+    sigma_within = jnp.einsum("i,ijk->jk", w, sigmas)  # (d, d)
+
+    # Between-component term: sum_i w_i (mu_i - mu_mix)(mu_i - mu_mix)^T
+    delta = mu_per_path - mu_mix[None, :]  # (n_paths, d)
+    sigma_between = jnp.einsum("i,ij,ik->jk", w, delta, delta)  # (d, d)
+
+    return sigma_within + sigma_between  # (d, d)
 
 
 def base(
@@ -105,13 +194,12 @@ def base(
         """Initialize adaptation from a pre-computed inverse mass matrix.
 
         Used in the multi-chain / multi-path dispatch where the IMM is derived
-        from PSIS-resampled empirical variance rather than the L-BFGS inverse
-        Hessian.
+        analytically or empirically from the multipathfinder output.
 
         Parameters
         ----------
         inverse_mass_matrix
-            Pre-computed diagonal IMM array, shape ``(d,)``.
+            Pre-computed dense IMM array, shape ``(d, d)``.
         initial_step_size
             The initial value for the step size.
 
@@ -169,6 +257,9 @@ def pathfinder_adaptation(
     n_paths: int | None = None,
     num_samples_per_path: int = 200,
     psis_imm_n_samples: int = 2000,
+    imm_estimator: Literal[
+        "lbfgs_psis_mixture", "psis_empirical"
+    ] = "lbfgs_psis_mixture",
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,
     adaptation_info_fn: Callable = return_all_adapt_info,
@@ -191,11 +282,11 @@ def pathfinder_adaptation(
         behaviour is identical to the original single-chain pathfinder
         adaptation.  When > 1, ``num_chains`` chains are run in parallel with
         per-chain init positions drawn from the PSIS mixture and a shared
-        diagonal IMM derived from the post-PSIS empirical variance.
+        dense ``(d, d)`` IMM.
     n_paths
         Number of independent L-BFGS paths for the multi-path Pathfinder run.
         Defaults to ``num_chains`` (one path per chain).  Ignored when both
-        ``num_chains == 1`` and ``n_paths`` is ``None`` (or explicitly 1) —
+        ``num_chains == 1`` and ``n_paths`` is ``None`` (or explicitly 1) ---
         the original single-path code path is used in that case.
     num_samples_per_path
         Number of samples drawn per path to estimate ELBO and PSIS weights.
@@ -203,7 +294,25 @@ def pathfinder_adaptation(
     psis_imm_n_samples
         Number of PSIS-resampled draws used to estimate the post-PSIS
         empirical covariance for the IMM.  Only used when
-        ``effective_n_paths >= 2``.  Default 2000.
+        ``imm_estimator="psis_empirical"`` and ``effective_n_paths >= 2``.
+        Default 2000.
+    imm_estimator
+        Method for deriving the inverse mass matrix when ``effective_n_paths >= 2``.
+
+        ``"lbfgs_psis_mixture"`` *(default)*
+            Analytic PSIS-weighted mixture covariance via the law of total
+            variance (within-component + between-component terms).  Returns a
+            dense ``(d, d)`` matrix.  When ``n_paths=1`` this equals the
+            single-path L-BFGS inverse Hessian exactly.
+
+        ``"psis_empirical"``
+            Empirical covariance estimated from ``psis_imm_n_samples`` draws
+            importance-resampled according to PSIS weights.  Returns a dense
+            ``(d, d)`` matrix.
+
+        Ignored for the single-chain single-path dispatch (``num_chains=1``,
+        ``effective_n_paths=1``).  Passing a non-default value in that case
+        raises a ``UserWarning``.
     initial_step_size
         The initial step size used in the algorithm.
     target_acceptance_rate
@@ -224,36 +333,60 @@ def pathfinder_adaptation(
 
     Notes
     -----
-    **Dispatch table** — the ``(num_chains, effective_n_paths)`` combination
+    **Dispatch table** --- the ``(num_chains, effective_n_paths)`` combination
     selects the internal code path:
 
-    +-----------+--------------------+--------------------------------------------------+
-    | num_chains| effective_n_paths  | Behaviour                                        |
-    +===========+====================+==================================================+
-    | 1         | 1                  | **Original** single-path Pathfinder + DA.        |
-    |           |                    | Backward-compatible; scalar step_size, (d,) IMM. |
-    +-----------+--------------------+--------------------------------------------------+
-    | 1         | >= 2               | Multipathfinder with ``n_paths`` paths;          |
-    |           |                    | PSIS-resample 1 init; empirical IMM; DA.         |
-    +-----------+--------------------+--------------------------------------------------+
-    | >= 2      | 1                  | Single-path Pathfinder; broadcast init × chains; |
-    |           |                    | vmap DA.  step_size shape (num_chains,).         |
-    +-----------+--------------------+--------------------------------------------------+
-    | >= 2      | >= 2               | **Paper-canonical** (Zhang et al. 2022).         |
-    |           |                    | Multipathfinder → PSIS-resample num_chains inits |
-    |           |                    | → shared IMM → vmap DA.                          |
-    +-----------+--------------------+--------------------------------------------------+
+    +-----------+--------------------+--------------------+---------------------------------------------+
+    | num_chains| effective_n_paths  | imm_estimator      | Behaviour                                   |
+    +===========+====================+====================+=============================================+
+    | 1         | 1                  | (ignored)          | **Original** single-path Pathfinder + DA.   |
+    |           |                    |                    | scalar step_size, ``(d, d)`` IMM.           |
+    +-----------+--------------------+--------------------+---------------------------------------------+
+    | 1         | >= 2               | lbfgs_psis_mixture | Multipathfinder; analytic PSIS-weighted     |
+    |           |                    |                    | mixture covariance; ``(d, d)`` dense IMM.   |
+    +-----------+--------------------+--------------------+---------------------------------------------+
+    | 1         | >= 2               | psis_empirical     | Multipathfinder; empirical covariance from  |
+    |           |                    |                    | psis_imm_n_samples resampled draws;         |
+    |           |                    |                    | ``(d, d)`` dense IMM.                       |
+    +-----------+--------------------+--------------------+---------------------------------------------+
+    | >= 2      | 1                  | (ignored)          | Single-path Pathfinder; broadcast init x    |
+    |           |                    |                    | chains; vmap DA. step_size (num_chains,).   |
+    |           |                    |                    | ``(d, d)`` IMM from L-BFGS inverse Hessian. |
+    +-----------+--------------------+--------------------+---------------------------------------------+
+    | >= 2      | >= 2               | lbfgs_psis_mixture | **Paper-canonical** (Zhang et al. 2022).    |
+    |           |                    |                    | Multipathfinder -> PSIS init -> analytic    |
+    |           |                    |                    | mixture covariance -> vmap DA.              |
+    +-----------+--------------------+--------------------+---------------------------------------------+
+    | >= 2      | >= 2               | psis_empirical     | Multipathfinder -> PSIS init -> empirical   |
+    |           |                    |                    | covariance -> vmap DA.                      |
+    +-----------+--------------------+--------------------+---------------------------------------------+
 
     **Return contract:**
 
     * ``num_chains == 1``: identical to the pre-change API.
       ``parameters["step_size"]`` is a scalar;
-      ``parameters["inverse_mass_matrix"]`` is ``(d,)``.
+      ``parameters["inverse_mass_matrix"]`` is uniformly ``(d, d)``.
     * ``num_chains > 1``: ``parameters["step_size"]`` is ``(num_chains,)``;
-      ``parameters["inverse_mass_matrix"]`` is the single shared ``(d,)`` IMM
-      (not broadcast — the caller broadcasts if needed).
+      ``parameters["inverse_mass_matrix"]`` is the single shared ``(d, d)`` IMM
+      (not broadcast --- the caller broadcasts if needed).
     * When ``effective_n_paths >= 2``, ``parameters`` also includes
       ``"_pathfinder_psis_pareto_k"`` (scalar) for downstream diagnostics.
+
+    **PSIS-weighted mixture covariance math** (``imm_estimator="lbfgs_psis_mixture"``):
+
+    Multipathfinder produces a mixture of Laplace approximations
+    ``p(theta) approx sum_i w_i * N(mu_i, Sigma_i)`` where ``mu_i`` is path ``i``'s
+    L-BFGS optimum position and ``Sigma_i`` is its L-BFGS inverse-Hessian estimate.
+    Weights ``w_i`` are aggregate (per-path sum) PSIS weights.
+
+    By the law of total variance:
+
+    .. math::
+
+        \\Sigma_{\\text{mix}} = \\sum_i w_i \\Sigma_i
+            + \\sum_i w_i (\\mu_i - \\bar\\mu)(\\mu_i - \\bar\\mu)^T
+
+    where :math:`\\bar\\mu = \\sum_i w_i \\mu_i`.
     """
     # --- Input validation (before JIT) ---
     if num_chains < 1:
@@ -262,6 +395,20 @@ def pathfinder_adaptation(
         raise ValueError(f"n_paths must be >= 1 or None, got {n_paths}")
 
     effective_n_paths = n_paths if n_paths is not None else num_chains
+
+    # Warn if imm_estimator is set to non-default on single-path single-chain.
+    if (
+        num_chains == 1
+        and effective_n_paths == 1
+        and imm_estimator != "lbfgs_psis_mixture"
+    ):
+        warnings.warn(
+            f"imm_estimator={imm_estimator!r} is ignored for the single-chain "
+            f"single-path dispatch (num_chains=1, effective_n_paths=1). "
+            f"The single-path L-BFGS inverse Hessian is always used.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     mcmc_kernel = algorithm.build_kernel()
 
@@ -317,7 +464,7 @@ def pathfinder_adaptation(
             return _run_multichain_single_path(rng_key, position, num_steps)
         else:
             # ----------------------------------------------------------------
-            # PATH C: multi-path (multipathfinder) — covers num_chains 1 or >1
+            # PATH C: multi-path (multipathfinder) --- covers num_chains 1 or >1
             # ----------------------------------------------------------------
             return _run_multipathfinder(rng_key, position, num_steps)
 
@@ -360,15 +507,12 @@ def pathfinder_adaptation(
         pf_key, rng_key = jax.random.split(rng_key)
         pathfinder_state, _ = vi.pathfinder.approximate(pf_key, logdensity_fn, position)
         # Derive the L-BFGS-based IMM from the single Pathfinder fit.
+        # lbfgs_inverse_hessian_formula_1 returns a dense (d, d) matrix.
         shared_imm = lbfgs_inverse_hessian_formula_1(
             pathfinder_state.alpha,
             pathfinder_state.beta,
             pathfinder_state.gamma,
-        )
-        # Ensure shared_imm is diagonal (1-D). lbfgs_inverse_hessian_formula_1
-        # may return a full matrix; extract diagonal if needed.
-        if shared_imm.ndim == 2:
-            shared_imm = jnp.diag(shared_imm)
+        )  # (d, d)
 
         # Sample num_chains init positions from the single Pathfinder fit.
         sample_keys = jax.random.split(rng_key, num_chains)
@@ -428,13 +572,13 @@ def pathfinder_adaptation(
 
         parameters = {
             "step_size": step_sizes,  # (num_chains,)
-            "inverse_mass_matrix": shared_imm,  # (d,) shared
+            "inverse_mass_matrix": shared_imm,  # (d, d) shared
             **extra_parameters,
         }
         return AdaptationResults(last_chain_states, parameters), infos
 
     def _run_multipathfinder(rng_key, position, num_steps):
-        """Multi-path Pathfinder → PSIS → PSIS-IMM → DA (single or multi-chain)."""
+        """Multi-path Pathfinder -> PSIS -> IMM -> DA (single or multi-chain)."""
         pf_key, resample_key, imm_key, rng_key = jax.random.split(rng_key, 4)
 
         # Replicate single position to (n_paths, ...) for the multi-path fit.
@@ -454,29 +598,39 @@ def pathfinder_adaptation(
         # Compute PSIS weights.
         log_weights, pareto_k = psis_weights(mpf_state)  # (n_paths*num_samples,)
 
-        # Flatten sample pool to (total_pool, ...).
-        samples_flat = jax.tree.map(
+        # ----- Derive shared dense (d, d) IMM -----
+        if imm_estimator == "lbfgs_psis_mixture":
+            # Analytic PSIS-weighted mixture covariance (law of total variance).
+            shared_imm = _psis_weighted_mixture_covariance(mpf_state, log_weights)
+        else:
+            # psis_empirical: empirical covariance from PSIS-resampled draws.
+            samples_flat = jax.tree.map(
+                lambda x: x.reshape(-1, *x.shape[2:]), mpf_state.samples
+            )
+            total_pool = log_weights.shape[0]
+            probs = jnp.exp(log_weights)
+            imm_indices = jax.random.choice(
+                imm_key, total_pool, shape=(psis_imm_n_samples,), replace=True, p=probs
+            )
+            imm_samples_pytree = jax.tree.map(lambda x: x[imm_indices], samples_flat)
+            # Flatten each sample to (d,) for covariance estimation.
+            flat_imm_samples = jax.vmap(lambda x: ravel_pytree(x)[0])(
+                imm_samples_pytree
+            )
+            # (psis_imm_n_samples, d) -> dense (d, d) covariance
+            shared_imm = jnp.cov(flat_imm_samples.T)  # (d, d)
+
+        # ----- Resample init positions via PSIS -----
+        samples_flat_for_init = jax.tree.map(
             lambda x: x.reshape(-1, *x.shape[2:]), mpf_state.samples
         )
         total_pool = log_weights.shape[0]
         probs = jnp.exp(log_weights)
-
-        # ----- Derive shared diagonal IMM from PSIS empirical variance -----
-        imm_indices = jax.random.choice(
-            imm_key, total_pool, shape=(psis_imm_n_samples,), replace=True, p=probs
-        )
-        imm_samples_pytree = jax.tree.map(lambda x: x[imm_indices], samples_flat)
-        # Flatten each sample to (d,) for variance estimation.
-        flat_imm_samples = jax.vmap(lambda x: ravel_pytree(x)[0])(imm_samples_pytree)
-        # (psis_imm_n_samples, d)
-        shared_imm = jnp.clip(jnp.var(flat_imm_samples, axis=0), min=1e-6)  # (d,)
-
-        # ----- Resample init positions via PSIS -----
         n_resample = max(num_chains, 1)
         init_indices = jax.random.choice(
             resample_key, total_pool, shape=(n_resample,), replace=True, p=probs
         )
-        init_from_psis = jax.tree.map(lambda x: x[init_indices], samples_flat)
+        init_from_psis = jax.tree.map(lambda x: x[init_indices], samples_flat_for_init)
         # init_from_psis: pytree with leading dim n_resample
 
         if num_chains == 1:
@@ -554,7 +708,7 @@ def pathfinder_adaptation(
             )
             parameters = {
                 "step_size": step_sizes,  # (num_chains,)
-                "inverse_mass_matrix": shared_imm,  # (d,) shared
+                "inverse_mass_matrix": shared_imm,  # (d, d) shared
                 "_pathfinder_psis_pareto_k": pareto_k,
                 **extra_parameters,
             }

--- a/blackjax/adaptation/pathfinder_adaptation.py
+++ b/blackjax/adaptation/pathfinder_adaptation.py
@@ -11,11 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementation of the Pathinder warmup for the HMC family of sampling algorithms."""
+"""Implementation of the Pathfinder warmup for the HMC family of sampling algorithms."""
 from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
 
 import blackjax.vi as vi
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
@@ -26,6 +27,7 @@ from blackjax.adaptation.step_size import (
 from blackjax.base import AdaptationAlgorithm
 from blackjax.optimizers.lbfgs import lbfgs_inverse_hessian_formula_1
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
+from blackjax.vi.multipathfinder import multi_approximate, psis_weights
 
 __all__ = ["PathfinderAdaptationState", "base", "pathfinder_adaptation"]
 
@@ -96,6 +98,29 @@ def base(
 
         return warmup_state
 
+    def init_from_imm(
+        inverse_mass_matrix: Array,
+        initial_step_size: float,
+    ) -> PathfinderAdaptationState:
+        """Initialize adaptation from a pre-computed inverse mass matrix.
+
+        Used in the multi-chain / multi-path dispatch where the IMM is derived
+        from PSIS-resampled empirical variance rather than the L-BFGS inverse
+        Hessian.
+
+        Parameters
+        ----------
+        inverse_mass_matrix
+            Pre-computed diagonal IMM array, shape ``(d,)``.
+        initial_step_size
+            The initial value for the step size.
+
+        """
+        da_state = da_init(initial_step_size)
+        return PathfinderAdaptationState(
+            da_state, initial_step_size, inverse_mass_matrix
+        )
+
     def update(
         adaptation_state: PathfinderAdaptationState,
         position: ArrayLikeTree,
@@ -133,19 +158,27 @@ def base(
         inverse_mass_matrix = warmup_state.inverse_mass_matrix
         return step_size, inverse_mass_matrix
 
-    return init, update, final
+    return init, init_from_imm, update, final
 
 
 def pathfinder_adaptation(
     algorithm,
     logdensity_fn: Callable,
+    *,
+    num_chains: int = 1,
+    n_paths: int | None = None,
+    num_samples_per_path: int = 200,
+    psis_imm_n_samples: int = 2000,
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,
     adaptation_info_fn: Callable = return_all_adapt_info,
     **extra_parameters,
 ) -> AdaptationAlgorithm:
     """Adapt the value of the inverse mass matrix and step size parameters of
-    algorithms in the HMC fmaily.
+    algorithms in the HMC family.
+
+    Supports single-chain (original behaviour) and multi-chain dispatch via
+    `blackjax.vi.multipathfinder`.
 
     Parameters
     ----------
@@ -153,6 +186,24 @@ def pathfinder_adaptation(
         The algorithm whose parameters are being tuned.
     logdensity_fn
         The log density probability density function from which we wish to sample.
+    num_chains
+        Number of independent chains to initialise.  When 1 (default) the
+        behaviour is identical to the original single-chain pathfinder
+        adaptation.  When > 1, ``num_chains`` chains are run in parallel with
+        per-chain init positions drawn from the PSIS mixture and a shared
+        diagonal IMM derived from the post-PSIS empirical variance.
+    n_paths
+        Number of independent L-BFGS paths for the multi-path Pathfinder run.
+        Defaults to ``num_chains`` (one path per chain).  Ignored when both
+        ``num_chains == 1`` and ``n_paths`` is ``None`` (or explicitly 1) —
+        the original single-path code path is used in that case.
+    num_samples_per_path
+        Number of samples drawn per path to estimate ELBO and PSIS weights.
+        Only used when ``effective_n_paths >= 2``.  Default 200.
+    psis_imm_n_samples
+        Number of PSIS-resampled draws used to estimate the post-PSIS
+        empirical covariance for the IMM.  Only used when
+        ``effective_n_paths >= 2``.  Default 2000.
     initial_step_size
         The initial step size used in the algorithm.
     target_acceptance_rate
@@ -171,11 +222,50 @@ def pathfinder_adaptation(
     A function that returns the last chain state and a sampling kernel with the
     tuned parameter values from an initial state.
 
+    Notes
+    -----
+    **Dispatch table** — the ``(num_chains, effective_n_paths)`` combination
+    selects the internal code path:
+
+    +-----------+--------------------+--------------------------------------------------+
+    | num_chains| effective_n_paths  | Behaviour                                        |
+    +===========+====================+==================================================+
+    | 1         | 1                  | **Original** single-path Pathfinder + DA.        |
+    |           |                    | Backward-compatible; scalar step_size, (d,) IMM. |
+    +-----------+--------------------+--------------------------------------------------+
+    | 1         | >= 2               | Multipathfinder with ``n_paths`` paths;          |
+    |           |                    | PSIS-resample 1 init; empirical IMM; DA.         |
+    +-----------+--------------------+--------------------------------------------------+
+    | >= 2      | 1                  | Single-path Pathfinder; broadcast init × chains; |
+    |           |                    | vmap DA.  step_size shape (num_chains,).         |
+    +-----------+--------------------+--------------------------------------------------+
+    | >= 2      | >= 2               | **Paper-canonical** (Zhang et al. 2022).         |
+    |           |                    | Multipathfinder → PSIS-resample num_chains inits |
+    |           |                    | → shared IMM → vmap DA.                          |
+    +-----------+--------------------+--------------------------------------------------+
+
+    **Return contract:**
+
+    * ``num_chains == 1``: identical to the pre-change API.
+      ``parameters["step_size"]`` is a scalar;
+      ``parameters["inverse_mass_matrix"]`` is ``(d,)``.
+    * ``num_chains > 1``: ``parameters["step_size"]`` is ``(num_chains,)``;
+      ``parameters["inverse_mass_matrix"]`` is the single shared ``(d,)`` IMM
+      (not broadcast — the caller broadcasts if needed).
+    * When ``effective_n_paths >= 2``, ``parameters`` also includes
+      ``"_pathfinder_psis_pareto_k"`` (scalar) for downstream diagnostics.
     """
+    # --- Input validation (before JIT) ---
+    if num_chains < 1:
+        raise ValueError(f"num_chains must be >= 1, got {num_chains}")
+    if n_paths is not None and n_paths < 1:
+        raise ValueError(f"n_paths must be >= 1 or None, got {n_paths}")
+
+    effective_n_paths = n_paths if n_paths is not None else num_chains
 
     mcmc_kernel = algorithm.build_kernel()
 
-    adapt_init, adapt_update, adapt_final = base(
+    adapt_init, adapt_init_from_imm, adapt_update, adapt_final = base(
         target_acceptance_rate,
     )
 
@@ -198,6 +288,41 @@ def pathfinder_adaptation(
         )
 
     def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 400):
+        """Run pathfinder adaptation.
+
+        Parameters
+        ----------
+        rng_key
+            PRNG key.
+        position
+            Single-chain position pytree.  The runner replicates internally
+            when ``num_chains > 1`` or ``effective_n_paths > 1``.
+        num_steps
+            Number of DA adaptation steps per chain.  Default 400.
+
+        Returns
+        -------
+        An ``AdaptationResults`` object and the adaptation info.
+        """
+        if num_chains == 1 and effective_n_paths == 1:
+            # ----------------------------------------------------------------
+            # PATH A: original single-chain single-path behaviour
+            # ----------------------------------------------------------------
+            return _run_single(rng_key, position, num_steps)
+        elif effective_n_paths == 1:
+            # ----------------------------------------------------------------
+            # PATH B: num_chains > 1 but single pathfinder fit
+            # Broadcast single-path L-BFGS IMM to all chains, vmap DA.
+            # ----------------------------------------------------------------
+            return _run_multichain_single_path(rng_key, position, num_steps)
+        else:
+            # ----------------------------------------------------------------
+            # PATH C: multi-path (multipathfinder) — covers num_chains 1 or >1
+            # ----------------------------------------------------------------
+            return _run_multipathfinder(rng_key, position, num_steps)
+
+    def _run_single(rng_key, position, num_steps):
+        """Original single-chain single-path Pathfinder + DA."""
         init_key, sample_key, rng_key = jax.random.split(rng_key, 3)
 
         pathfinder_state, _ = vi.pathfinder.approximate(
@@ -229,5 +354,210 @@ def pathfinder_adaptation(
         }
 
         return AdaptationResults(last_chain_state, parameters), info
+
+    def _run_multichain_single_path(rng_key, position, num_steps):
+        """Single Pathfinder fit; broadcast init and IMM to num_chains; vmap DA."""
+        pf_key, rng_key = jax.random.split(rng_key)
+        pathfinder_state, _ = vi.pathfinder.approximate(pf_key, logdensity_fn, position)
+        # Derive the L-BFGS-based IMM from the single Pathfinder fit.
+        shared_imm = lbfgs_inverse_hessian_formula_1(
+            pathfinder_state.alpha,
+            pathfinder_state.beta,
+            pathfinder_state.gamma,
+        )
+        # Ensure shared_imm is diagonal (1-D). lbfgs_inverse_hessian_formula_1
+        # may return a full matrix; extract diagonal if needed.
+        if shared_imm.ndim == 2:
+            shared_imm = jnp.diag(shared_imm)
+
+        # Sample num_chains init positions from the single Pathfinder fit.
+        sample_keys = jax.random.split(rng_key, num_chains)
+
+        @jax.vmap
+        def sample_one(key):
+            pos, _ = vi.pathfinder.sample(key, pathfinder_state)
+            return pos
+
+        init_positions = sample_one(sample_keys)
+
+        # Initialize chains.
+        @jax.vmap
+        def init_chain(pos):
+            init_state = algorithm.init(pos, logdensity_fn)
+            init_adapt = adapt_init_from_imm(shared_imm, initial_step_size)
+            return init_state, init_adapt
+
+        init_states, init_adapt_states = init_chain(init_positions)
+
+        def one_step_chain(carry, rng_key):
+            state, adaptation_state = carry
+            new_state, info = mcmc_kernel(
+                rng_key,
+                state,
+                logdensity_fn,
+                adaptation_state.step_size,
+                adaptation_state.inverse_mass_matrix,
+                **extra_parameters,
+            )
+            new_adaptation_state = adapt_update(
+                adaptation_state, new_state.position, info.acceptance_rate
+            )
+            return (
+                (new_state, new_adaptation_state),
+                adaptation_info_fn(new_state, info, new_adaptation_state),
+            )
+
+        chain_keys = jax.random.split(rng_key, num_chains)
+
+        @jax.vmap
+        def run_one_chain(init_state_and_adapt, chain_rng_key):
+            init_state, init_adapt = init_state_and_adapt
+            keys_for_steps = jax.random.split(chain_rng_key, num_steps)
+            last_state, info = jax.lax.scan(
+                one_step_chain,
+                (init_state, init_adapt),
+                keys_for_steps,
+            )
+            last_chain_state, last_warmup_state = last_state
+            step_size, _ = adapt_final(last_warmup_state)
+            return last_chain_state, step_size, info
+
+        last_chain_states, step_sizes, infos = run_one_chain(
+            (init_states, init_adapt_states), chain_keys
+        )
+
+        parameters = {
+            "step_size": step_sizes,  # (num_chains,)
+            "inverse_mass_matrix": shared_imm,  # (d,) shared
+            **extra_parameters,
+        }
+        return AdaptationResults(last_chain_states, parameters), infos
+
+    def _run_multipathfinder(rng_key, position, num_steps):
+        """Multi-path Pathfinder → PSIS → PSIS-IMM → DA (single or multi-chain)."""
+        pf_key, resample_key, imm_key, rng_key = jax.random.split(rng_key, 4)
+
+        # Replicate single position to (n_paths, ...) for the multi-path fit.
+        init_positions = jax.tree.map(
+            lambda x: jnp.broadcast_to(x[None], (effective_n_paths,) + x.shape),
+            position,
+        )
+
+        # Run multi-path Pathfinder.
+        mpf_state, _ = multi_approximate(
+            pf_key,
+            logdensity_fn,
+            init_positions,
+            num_samples=num_samples_per_path,
+        )
+
+        # Compute PSIS weights.
+        log_weights, pareto_k = psis_weights(mpf_state)  # (n_paths*num_samples,)
+
+        # Flatten sample pool to (total_pool, ...).
+        samples_flat = jax.tree.map(
+            lambda x: x.reshape(-1, *x.shape[2:]), mpf_state.samples
+        )
+        total_pool = log_weights.shape[0]
+        probs = jnp.exp(log_weights)
+
+        # ----- Derive shared diagonal IMM from PSIS empirical variance -----
+        imm_indices = jax.random.choice(
+            imm_key, total_pool, shape=(psis_imm_n_samples,), replace=True, p=probs
+        )
+        imm_samples_pytree = jax.tree.map(lambda x: x[imm_indices], samples_flat)
+        # Flatten each sample to (d,) for variance estimation.
+        flat_imm_samples = jax.vmap(lambda x: ravel_pytree(x)[0])(imm_samples_pytree)
+        # (psis_imm_n_samples, d)
+        shared_imm = jnp.clip(jnp.var(flat_imm_samples, axis=0), min=1e-6)  # (d,)
+
+        # ----- Resample init positions via PSIS -----
+        n_resample = max(num_chains, 1)
+        init_indices = jax.random.choice(
+            resample_key, total_pool, shape=(n_resample,), replace=True, p=probs
+        )
+        init_from_psis = jax.tree.map(lambda x: x[init_indices], samples_flat)
+        # init_from_psis: pytree with leading dim n_resample
+
+        if num_chains == 1:
+            # ----------------------------------------------------------------
+            # Single-chain multi-path: pick first (only) position, run DA.
+            # ----------------------------------------------------------------
+            single_pos = jax.tree.map(lambda x: x[0], init_from_psis)
+            init_state = algorithm.init(single_pos, logdensity_fn)
+            init_adapt = adapt_init_from_imm(shared_imm, initial_step_size)
+
+            chain_rng_key = rng_key
+            keys = jax.random.split(chain_rng_key, num_steps)
+            last_state, info = jax.lax.scan(
+                one_step,
+                (init_state, init_adapt),
+                keys,
+            )
+            last_chain_state, last_warmup_state = last_state
+            step_size, _ = adapt_final(last_warmup_state)
+            parameters = {
+                "step_size": step_size,
+                "inverse_mass_matrix": shared_imm,
+                "_pathfinder_psis_pareto_k": pareto_k,
+                **extra_parameters,
+            }
+            return AdaptationResults(last_chain_state, parameters), info
+
+        else:
+            # ----------------------------------------------------------------
+            # Multi-chain multi-path: vmap DA over num_chains chains.
+            # ----------------------------------------------------------------
+            @jax.vmap
+            def init_chain(pos):
+                init_state = algorithm.init(pos, logdensity_fn)
+                init_adapt = adapt_init_from_imm(shared_imm, initial_step_size)
+                return init_state, init_adapt
+
+            init_states, init_adapt_states = init_chain(init_from_psis)
+
+            def one_step_chain(carry, rng_key_step):
+                state, adaptation_state = carry
+                new_state, info = mcmc_kernel(
+                    rng_key_step,
+                    state,
+                    logdensity_fn,
+                    adaptation_state.step_size,
+                    adaptation_state.inverse_mass_matrix,
+                    **extra_parameters,
+                )
+                new_adaptation_state = adapt_update(
+                    adaptation_state, new_state.position, info.acceptance_rate
+                )
+                return (
+                    (new_state, new_adaptation_state),
+                    adaptation_info_fn(new_state, info, new_adaptation_state),
+                )
+
+            chain_keys = jax.random.split(rng_key, num_chains)
+
+            @jax.vmap
+            def run_one_chain(init_state_and_adapt, chain_rng_key):
+                init_state, init_adapt = init_state_and_adapt
+                keys_for_steps = jax.random.split(chain_rng_key, num_steps)
+                last_state, info = jax.lax.scan(
+                    one_step_chain,
+                    (init_state, init_adapt),
+                    keys_for_steps,
+                )
+                last_chain_state, last_warmup_state = last_state
+                step_size, _ = adapt_final(last_warmup_state)
+                return last_chain_state, step_size, info
+
+            last_chain_states, step_sizes, infos = run_one_chain(
+                (init_states, init_adapt_states), chain_keys
+            )
+            parameters = {
+                "step_size": step_sizes,  # (num_chains,)
+                "inverse_mass_matrix": shared_imm,  # (d,) shared
+                "_pathfinder_psis_pareto_k": pareto_k,
+                **extra_parameters,
+            }
+            return AdaptationResults(last_chain_states, parameters), infos
 
     return AdaptationAlgorithm(run)

--- a/tests/adaptation/conftest.py
+++ b/tests/adaptation/conftest.py
@@ -1,0 +1,34 @@
+# Copyright 2024- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared pytest fixtures for blackjax/tests/adaptation/."""
+import jax
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def clear_jax_caches():
+    """Clear JAX JIT/XLA caches between adaptation tests.
+
+    Adaptation tests compile many structurally-different traced functions
+    (different num_chains, n_paths, dispatch paths).  Without cache clearing
+    the xdist worker that runs these tests accumulates JIT traces across tests,
+    which can OOM the GitHub-hosted runner (7 GB) when multiple workers run
+    heavy adaptation tests in parallel.
+
+    Clearing after each test keeps per-worker peak RSS under the CI limit.
+    Note: this makes sequential single-process runs slower (each test re-JITs),
+    but CI uses xdist workers where each test already starts with a cold cache.
+    """
+    yield
+    jax.clear_caches()

--- a/tests/adaptation/test_pathfinder_adaptation_multichain.py
+++ b/tests/adaptation/test_pathfinder_adaptation_multichain.py
@@ -18,18 +18,18 @@ import numpy as np
 import pytest
 
 import blackjax
+from tests.fixtures import std_normal_logdensity
 
 # ---------------------------------------------------------------------------
-# Shared fixture: 3-D isotropic Gaussian
+# Shared position dimension (kept small to limit JIT compilation footprint)
 # ---------------------------------------------------------------------------
 
 DIM = 3
-TARGET_MEAN = jnp.zeros(DIM)
-TARGET_STD = jnp.ones(DIM)
 
 
-def logdensity_fn(x):
-    return jax.scipy.stats.norm.logpdf(x, loc=TARGET_MEAN, scale=TARGET_STD).sum()
+def _logdensity_fn(x):
+    """Wrapper that fixes DIM=3 for std_normal_logdensity."""
+    return std_normal_logdensity(x)
 
 
 # ---------------------------------------------------------------------------
@@ -46,10 +46,10 @@ def test_backward_compat_single_chain():
     rng_key = jax.random.key(0)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=200)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=50)
     step_size = params["step_size"]
     imm = params["inverse_mass_matrix"]
     assert step_size.shape == ()  # scalar
@@ -70,12 +70,12 @@ def test_multichain_single_path_shapes():
     rng_key = jax.random.key(1)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=4,
         n_paths=1,
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     assert params["step_size"].shape == (4,)
     # Single-path always returns dense (d, d) from L-BFGS inverse Hessian
     assert params["inverse_mass_matrix"].shape == (DIM, DIM)
@@ -89,12 +89,12 @@ def test_multichain_single_path_default_n_paths():
     rng_key = jax.random.key(7)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=4,
         # n_paths defaults to num_chains=4 -> triggers multipathfinder path
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     # n_paths = num_chains = 4 -> multi-path path
     assert params["step_size"].shape == (4,)
     # Multi-path returns dense (d, d) IMM
@@ -112,14 +112,14 @@ def test_single_chain_multipathfinder():
     rng_key = jax.random.key(2)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=1,
         n_paths=4,
-        num_samples_per_path=50,
-        psis_imm_n_samples=200,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     assert params["step_size"].shape == ()  # scalar
     # Multi-path returns dense (d, d) IMM
     assert params["inverse_mass_matrix"].shape == (DIM, DIM)
@@ -142,14 +142,14 @@ def test_paper_canonical_multichain_multipathfinder():
     rng_key = jax.random.key(3)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=4,
         n_paths=4,
-        num_samples_per_path=50,
-        psis_imm_n_samples=200,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     # Step sizes: one per chain
     assert params["step_size"].shape == (4,)
     assert jnp.all(params["step_size"] > 0)
@@ -174,7 +174,7 @@ def test_num_chains_zero_raises():
     with pytest.raises(ValueError, match="num_chains"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            logdensity_fn,
+            _logdensity_fn,
             num_chains=0,
         )
 
@@ -184,7 +184,7 @@ def test_num_chains_negative_raises():
     with pytest.raises(ValueError, match="num_chains"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            logdensity_fn,
+            _logdensity_fn,
             num_chains=-1,
         )
 
@@ -194,7 +194,7 @@ def test_n_paths_zero_raises():
     with pytest.raises(ValueError, match="n_paths"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            logdensity_fn,
+            _logdensity_fn,
             n_paths=0,
         )
 
@@ -204,7 +204,7 @@ def test_n_paths_negative_raises():
     with pytest.raises(ValueError, match="n_paths"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            logdensity_fn,
+            _logdensity_fn,
             n_paths=-2,
         )
 
@@ -219,15 +219,15 @@ def test_psis_empirical_single_chain_multipathfinder():
     rng_key = jax.random.key(10)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=1,
         n_paths=4,
-        num_samples_per_path=50,
-        psis_imm_n_samples=200,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
         imm_estimator="psis_empirical",
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     assert params["step_size"].shape == ()
     # psis_empirical also returns dense (d, d)
     assert params["inverse_mass_matrix"].shape == (DIM, DIM)
@@ -239,15 +239,15 @@ def test_psis_empirical_multichain_multipathfinder():
     rng_key = jax.random.key(11)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=4,
         n_paths=4,
-        num_samples_per_path=50,
-        psis_imm_n_samples=200,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
         imm_estimator="psis_empirical",
     )
     init_pos = jnp.zeros(DIM)
-    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     assert params["step_size"].shape == (4,)
     assert params["inverse_mass_matrix"].shape == (DIM, DIM)
     assert "_pathfinder_psis_pareto_k" in params
@@ -276,15 +276,15 @@ def test_imm_shape_uniformly_dense(num_chains, n_paths, imm_estimator):
     rng_key = jax.random.key(42)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=num_chains,
         n_paths=n_paths,
-        num_samples_per_path=30,
-        psis_imm_n_samples=100,
+        num_samples_per_path=20,
+        psis_imm_n_samples=50,
         imm_estimator=imm_estimator,
     )
     init_pos = jnp.zeros(DIM)
-    (_, params), _ = warmup.run(rng_key, init_pos, num_steps=50)
+    (_, params), _ = warmup.run(rng_key, init_pos, num_steps=20)
     imm = params["inverse_mass_matrix"]
     assert imm.shape == (DIM, DIM), (
         f"Expected (d, d)=({DIM}, {DIM}) but got {imm.shape} "
@@ -307,15 +307,15 @@ def test_imm_is_symmetric_and_psd(imm_estimator):
     rng_key = jax.random.key(20)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        logdensity_fn,
+        _logdensity_fn,
         num_chains=1,
         n_paths=4,
-        num_samples_per_path=50,
-        psis_imm_n_samples=200,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
         imm_estimator=imm_estimator,
     )
     init_pos = jnp.zeros(DIM)
-    (_, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    (_, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
     imm = params["inverse_mass_matrix"]
     # Symmetry
     assert jnp.allclose(imm, imm.T, atol=1e-5), (
@@ -356,7 +356,7 @@ def test_degenerate_n_paths_1_matches_single_path():
     pf_key, _ = jax.random.split(rng_key)
     init_positions = init_pos[None]  # (1, DIM)
     mpf_state, _ = multi_approximate(
-        pf_key, logdensity_fn, init_positions, num_samples=50
+        pf_key, _logdensity_fn, init_positions, num_samples=50
     )
     log_weights, _ = psis_weights(mpf_state)
 
@@ -391,20 +391,20 @@ def test_both_estimators_converge_on_gaussian():
     is the analytic estimator. We just verify they're in the same ballpark.
     """
     n_paths = 4
-    num_samples_per_path = 200
-    psis_imm_n_samples = 400
+    num_samples_per_path = 100
+    psis_imm_n_samples = 200
 
     def run_estimator(key, estimator):
         warmup = blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            logdensity_fn,
+            _logdensity_fn,
             num_chains=1,
             n_paths=n_paths,
             num_samples_per_path=num_samples_per_path,
             psis_imm_n_samples=psis_imm_n_samples,
             imm_estimator=estimator,
         )
-        (_, params), _ = warmup.run(key, jnp.zeros(DIM), num_steps=50)
+        (_, params), _ = warmup.run(key, jnp.zeros(DIM), num_steps=30)
         return params["inverse_mass_matrix"]
 
     key_a, key_b = jax.random.split(jax.random.key(99))
@@ -503,7 +503,7 @@ def test_imm_estimator_warns_on_single_path():
     with pytest.warns(UserWarning, match="imm_estimator"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            logdensity_fn,
+            _logdensity_fn,
             num_chains=1,
             n_paths=1,
             imm_estimator="psis_empirical",

--- a/tests/adaptation/test_pathfinder_adaptation_multichain.py
+++ b/tests/adaptation/test_pathfinder_adaptation_multichain.py
@@ -387,7 +387,7 @@ def test_both_estimators_converge_on_gaussian():
     """On an isotropic Gaussian, both estimators produce similar IMMs (rtol=0.5).
 
     This test uses generous tolerance because empirical covariance with only
-    200 samples can have substantial Monte Carlo noise, and lbfgs_psis_mixture
+    100 samples can have substantial Monte Carlo noise, and lbfgs_psis_mixture
     is the analytic estimator. We just verify they're in the same ballpark.
     """
     n_paths = 4

--- a/tests/adaptation/test_pathfinder_adaptation_multichain.py
+++ b/tests/adaptation/test_pathfinder_adaptation_multichain.py
@@ -1,0 +1,209 @@
+# Copyright 2024- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for pathfinder_adaptation's num_chains + n_paths kwargs (P1)."""
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import blackjax
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: 3-D isotropic Gaussian
+# ---------------------------------------------------------------------------
+
+DIM = 3
+TARGET_MEAN = jnp.zeros(DIM)
+TARGET_STD = jnp.ones(DIM)
+
+
+def logdensity_fn(x):
+    return jax.scipy.stats.norm.logpdf(x, loc=TARGET_MEAN, scale=TARGET_STD).sum()
+
+
+# ---------------------------------------------------------------------------
+# 1. Backward compatibility: no num_chains / n_paths kwargs
+# ---------------------------------------------------------------------------
+
+
+def test_backward_compat_single_chain():
+    """pathfinder_adaptation with no new kwargs is identical to original API.
+
+    The original single-chain single-path API returns a dense (d, d) IMM
+    from lbfgs_inverse_hessian_formula_1.  Scalar step_size.
+    """
+    rng_key = jax.random.key(0)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=200)
+    step_size = params["step_size"]
+    imm = params["inverse_mass_matrix"]
+    assert step_size.shape == ()  # scalar
+    # Original returns dense (d, d) IMM from the L-BFGS inverse Hessian
+    assert imm.shape == (DIM, DIM)
+    assert float(step_size) > 0
+    # Pareto-k should NOT be present in single-path single-chain
+    assert "_pathfinder_psis_pareto_k" not in params
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-chain single-path: num_chains > 1, n_paths defaults to 1
+# ---------------------------------------------------------------------------
+
+
+def test_multichain_single_path_shapes():
+    """num_chains=4 returns batched step_size (4,) and shared IMM (d,)."""
+    rng_key = jax.random.key(1)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=4,
+        n_paths=1,
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    assert params["step_size"].shape == (4,)
+    assert params["inverse_mass_matrix"].shape == (DIM,)
+    assert jnp.all(params["step_size"] > 0)
+    assert jnp.all(params["inverse_mass_matrix"] > 0)
+    # state.position should have leading dim 4
+    assert state.position.shape == (4, DIM)
+
+
+def test_multichain_single_path_default_n_paths():
+    """num_chains=4 with n_paths=None defaults to n_paths=num_chains=4 (multipathfinder)."""
+    rng_key = jax.random.key(7)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=4,
+        # n_paths defaults to num_chains=4 → triggers multipathfinder path
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    # n_paths = num_chains = 4 → multi-path path
+    assert params["step_size"].shape == (4,)
+    assert params["inverse_mass_matrix"].shape == (DIM,)
+    assert "_pathfinder_psis_pareto_k" in params
+
+
+# ---------------------------------------------------------------------------
+# 3. Single-chain multi-path: num_chains=1, n_paths=4
+# ---------------------------------------------------------------------------
+
+
+def test_single_chain_multipathfinder():
+    """num_chains=1, n_paths=4 runs multipathfinder, returns scalar step_size."""
+    rng_key = jax.random.key(2)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=1,
+        n_paths=4,
+        num_samples_per_path=50,
+        psis_imm_n_samples=200,
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    assert params["step_size"].shape == ()  # scalar
+    assert params["inverse_mass_matrix"].shape == (DIM,)
+    assert float(params["step_size"]) > 0
+    assert "_pathfinder_psis_pareto_k" in params
+    pareto_k = params["_pathfinder_psis_pareto_k"]
+    assert pareto_k.shape == ()
+    # pareto_k is a scalar diagnostic (can be NaN on degenerate samples, but
+    # should always be a finite-or-nan float, not an array)
+    assert pareto_k.ndim == 0
+
+
+# ---------------------------------------------------------------------------
+# 4. Paper-canonical: num_chains=4, n_paths=4
+# ---------------------------------------------------------------------------
+
+
+def test_paper_canonical_multichain_multipathfinder():
+    """num_chains=4, n_paths=4: multipathfinder → PSIS init → vmap DA."""
+    rng_key = jax.random.key(3)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=4,
+        n_paths=4,
+        num_samples_per_path=50,
+        psis_imm_n_samples=200,
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    # Step sizes: one per chain
+    assert params["step_size"].shape == (4,)
+    assert jnp.all(params["step_size"] > 0)
+    # IMM: shared single diagonal
+    assert params["inverse_mass_matrix"].shape == (DIM,)
+    assert jnp.all(params["inverse_mass_matrix"] > 0)
+    # PSIS diagnostic included
+    assert "_pathfinder_psis_pareto_k" in params
+    # state: batched over 4 chains
+    assert state.position.shape == (4, DIM)
+    # Empirical means should be near zero on this isotropic Gaussian
+    mean = jnp.mean(state.position, axis=0)
+    np.testing.assert_allclose(mean, jnp.zeros(DIM), atol=2.0)
+
+
+# ---------------------------------------------------------------------------
+# 5. Edge cases: invalid num_chains / n_paths raise ValueError
+# ---------------------------------------------------------------------------
+
+
+def test_num_chains_zero_raises():
+    """num_chains=0 raises ValueError at construction time."""
+    with pytest.raises(ValueError, match="num_chains"):
+        blackjax.pathfinder_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            num_chains=0,
+        )
+
+
+def test_num_chains_negative_raises():
+    """num_chains=-1 raises ValueError at construction time."""
+    with pytest.raises(ValueError, match="num_chains"):
+        blackjax.pathfinder_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            num_chains=-1,
+        )
+
+
+def test_n_paths_zero_raises():
+    """n_paths=0 raises ValueError at construction time."""
+    with pytest.raises(ValueError, match="n_paths"):
+        blackjax.pathfinder_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            n_paths=0,
+        )
+
+
+def test_n_paths_negative_raises():
+    """n_paths=-2 raises ValueError at construction time."""
+    with pytest.raises(ValueError, match="n_paths"):
+        blackjax.pathfinder_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            n_paths=-2,
+        )

--- a/tests/adaptation/test_pathfinder_adaptation_multichain.py
+++ b/tests/adaptation/test_pathfinder_adaptation_multichain.py
@@ -27,11 +27,6 @@ from tests.fixtures import std_normal_logdensity
 DIM = 3
 
 
-def _logdensity_fn(x):
-    """Wrapper that fixes DIM=3 for std_normal_logdensity."""
-    return std_normal_logdensity(x)
-
-
 # ---------------------------------------------------------------------------
 # 1. Backward compatibility: no num_chains / n_paths kwargs
 # ---------------------------------------------------------------------------
@@ -46,7 +41,7 @@ def test_backward_compat_single_chain():
     rng_key = jax.random.key(0)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
     )
     init_pos = jnp.zeros(DIM)
     (state, params), _ = warmup.run(rng_key, init_pos, num_steps=50)
@@ -70,7 +65,7 @@ def test_multichain_single_path_shapes():
     rng_key = jax.random.key(1)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=4,
         n_paths=1,
     )
@@ -89,7 +84,7 @@ def test_multichain_single_path_default_n_paths():
     rng_key = jax.random.key(7)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=4,
         # n_paths defaults to num_chains=4 -> triggers multipathfinder path
     )
@@ -112,7 +107,7 @@ def test_single_chain_multipathfinder():
     rng_key = jax.random.key(2)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=1,
         n_paths=4,
         num_samples_per_path=30,
@@ -142,7 +137,7 @@ def test_paper_canonical_multichain_multipathfinder():
     rng_key = jax.random.key(3)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=4,
         n_paths=4,
         num_samples_per_path=30,
@@ -174,7 +169,7 @@ def test_num_chains_zero_raises():
     with pytest.raises(ValueError, match="num_chains"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            _logdensity_fn,
+            std_normal_logdensity,
             num_chains=0,
         )
 
@@ -184,7 +179,7 @@ def test_num_chains_negative_raises():
     with pytest.raises(ValueError, match="num_chains"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            _logdensity_fn,
+            std_normal_logdensity,
             num_chains=-1,
         )
 
@@ -194,7 +189,7 @@ def test_n_paths_zero_raises():
     with pytest.raises(ValueError, match="n_paths"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            _logdensity_fn,
+            std_normal_logdensity,
             n_paths=0,
         )
 
@@ -204,7 +199,7 @@ def test_n_paths_negative_raises():
     with pytest.raises(ValueError, match="n_paths"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            _logdensity_fn,
+            std_normal_logdensity,
             n_paths=-2,
         )
 
@@ -219,7 +214,7 @@ def test_psis_empirical_single_chain_multipathfinder():
     rng_key = jax.random.key(10)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=1,
         n_paths=4,
         num_samples_per_path=30,
@@ -239,7 +234,7 @@ def test_psis_empirical_multichain_multipathfinder():
     rng_key = jax.random.key(11)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=4,
         n_paths=4,
         num_samples_per_path=30,
@@ -276,7 +271,7 @@ def test_imm_shape_uniformly_dense(num_chains, n_paths, imm_estimator):
     rng_key = jax.random.key(42)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=num_chains,
         n_paths=n_paths,
         num_samples_per_path=20,
@@ -307,7 +302,7 @@ def test_imm_is_symmetric_and_psd(imm_estimator):
     rng_key = jax.random.key(20)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
-        _logdensity_fn,
+        std_normal_logdensity,
         num_chains=1,
         n_paths=4,
         num_samples_per_path=30,
@@ -356,7 +351,7 @@ def test_degenerate_n_paths_1_matches_single_path():
     pf_key, _ = jax.random.split(rng_key)
     init_positions = init_pos[None]  # (1, DIM)
     mpf_state, _ = multi_approximate(
-        pf_key, _logdensity_fn, init_positions, num_samples=50
+        pf_key, std_normal_logdensity, init_positions, num_samples=50
     )
     log_weights, _ = psis_weights(mpf_state)
 
@@ -397,7 +392,7 @@ def test_both_estimators_converge_on_gaussian():
     def run_estimator(key, estimator):
         warmup = blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            _logdensity_fn,
+            std_normal_logdensity,
             num_chains=1,
             n_paths=n_paths,
             num_samples_per_path=num_samples_per_path,
@@ -503,7 +498,7 @@ def test_imm_estimator_warns_on_single_path():
     with pytest.warns(UserWarning, match="imm_estimator"):
         blackjax.pathfinder_adaptation(
             blackjax.nuts,
-            _logdensity_fn,
+            std_normal_logdensity,
             num_chains=1,
             n_paths=1,
             imm_estimator="psis_empirical",

--- a/tests/adaptation/test_pathfinder_adaptation_multichain.py
+++ b/tests/adaptation/test_pathfinder_adaptation_multichain.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for pathfinder_adaptation's num_chains + n_paths kwargs (P1)."""
+"""Tests for pathfinder_adaptation's num_chains, n_paths, and imm_estimator kwargs."""
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 import blackjax
-
 
 # ---------------------------------------------------------------------------
 # Shared fixture: 3-D isotropic Gaussian
@@ -62,12 +61,12 @@ def test_backward_compat_single_chain():
 
 
 # ---------------------------------------------------------------------------
-# 2. Multi-chain single-path: num_chains > 1, n_paths defaults to 1
+# 2. Multi-chain single-path: num_chains > 1, n_paths=1
 # ---------------------------------------------------------------------------
 
 
 def test_multichain_single_path_shapes():
-    """num_chains=4 returns batched step_size (4,) and shared IMM (d,)."""
+    """num_chains=4, n_paths=1 returns batched step_size (4,) and shared dense IMM (d, d)."""
     rng_key = jax.random.key(1)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
@@ -78,9 +77,9 @@ def test_multichain_single_path_shapes():
     init_pos = jnp.zeros(DIM)
     (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
     assert params["step_size"].shape == (4,)
-    assert params["inverse_mass_matrix"].shape == (DIM,)
+    # Single-path always returns dense (d, d) from L-BFGS inverse Hessian
+    assert params["inverse_mass_matrix"].shape == (DIM, DIM)
     assert jnp.all(params["step_size"] > 0)
-    assert jnp.all(params["inverse_mass_matrix"] > 0)
     # state.position should have leading dim 4
     assert state.position.shape == (4, DIM)
 
@@ -92,13 +91,14 @@ def test_multichain_single_path_default_n_paths():
         blackjax.nuts,
         logdensity_fn,
         num_chains=4,
-        # n_paths defaults to num_chains=4 → triggers multipathfinder path
+        # n_paths defaults to num_chains=4 -> triggers multipathfinder path
     )
     init_pos = jnp.zeros(DIM)
     (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
-    # n_paths = num_chains = 4 → multi-path path
+    # n_paths = num_chains = 4 -> multi-path path
     assert params["step_size"].shape == (4,)
-    assert params["inverse_mass_matrix"].shape == (DIM,)
+    # Multi-path returns dense (d, d) IMM
+    assert params["inverse_mass_matrix"].shape == (DIM, DIM)
     assert "_pathfinder_psis_pareto_k" in params
 
 
@@ -108,7 +108,7 @@ def test_multichain_single_path_default_n_paths():
 
 
 def test_single_chain_multipathfinder():
-    """num_chains=1, n_paths=4 runs multipathfinder, returns scalar step_size."""
+    """num_chains=1, n_paths=4 runs multipathfinder, returns scalar step_size and (d,d) IMM."""
     rng_key = jax.random.key(2)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
@@ -121,7 +121,8 @@ def test_single_chain_multipathfinder():
     init_pos = jnp.zeros(DIM)
     (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
     assert params["step_size"].shape == ()  # scalar
-    assert params["inverse_mass_matrix"].shape == (DIM,)
+    # Multi-path returns dense (d, d) IMM
+    assert params["inverse_mass_matrix"].shape == (DIM, DIM)
     assert float(params["step_size"]) > 0
     assert "_pathfinder_psis_pareto_k" in params
     pareto_k = params["_pathfinder_psis_pareto_k"]
@@ -137,7 +138,7 @@ def test_single_chain_multipathfinder():
 
 
 def test_paper_canonical_multichain_multipathfinder():
-    """num_chains=4, n_paths=4: multipathfinder → PSIS init → vmap DA."""
+    """num_chains=4, n_paths=4: multipathfinder -> PSIS init -> vmap DA."""
     rng_key = jax.random.key(3)
     warmup = blackjax.pathfinder_adaptation(
         blackjax.nuts,
@@ -152,9 +153,8 @@ def test_paper_canonical_multichain_multipathfinder():
     # Step sizes: one per chain
     assert params["step_size"].shape == (4,)
     assert jnp.all(params["step_size"] > 0)
-    # IMM: shared single diagonal
-    assert params["inverse_mass_matrix"].shape == (DIM,)
-    assert jnp.all(params["inverse_mass_matrix"] > 0)
+    # IMM: shared dense (d, d) matrix
+    assert params["inverse_mass_matrix"].shape == (DIM, DIM)
     # PSIS diagnostic included
     assert "_pathfinder_psis_pareto_k" in params
     # state: batched over 4 chains
@@ -206,4 +206,305 @@ def test_n_paths_negative_raises():
             blackjax.nuts,
             logdensity_fn,
             n_paths=-2,
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. imm_estimator="psis_empirical" variant
+# ---------------------------------------------------------------------------
+
+
+def test_psis_empirical_single_chain_multipathfinder():
+    """imm_estimator='psis_empirical' returns dense (d, d) IMM via jnp.cov."""
+    rng_key = jax.random.key(10)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=1,
+        n_paths=4,
+        num_samples_per_path=50,
+        psis_imm_n_samples=200,
+        imm_estimator="psis_empirical",
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    assert params["step_size"].shape == ()
+    # psis_empirical also returns dense (d, d)
+    assert params["inverse_mass_matrix"].shape == (DIM, DIM)
+    assert "_pathfinder_psis_pareto_k" in params
+
+
+def test_psis_empirical_multichain_multipathfinder():
+    """imm_estimator='psis_empirical', num_chains=4, n_paths=4 returns (d, d) IMM."""
+    rng_key = jax.random.key(11)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=4,
+        n_paths=4,
+        num_samples_per_path=50,
+        psis_imm_n_samples=200,
+        imm_estimator="psis_empirical",
+    )
+    init_pos = jnp.zeros(DIM)
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    assert params["step_size"].shape == (4,)
+    assert params["inverse_mass_matrix"].shape == (DIM, DIM)
+    assert "_pathfinder_psis_pareto_k" in params
+    assert state.position.shape == (4, DIM)
+
+
+# ---------------------------------------------------------------------------
+# 7. Shape contract uniformity: all dispatch paths return (d, d) IMM
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "num_chains,n_paths,imm_estimator",
+    [
+        (1, None, "lbfgs_psis_mixture"),  # PATH A: original single-chain
+        (1, 1, "lbfgs_psis_mixture"),  # PATH A: explicit n_paths=1
+        (4, 1, "lbfgs_psis_mixture"),  # PATH B: multi-chain single-path
+        (1, 4, "lbfgs_psis_mixture"),  # PATH C: single-chain multi-path
+        (4, 4, "lbfgs_psis_mixture"),  # PATH C: paper-canonical
+        (1, 4, "psis_empirical"),  # PATH C: psis_empirical single chain
+        (4, 4, "psis_empirical"),  # PATH C: psis_empirical multi-chain
+    ],
+)
+def test_imm_shape_uniformly_dense(num_chains, n_paths, imm_estimator):
+    """Across all dispatch paths and estimators, inverse_mass_matrix is (d, d)."""
+    rng_key = jax.random.key(42)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=num_chains,
+        n_paths=n_paths,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
+        imm_estimator=imm_estimator,
+    )
+    init_pos = jnp.zeros(DIM)
+    (_, params), _ = warmup.run(rng_key, init_pos, num_steps=50)
+    imm = params["inverse_mass_matrix"]
+    assert imm.shape == (DIM, DIM), (
+        f"Expected (d, d)=({DIM}, {DIM}) but got {imm.shape} "
+        f"for num_chains={num_chains}, n_paths={n_paths}, "
+        f"imm_estimator={imm_estimator!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. PSD check: IMM is symmetric and positive-definite
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "imm_estimator",
+    ["lbfgs_psis_mixture", "psis_empirical"],
+)
+def test_imm_is_symmetric_and_psd(imm_estimator):
+    """Returned IMM is symmetric and passes Cholesky (positive-definite)."""
+    rng_key = jax.random.key(20)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        logdensity_fn,
+        num_chains=1,
+        n_paths=4,
+        num_samples_per_path=50,
+        psis_imm_n_samples=200,
+        imm_estimator=imm_estimator,
+    )
+    init_pos = jnp.zeros(DIM)
+    (_, params), _ = warmup.run(rng_key, init_pos, num_steps=100)
+    imm = params["inverse_mass_matrix"]
+    # Symmetry
+    assert jnp.allclose(imm, imm.T, atol=1e-5), (
+        f"IMM not symmetric for imm_estimator={imm_estimator!r}: "
+        f"max asymmetry = {jnp.max(jnp.abs(imm - imm.T))}"
+    )
+    # Positive-definite: Cholesky must not raise
+    jnp.linalg.cholesky(imm)
+
+
+# ---------------------------------------------------------------------------
+# 9. Degenerate equivalence: n_paths=1 lbfgs_psis_mixture == single-path L-BFGS
+# ---------------------------------------------------------------------------
+
+
+def test_degenerate_n_paths_1_matches_single_path():
+    """With n_paths=1, lbfgs_psis_mixture IMM equals the single-path L-BFGS IMM.
+
+    The between-component term is zero when n_paths=1 (only one mu_i = mu_mix),
+    so Sigma_mix = Sigma_0 exactly.
+    """
+    # We use the same key for both runs so that the L-BFGS optimization follows
+    # the same trajectory. The single-path run uses a 3-way key split while the
+    # n_paths=1 multi-path uses a 4-way split; keys diverge after the first
+    # split. We therefore can't check bit-exact equality, but we CAN verify that
+    # the n_paths=1 lbfgs_psis_mixture result is a valid (d, d) PSD matrix
+    # and that it equals the lbfgs_inverse_hessian at the same ELBO-argmax
+    # iterate from that run.
+    from blackjax.adaptation.pathfinder_adaptation import (
+        _psis_weighted_mixture_covariance,
+    )
+    from blackjax.vi.multipathfinder import multi_approximate, psis_weights
+
+    rng_key = jax.random.key(0)
+    init_pos = jnp.zeros(DIM)
+
+    # Run multi_approximate with n_paths=1 and extract directly.
+    pf_key, _ = jax.random.split(rng_key)
+    init_positions = init_pos[None]  # (1, DIM)
+    mpf_state, _ = multi_approximate(
+        pf_key, logdensity_fn, init_positions, num_samples=50
+    )
+    log_weights, _ = psis_weights(mpf_state)
+
+    # lbfgs_psis_mixture IMM from the helper
+    mix_imm = _psis_weighted_mixture_covariance(mpf_state, log_weights)
+
+    # Directly compute via lbfgs_inverse_hessian_formula_1 on the single path
+    from blackjax.optimizers.lbfgs import lbfgs_inverse_hessian_formula_1
+
+    single_imm = lbfgs_inverse_hessian_formula_1(
+        mpf_state.path_states.alpha[0],
+        mpf_state.path_states.beta[0],
+        mpf_state.path_states.gamma[0],
+    )
+
+    assert jnp.allclose(mix_imm, single_imm, atol=1e-5), (
+        f"n_paths=1 mixture IMM != single-path LBFGS IMM: "
+        f"max diff = {jnp.max(jnp.abs(mix_imm - single_imm))}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 10. Both estimators converge on the same Gaussian target
+# ---------------------------------------------------------------------------
+
+
+def test_both_estimators_converge_on_gaussian():
+    """On an isotropic Gaussian, both estimators produce similar IMMs (rtol=0.5).
+
+    This test uses generous tolerance because empirical covariance with only
+    200 samples can have substantial Monte Carlo noise, and lbfgs_psis_mixture
+    is the analytic estimator. We just verify they're in the same ballpark.
+    """
+    n_paths = 4
+    num_samples_per_path = 200
+    psis_imm_n_samples = 400
+
+    def run_estimator(key, estimator):
+        warmup = blackjax.pathfinder_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            num_chains=1,
+            n_paths=n_paths,
+            num_samples_per_path=num_samples_per_path,
+            psis_imm_n_samples=psis_imm_n_samples,
+            imm_estimator=estimator,
+        )
+        (_, params), _ = warmup.run(key, jnp.zeros(DIM), num_steps=50)
+        return params["inverse_mass_matrix"]
+
+    key_a, key_b = jax.random.split(jax.random.key(99))
+    imm_a = run_estimator(key_a, "lbfgs_psis_mixture")
+    imm_b = run_estimator(key_b, "psis_empirical")
+
+    # Both should have the same shape
+    assert imm_a.shape == (DIM, DIM)
+    assert imm_b.shape == (DIM, DIM)
+
+    # Diagonal elements (variances) should be positive and in the same ballpark.
+    diag_a = jnp.diag(imm_a)
+    diag_b = jnp.diag(imm_b)
+    assert jnp.all(
+        diag_a > 0
+    ), f"lbfgs_psis_mixture diagonal not all positive: {diag_a}"
+    assert jnp.all(diag_b > 0), f"psis_empirical diagonal not all positive: {diag_b}"
+
+    # Trace should be similar within a generous factor (x5)
+    trace_a = jnp.trace(imm_a)
+    trace_b = jnp.trace(imm_b)
+    ratio = jnp.maximum(trace_a, trace_b) / jnp.minimum(trace_a, trace_b)
+    assert float(ratio) < 5.0, (
+        "Traces differ by more than 5x: "
+        f"trace_a={float(trace_a)}, trace_b={float(trace_b)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 11. Between-component term is non-zero for a bimodal target
+# ---------------------------------------------------------------------------
+
+
+def test_between_component_contributes_for_bimodal_target():
+    """lbfgs_psis_mixture IMM has larger trace than within-component alone on bimodal.
+
+    We construct a 1-D bimodal target (mixture of two separated Gaussians) and
+    verify that the between-component correction increases the trace relative to
+    a within-component-only estimate.
+    """
+    from blackjax.adaptation.pathfinder_adaptation import (
+        _psis_weighted_mixture_covariance,
+    )
+    from blackjax.optimizers.lbfgs import lbfgs_inverse_hessian_formula_1
+    from blackjax.vi.multipathfinder import multi_approximate, psis_weights
+
+    # 1-D bimodal: two Gaussians at -3 and +3
+    def bimodal_logdensity(x):
+        log_p1 = jax.scipy.stats.norm.logpdf(x, loc=-3.0, scale=1.0)
+        log_p2 = jax.scipy.stats.norm.logpdf(x, loc=3.0, scale=1.0)
+        return jax.scipy.special.logsumexp(jnp.array([log_p1, log_p2]))
+
+    # Start one path near each mode
+    init_positions = jnp.array([[-3.0], [3.0]])
+
+    rng_key = jax.random.key(5)
+    mpf_state, _ = multi_approximate(
+        rng_key, bimodal_logdensity, init_positions, num_samples=100
+    )
+    log_weights, _ = psis_weights(mpf_state)
+
+    # Full mixture covariance
+    mix_imm = _psis_weighted_mixture_covariance(mpf_state, log_weights)
+
+    # Within-component only (no between term)
+    path_states = mpf_state.path_states
+    num_samples_per_path = mpf_state.logp.shape[1]
+    n_paths_local = log_weights.shape[0] // num_samples_per_path
+    log_weights_per_path = log_weights.reshape(n_paths_local, num_samples_per_path)
+    log_path_weights = jax.scipy.special.logsumexp(log_weights_per_path, axis=1)
+    log_path_weights_norm = log_path_weights - jax.scipy.special.logsumexp(
+        log_path_weights
+    )
+    w = jnp.exp(log_path_weights_norm)
+    sigmas = jax.vmap(lbfgs_inverse_hessian_formula_1)(
+        path_states.alpha, path_states.beta, path_states.gamma
+    )
+    sigma_within = jnp.einsum("i,ijk->jk", w, sigmas)
+
+    # The full mixture covariance should have larger trace
+    mix_trace = float(jnp.trace(mix_imm))
+    within_trace = float(jnp.trace(sigma_within))
+    assert mix_trace > within_trace, (
+        f"Expected mixture trace ({mix_trace}) > within-only trace ({within_trace}). "
+        "between-component term should add variance for bimodal target"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. imm_estimator warning on single-chain single-path
+# ---------------------------------------------------------------------------
+
+
+def test_imm_estimator_warns_on_single_path():
+    """Passing imm_estimator='psis_empirical' on single-path dispatch raises UserWarning."""
+    with pytest.warns(UserWarning, match="imm_estimator"):
+        blackjax.pathfinder_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            num_chains=1,
+            n_paths=1,
+            imm_estimator="psis_empirical",
         )


### PR DESCRIPTION
## Motivation

`pathfinder_adaptation` was single-chain only. Downstream consumers (e.g., tuningfork PR #31, stoch_vol groundtruth) had to wrap it with their own `jax.vmap` glue to get N chains, duplicating the multi-chain logic in every consumer. More importantly, this missed the **paper-canonical multi-path Pathfinder path** (Zhang et al. 2022, JMLR § 4 Birthday GP case study: *"adaptive HMC chains initialized by multi-path Pathfinder"*) — which requires multipathfinder + PSIS-resampled init positions + a shared IMM derived from the posterior covariance. Pushing this dispatch upstream into the blackjax API means every consumer becomes a thin shim.

## API design

```python
def pathfinder_adaptation(
    algorithm,
    logdensity_fn: Callable,
    *,
    num_chains: int = 1,
    n_paths: int | None = None,           # default = num_chains
    num_samples_per_path: int = 200,      # multipathfinder ELBO budget
    psis_imm_n_samples: int = 2000,       # PSIS empirical IMM sample budget (psis_empirical only)
    imm_estimator: Literal["lbfgs_psis_mixture", "psis_empirical"] = "lbfgs_psis_mixture",
    initial_step_size: float = 1.0,
    target_acceptance_rate: float = 0.80,
    adaptation_info_fn: Callable = return_all_adapt_info,
    **extra_parameters,
) -> AdaptationAlgorithm:
```

## Dispatch table

| `num_chains` | `effective_n_paths` | `imm_estimator` | Behaviour |
|---|---|---|---|
| 1 | 1 | (ignored) | **Original** single-path Pathfinder + DA (backward compat) |
| 1 | >= 2 | `lbfgs_psis_mixture` | Multipathfinder → PSIS-resample 1 init → analytic mixture covariance → DA |
| 1 | >= 2 | `psis_empirical` | Multipathfinder → PSIS-resample 1 init → empirical covariance → DA |
| >= 2 | 1 | (ignored) | Single Pathfinder fit → broadcast init × num_chains → vmap DA |
| >= 2 | >= 2 | `lbfgs_psis_mixture` | **Paper-canonical**: multipathfinder → PSIS-resample num_chains inits → analytic mixture covariance → vmap DA |
| >= 2 | >= 2 | `psis_empirical` | Multipathfinder → PSIS-resample num_chains inits → empirical covariance → vmap DA |

Note: `n_paths=None` (default) sets `effective_n_paths = num_chains`, so `pathfinder_adaptation(nuts, ld, num_chains=4)` is the paper-canonical path with 4 paths and 4 chains.

## Return contract

Uniformly `(d, d)` dense IMM across **all dispatch paths**:

- `num_chains == 1`: `parameters["step_size"]` is scalar; `parameters["inverse_mass_matrix"]` is `(d, d)`.
- `num_chains > 1`: `parameters["step_size"]` is `(num_chains,)`; `parameters["inverse_mass_matrix"]` is the single shared `(d, d)` IMM (not broadcast — caller broadcasts if needed).
- When `effective_n_paths >= 2`: `parameters["_pathfinder_psis_pareto_k"]` is included (scalar PSIS Pareto-k diagnostic).

## PSIS-weighted L-BFGS mixture covariance (`imm_estimator="lbfgs_psis_mixture"`)

Multipathfinder produces a mixture of Laplace approximations `p(theta) ≈ sum_i w_i * N(mu_i, Sigma_i)` where:
- `mu_i` = path `i`'s L-BFGS optimum position (ELBO-argmax iterate)
- `Sigma_i = lbfgs_inverse_hessian_formula_1(alpha_i, beta_i, gamma_i)` = path `i`'s L-BFGS inverse-Hessian estimate
- `w_i` = path `i`'s aggregate PSIS weight (sum of per-sample PSIS weights over the `num_samples_per_path` samples from that path)

By the **law of total variance** the mixture covariance is:

```
Sigma_mix = sum_i w_i * Sigma_i                                    (within-component)
          + sum_i w_i * (mu_i - mu_mix)(mu_i - mu_mix)^T           (between-component)
where mu_mix = sum_i w_i * mu_i
```

This is analytic (no Monte Carlo), yields a dense `(d, d)` PSD matrix, and degenerates correctly: when `n_paths=1`, the between-component term is zero and `Sigma_mix = Sigma_0` (the single path's L-BFGS inverse Hessian), matching the single-path branch exactly.

## Implementation notes

- `_psis_weighted_mixture_covariance(mpf_state, log_weights)` is a private helper implementing the mixture covariance formula. Uses `jax.vmap(lbfgs_inverse_hessian_formula_1)` over paths.
- `base()` returns a 4-tuple `(init, init_from_imm, update, final)`. The `init_from_imm` path accepts a pre-computed dense `(d, d)` IMM.
- `psis_empirical` path uses `jnp.cov(flat_imm_samples.T)` for dense `(d, d)` output (previously used `jnp.var` which returned diagonal `(d,)`).
- `imm_estimator` is ignored on the single-path single-chain dispatch; passing a non-default value raises a `UserWarning`.
- All input validation (`num_chains < 1`, `n_paths < 1`) at construction time before JIT.

## Test plan

- [x] Backward compat: `pathfinder_adaptation(nuts, ld)` returns scalar step_size, dense `(d, d)` IMM (original L-BFGS behaviour), no `_pathfinder_psis_pareto_k`
- [x] Multi-chain single-path (`num_chains=4, n_paths=1`): `step_size.shape == (4,)`, `imm.shape == (d, d)`, `state.position.shape == (4, d)`
- [x] Default `n_paths=None` with `num_chains=4`: triggers multipathfinder path
- [x] Single-chain multipath (`num_chains=1, n_paths=4`): scalar step_size, `(d, d)` IMM, `_pathfinder_psis_pareto_k` present
- [x] Paper-canonical (`num_chains=4, n_paths=4`): correct shapes, empirical mean near target
- [x] `imm_estimator="psis_empirical"` on single-chain and multi-chain: both return `(d, d)`
- [x] Shape-contract parametrized test: all 7 `(num_chains, n_paths, imm_estimator)` combinations return `(d, d)` IMM
- [x] PSD check: both estimators return symmetric, Cholesky-able matrix
- [x] Degenerate equivalence: `n_paths=1` `lbfgs_psis_mixture` helper equals `lbfgs_inverse_hessian_formula_1` directly
- [x] Both estimators converge on isotropic Gaussian (trace within 5x)
- [x] Between-component term contributes on bimodal target (mixture trace > within-only trace)
- [x] Warning raised when `imm_estimator != "lbfgs_psis_mixture"` on single-path dispatch
- [x] Edge: `num_chains=0/-1` raises ValueError; `n_paths=0/-2` raises ValueError

24 tests in `tests/adaptation/test_pathfinder_adaptation_multichain.py`. Pre-commit clean.

## Follow-up (out of scope here)

- The tuningfork `multipathfinder` warmup wrapper can be simplified to call `pathfinder_adaptation(num_chains=..., n_paths=...)` once this merges.
- The uniform `(d, d)` contract simplifies tuningfork's mass-matrix broadcasting: no need to distinguish diagonal vs dense dispatch paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)