### PR TITLE
fix(pathfinder_adaptation): ravel pytree positions before PSIS mixture-covariance einsum

### DIFF
--- a/blackjax/adaptation/pathfinder_adaptation.py
+++ b/blackjax/adaptation/pathfinder_adaptation.py
@@ -103,10 +103,19 @@ def _psis_weighted_mixture_covariance(
     )
     w = jnp.exp(log_path_weights_norm)  # (n_paths,)
 
-    # Per-path means: mu_i = path_states.position[i], shape (n_paths, d)
-    # (These are already flat arrays since PathfinderState.position is an Array
-    # after the ravel_pytree unravelling inside approximate().)
-    mu_per_path = path_states.position  # (n_paths, d)
+    # Per-path means: mu_i = path_states.position[i], shape (n_paths, d).
+    # PathfinderState.position is stored in the user's *pytree* shape (e.g.
+    # ``{'x': (n_paths, d_x), 'y': (n_paths, d_y)}`` for a dict-position
+    # model).  Ravel each path's pytree into a flat ``(d,)`` array via
+    # ``jax.vmap`` over the leading ``n_paths`` axis.  For models whose
+    # position is already a flat ``Array``, this is a no-op (a single leaf
+    # raveled to itself); for dict / tuple / nested pytrees it concatenates
+    # the flattened leaves in canonical leaf order.
+    def _ravel_one_path(pos_pytree):
+        flat, _ = ravel_pytree(pos_pytree)
+        return flat
+
+    mu_per_path = jax.vmap(_ravel_one_path)(path_states.position)  # (n_paths, d)
 
     # Per-path covariance Sigma_i = lbfgs_inverse_hessian_formula_1(alpha_i, beta_i, gamma_i)
     # Returns (d, d) per path; vmap over paths gives (n_paths, d, d)

--- a/tests/adaptation/test_pathfinder_adaptation_multichain.py
+++ b/tests/adaptation/test_pathfinder_adaptation_multichain.py
@@ -503,3 +503,44 @@ def test_imm_estimator_warns_on_single_path():
             n_paths=1,
             imm_estimator="psis_empirical",
         )
+
+
+# ---------------------------------------------------------------------------
+# 13. Pytree position regression: dict-shaped position survives PATH C
+# ---------------------------------------------------------------------------
+
+
+def test_pytree_position_multipathfinder_dispatch():
+    """Multi-path dispatch handles dict-shaped pytree positions without shape leak.
+
+    Regression for the bug where ``_psis_weighted_mixture_covariance`` assumed
+    ``path_states.position`` was a flat ``(n_paths, d)`` array, but
+    ``PathfinderState.position`` actually stores the user's pytree shape.
+    For a dict-position model like ``{'x': array}`` the einsum
+    ``"i,id->d"`` chokes with a ``ValueError`` from ``opt_einsum`` since
+    a dict isn't array-like.
+
+    Surfaced 2026-05-19 during tuningfork's pathfinder shim consolidation
+    (PR #33).  The fix ravels each path's pytree position before the einsum.
+    """
+
+    def dict_logdensity(pos):
+        # 10-D isotropic Gaussian over a single named site.
+        return std_normal_logdensity(pos["x"])
+
+    rng_key = jax.random.key(20260519)
+    warmup = blackjax.pathfinder_adaptation(
+        blackjax.nuts,
+        dict_logdensity,
+        num_chains=4,
+        n_paths=4,
+        num_samples_per_path=30,
+        psis_imm_n_samples=100,
+    )
+    init_pos = {"x": jnp.zeros(10)}
+    (state, params), _ = warmup.run(rng_key, init_pos, num_steps=30)
+
+    # Successful run is the regression check; just verify shape contract.
+    assert params["step_size"].shape == (4,)
+    assert params["inverse_mass_matrix"].shape == (10, 10)
+    assert "_pathfinder_psis_pareto_k" in params


### PR DESCRIPTION
## Summary

Fixes a shape-leak bug in `_psis_weighted_mixture_covariance` (added in #919) where dict / tuple / nested-pytree positions break the multipathfinder dispatch (PATH C, `n_paths >= 2`).

## Root cause

`PathfinderState.position` preserves the user's pytree shape — for a model with `init_position = {'x': jnp.zeros(10)}` the field stores `{'x': (n_paths, 10) array}`, not a flat `(n_paths, d)` array. PR #919's `_psis_weighted_mixture_covariance` passed this pytree directly into `jnp.einsum('i,id->d', w, mu_per_path)`, which `opt_einsum.parser.get_shape` cannot resolve:

```
ValueError: Cannot determine the shape of {'x': Array([[…(4, 10)…]], dtype=float32)},
can only determine the shape of array-like objects.
```

Surfaced 2026-05-19 by `tuningfork` PR #33's multipathfinder-shim simplification hitting it on `mvn_10` (a single-site dict-position model). Tuningfork added a local `_psis_mixture_covariance_flat` workaround that ravels positions before the einsum; this upstream fix lets that workaround be deleted.

## Fix

`jax.vmap(ravel_pytree)` over the leading `n_paths` axis converts each path's pytree position into a flat `(d,)` array before computing the mixture mean / between-component delta. For flat-array positions this is a no-op (single-leaf ravel returns the same array); for nested pytrees the leaves are concatenated in canonical leaf order.

5-line change in `_psis_weighted_mixture_covariance`. The comment block above the changed line is updated to document the new pytree-handling.

## Regression test

`test_pytree_position_multipathfinder_dispatch` in `tests/adaptation/test_pathfinder_adaptation_multichain.py`:
- Constructs `init_position = {'x': jnp.zeros(10)}` with `num_chains=4, n_paths=4`
- Runs `pathfinder_adaptation` end-to-end through PATH C
- Pre-fix: `ValueError` from opt_einsum
- Post-fix: success, expected shape contract `step_size=(4,)`, `imm=(10, 10)`, `pareto_k` sidecar present

## Test plan

- [x] 25/25 tests in `test_pathfinder_adaptation_multichain.py` pass (24 prior + 1 new regression), 5m48s wall at float32 + CPU
- [x] Pre-commit clean (black, isort, flake8, mypy, pyupgrade)
- [ ] CI green on all 3 Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)