### PR TITLE
rename low_rank_window_adaptation → window_adaptation_low_rank

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -6,7 +6,10 @@ from blackjax._version import __version__
 
 from .adaptation.adjusted_mclmc_adaptation import adjusted_mclmc_find_L_and_step_size
 from .adaptation.chees_adaptation import chees_adaptation
-from .adaptation.low_rank_adaptation import low_rank_window_adaptation
+from .adaptation.low_rank_adaptation import (
+    low_rank_window_adaptation,
+    window_adaptation_low_rank,
+)
 from .adaptation.mclmc_adaptation import mclmc_find_L_and_step_size
 from .adaptation.meads_adaptation import meads_adaptation
 from .adaptation.pathfinder_adaptation import pathfinder_adaptation
@@ -257,7 +260,8 @@ __all__ = [
     "dynamic_hmc",  # backward-compatible alias for dhmc
     "barker_proposal",  # backward-compatible alias for barker
     "window_adaptation",  # mcmc adaptation
-    "low_rank_window_adaptation",
+    "window_adaptation_low_rank",
+    "low_rank_window_adaptation",  # deprecated alias
     "meads_adaptation",
     "chees_adaptation",
     "pathfinder_adaptation",

--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -6,10 +6,7 @@ from blackjax._version import __version__
 
 from .adaptation.adjusted_mclmc_adaptation import adjusted_mclmc_find_L_and_step_size
 from .adaptation.chees_adaptation import chees_adaptation
-from .adaptation.low_rank_adaptation import (
-    low_rank_window_adaptation,
-    window_adaptation_low_rank,
-)
+from .adaptation.low_rank_adaptation import window_adaptation_low_rank
 from .adaptation.mclmc_adaptation import mclmc_find_L_and_step_size
 from .adaptation.meads_adaptation import meads_adaptation
 from .adaptation.pathfinder_adaptation import pathfinder_adaptation
@@ -261,7 +258,6 @@ __all__ = [
     "barker_proposal",  # backward-compatible alias for barker
     "window_adaptation",  # mcmc adaptation
     "window_adaptation_low_rank",
-    "low_rank_window_adaptation",  # deprecated alias
     "meads_adaptation",
     "chees_adaptation",
     "pathfinder_adaptation",

--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -65,7 +65,6 @@ __all__ = [
     "LowRankAdaptationState",
     "base",
     "window_adaptation_low_rank",
-    "low_rank_window_adaptation",  # deprecated alias
 ]
 
 
@@ -595,22 +594,3 @@ def window_adaptation_low_rank(
         return AdaptationResults(mu_star_state, parameters), info
 
     return AdaptationAlgorithm(run)
-
-
-# Backward-compatibility alias (added 2026-05-20 alongside the rename to
-# window_adaptation_low_rank). Will be removed in a future release.
-def low_rank_window_adaptation(*args, **kwargs):
-    """Deprecated alias for window_adaptation_low_rank.
-
-    .. deprecated::
-        Use :func:`window_adaptation_low_rank` instead.
-    """
-    import warnings
-
-    warnings.warn(
-        "low_rank_window_adaptation is deprecated, use "
-        "window_adaptation_low_rank instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return window_adaptation_low_rank(*args, **kwargs)

--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -64,7 +64,8 @@ from blackjax.util import pytree_size
 __all__ = [
     "LowRankAdaptationState",
     "base",
-    "low_rank_window_adaptation",
+    "window_adaptation_low_rank",
+    "low_rank_window_adaptation",  # deprecated alias
 ]
 
 
@@ -436,7 +437,7 @@ def base(
 # ---------------------------------------------------------------------------
 
 
-def low_rank_window_adaptation(
+def window_adaptation_low_rank(
     algorithm,
     logdensity_fn: Callable,
     max_rank: int = 10,
@@ -594,3 +595,22 @@ def low_rank_window_adaptation(
         return AdaptationResults(mu_star_state, parameters), info
 
     return AdaptationAlgorithm(run)
+
+
+# Backward-compatibility alias (added 2026-05-20 alongside the rename to
+# window_adaptation_low_rank). Will be removed in a future release.
+def low_rank_window_adaptation(*args, **kwargs):
+    """Deprecated alias for window_adaptation_low_rank.
+
+    .. deprecated::
+        Use :func:`window_adaptation_low_rank` instead.
+    """
+    import warnings
+
+    warnings.warn(
+        "low_rank_window_adaptation is deprecated, use "
+        "window_adaptation_low_rank instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return window_adaptation_low_rank(*args, **kwargs)

--- a/blackjax/mcmc/metrics.py
+++ b/blackjax/mcmc/metrics.py
@@ -99,7 +99,7 @@ class LowRankInverseMassMatrix(NamedTuple):
     has orthonormal columns and :math:`\\Lambda = \\operatorname{diag}(\\lambda)`.
 
     This is the array-only payload produced by
-    :func:`~blackjax.adaptation.low_rank_adaptation.low_rank_window_adaptation`.
+    :func:`~blackjax.adaptation.low_rank_adaptation.window_adaptation_low_rank`.
     Unlike a fully-constructed :class:`Metric` (whose fields are Python closures
     that capture these arrays), this NamedTuple is a pure JAX pytree and can be
     safely transported across ``jax.vmap`` / ``jax.pmap`` boundaries.
@@ -136,7 +136,7 @@ def default_metric(metric: MetricTypes) -> Metric:
     - A ``LowRankInverseMassMatrix`` NamedTuple holding ``(sigma, U, lam)``,
       which is expanded to a full :class:`Metric` via
       :func:`gaussian_euclidean_low_rank`. This is the form returned by
-      :func:`~blackjax.adaptation.low_rank_adaptation.low_rank_window_adaptation`
+      :func:`~blackjax.adaptation.low_rank_adaptation.window_adaptation_low_rank`
       and is safe to transport across ``jax.vmap`` boundaries.
     - An ``Array`` which is assumed to specify the inverse mass matrix of a static
       metric

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,7 +164,7 @@ marked *Sampling Book* are covered in depth at
 | `chees_adaptation` | CHEES (chain-ensemble adaptation) | — | [API](autoapi/blackjax/adaptation/chees_adaptation/index) |
 | `meads_adaptation` | MEADS (mass-matrix via ensemble) | — | [API](autoapi/blackjax/adaptation/meads_adaptation/index) |
 | `pathfinder_adaptation` | Pathfinder-based warmup | — | [API](autoapi/blackjax/adaptation/pathfinder_adaptation/index) |
-| `low_rank_window_adaptation` | Window adaptation with low-rank mass matrix | — | [API](autoapi/blackjax/adaptation/low_rank_adaptation/index) |
+| `window_adaptation_low_rank` | Window adaptation with low-rank mass matrix | — | [API](autoapi/blackjax/adaptation/low_rank_adaptation/index) |
 
 ## Diagnostics & Utilities
 

--- a/tests/adaptation/test_low_rank_adaptation.py
+++ b/tests/adaptation/test_low_rank_adaptation.py
@@ -159,12 +159,12 @@ class ComputeLowRankMetricTest(BlackJAXTest):
 
 
 class LowRankWindowAdaptationTest(BlackJAXTest):
-    """Integration tests for low_rank_window_adaptation."""
+    """Integration tests for window_adaptation_low_rank."""
 
     def test_runs_on_standard_normal(self):
         """Adaptation runs without error on a standard normal target."""
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.nuts, logdensity_fn, max_rank=3
         )
         (state, params), _ = warmup.run(self.next_key(), jnp.ones(5), num_steps=200)
@@ -178,7 +178,7 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         d = 6
         true_mean = jnp.array([2.0, -1.0, 0.5, -0.5, 1.5, -2.0])
         logdensity_fn = lambda x: -0.5 * jnp.sum((x - true_mean) ** 2)
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.nuts, logdensity_fn, max_rank=3
         )
         (state, _), _ = warmup.run(self.next_key(), jnp.zeros(d), num_steps=500)
@@ -187,7 +187,7 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
     def test_step_size_positive(self):
         """Adapted step size is strictly positive."""
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.nuts, logdensity_fn, max_rank=2
         )
         (_, params), _ = warmup.run(self.next_key(), jnp.zeros(4), num_steps=200)
@@ -196,7 +196,7 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
     def test_works_with_hmc(self):
         """Adaptation works with HMC (not just NUTS)."""
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.hmc,
             logdensity_fn,
             max_rank=2,
@@ -210,7 +210,7 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         d = 8
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
         for max_rank in [1, 5, 10]:
-            warmup = blackjax.low_rank_window_adaptation(
+            warmup = blackjax.window_adaptation_low_rank(
                 blackjax.nuts, logdensity_fn, max_rank=max_rank
             )
             (state, params), _ = warmup.run(
@@ -227,7 +227,7 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         """
         d = 5
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.nuts, logdensity_fn, max_rank=3
         )
         (_, params), _ = warmup.run(self.next_key(), jnp.zeros(d), num_steps=200)
@@ -253,7 +253,7 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         num_chains = 3
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
 
-        warmup = blackjax.low_rank_window_adaptation(
+        warmup = blackjax.window_adaptation_low_rank(
             blackjax.hmc,
             logdensity_fn,
             num_integration_steps=5,
@@ -291,6 +291,47 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         )
         new_state, _info = nuts.step(self.next_key(), chain0_state)
         self.assertEqual(new_state.position.shape, (d,))
+
+
+class DeprecationAliasTest(BlackJAXTest):
+    """Test backward-compatibility alias low_rank_window_adaptation."""
+
+    def test_low_rank_window_adaptation_alias_deprecated(self):
+        """The deprecated alias still works but emits DeprecationWarning."""
+        import warnings
+
+        logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            # Call the deprecated alias via the module to trigger the warning
+            warmup = blackjax.low_rank_window_adaptation(
+                blackjax.nuts, logdensity_fn, max_rank=2
+            )
+            (state, params), _ = warmup.run(
+                self.next_key(), jnp.zeros(4), num_steps=100
+            )
+
+            # Verify a deprecation warning was raised
+            deprecation_warnings = [
+                warning
+                for warning in w
+                if issubclass(warning.category, DeprecationWarning)
+            ]
+            self.assertGreater(len(deprecation_warnings), 0)
+
+            # Check that the warning message references the new function name
+            warning_messages = [
+                str(warning.message) for warning in deprecation_warnings
+            ]
+            self.assertTrue(
+                any("window_adaptation_low_rank" in msg for msg in warning_messages)
+            )
+
+            # Verify that the function still works correctly
+            self.assertIn("step_size", params)
+            self.assertIn("inverse_mass_matrix", params)
+            self.assertEqual(state.position.shape, (4,))
 
 
 if __name__ == "__main__":

--- a/tests/adaptation/test_low_rank_adaptation.py
+++ b/tests/adaptation/test_low_rank_adaptation.py
@@ -293,46 +293,5 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         self.assertEqual(new_state.position.shape, (d,))
 
 
-class DeprecationAliasTest(BlackJAXTest):
-    """Test backward-compatibility alias low_rank_window_adaptation."""
-
-    def test_low_rank_window_adaptation_alias_deprecated(self):
-        """The deprecated alias still works but emits DeprecationWarning."""
-        import warnings
-
-        logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            # Call the deprecated alias via the module to trigger the warning
-            warmup = blackjax.low_rank_window_adaptation(
-                blackjax.nuts, logdensity_fn, max_rank=2
-            )
-            (state, params), _ = warmup.run(
-                self.next_key(), jnp.zeros(4), num_steps=100
-            )
-
-            # Verify a deprecation warning was raised
-            deprecation_warnings = [
-                warning
-                for warning in w
-                if issubclass(warning.category, DeprecationWarning)
-            ]
-            self.assertGreater(len(deprecation_warnings), 0)
-
-            # Check that the warning message references the new function name
-            warning_messages = [
-                str(warning.message) for warning in deprecation_warnings
-            ]
-            self.assertTrue(
-                any("window_adaptation_low_rank" in msg for msg in warning_messages)
-            )
-
-            # Verify that the function still works correctly
-            self.assertIn("step_size", params)
-            self.assertIn("inverse_mass_matrix", params)
-            self.assertEqual(state.position.shape, (4,))
-
-
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## Summary

Rename `low_rank_window_adaptation` → `window_adaptation_low_rank` for naming alignment with the existing `blackjax.window_adaptation` entry point. The `low_rank` qualifier is sufficient since this is the only adaptation-specific window-adaptation function; the previous name's word order (`low_rank_window_adaptation`) read awkwardly next to `window_adaptation`.

**No backward-compat alias.** The function landed recently (post-#917, 2026-05-18) so few external integrations have hardcoded the old name. Downstream audit: sampling-book has zero usages of `low_rank_window_adaptation`. Downstream tuningfork wrapper has its own name (`window_adaptation_low_rank_imm`) that doesn't depend on the upstream symbol.

## Changes (6 commits)

| Commit | What |
|---|---|
| `d1e99bc4` | `adaptation/low_rank_adaptation.py`: rename function, update `__all__` (originally with deprecation-alias — removed in `292d0e0c`) |
| `138d7eea` | `blackjax/__init__.py`: import + `__all__` (originally with dual-name — simplified in `292d0e0c`) |
| `173281e9` | `mcmc/metrics.py`: update 2 docstring cross-refs |
| `e32fcfa7` | `docs/index.md`: update API table entry |
| `5f54e455` | tests: update 7 callsites to new name (deprecation test added — removed in `292d0e0c`) |
| `292d0e0c` | remove backward-compat alias and deprecation test (per downstream-audit confirmation; alias unnecessary for a low-risk new feature) |

## What does NOT change

- Module filename `blackjax/adaptation/low_rank_adaptation.py` (preserves `from blackjax.adaptation.low_rank_adaptation import …` imports)
- `LowRankInverseMassMatrix` NamedTuple class
- Any other public API

## Downstream coordination

Downstream tuningfork PR #40 (merged 2026-05-20) renamed its wrapper to `window_adaptation_low_rank_imm` (with `_imm` suffix for internal consistency with `window_adaptation_diag_imm` / `window_adaptation_dense_imm`). The two repos diverge intentionally — tuningfork's `_imm` qualifier serves internal consistency; blackjax's bare `window_adaptation_low_rank` aligns with its `window_adaptation` parent.

Tuningfork's emit_script template will be updated in a follow-up tuningfork PR to call `blackjax.window_adaptation_low_rank` directly (currently calls the old `blackjax.adaptation.low_rank_adaptation.low_rank_window_adaptation` path — with this PR, that path no longer exists).

## Test plan

- [ ] CI: all existing tests in `test_low_rank_adaptation.py` pass with the new name (20/20 locally)
- [ ] CI: `Run tests for Python 3.12` previously failed on `test_schrodinger_follmer.py` — that's a flaky VI test unrelated to this rename; re-run should pass or remain unrelatedly flaky.
