### PR TITLE
tests(vi): stabilize Schrödinger-Föllmer recover-posterior test under date-rotated seed

### DIFF
--- a/tests/vi/test_schrodinger_follmer.py
+++ b/tests/vi/test_schrodinger_follmer.py
@@ -63,7 +63,14 @@ class SchrodingerFollmerTest(BlackJAXTest):
             observed, prior_mu, prior_prec, true_prec
         )
 
-        schrodinger_follmer_algo = schrodinger_follmer(logp_model, 50, 25)
+        # n_steps=100 SDE steps with n_inner_samples=100 drift Monte Carlo
+        # samples — previously (50, 25), which gave a variational bias of order
+        # ~0.13 on the second posterior component for an unlucky `BlackJAXTest`
+        # date-rotated seed (e.g. 2026-05-20 → seed=20260520). Doubling each
+        # parameter cuts the worst-seed max-diff from 0.131 → 0.060, giving a
+        # comfortable safety margin under `atol=0.1` across 20 sampled daily
+        # seeds for ~0.25s of extra wall time.
+        schrodinger_follmer_algo = schrodinger_follmer(logp_model, 100, 100)
 
         initial_state = schrodinger_follmer_algo.init(initial_position)
         schrodinger_follmer_algo_sample = self.variant(


### PR DESCRIPTION
## Summary

- Nightly-JAX CI failed all 4 `test_recover_posterior__*` variants in `tests/vi/test_schrodinger_follmer.py` with `|diff|=0.131` on dim-1 vs `atol=0.1` ([job 76921882936](https://github.com/blackjax-devs/blackjax/actions/runs/26152101233/job/76921882936)).
- Reproduced **identically** on stable JAX locally → not a JAX-nightly regression. The `BlackJAXTest` fixture seeds from today's date (`20260520`), so the failure is deterministic-for-today and rotates.
- Schrödinger-Föllmer is a *biased* variational sampler. With `(n_steps=50, n_inner=25)`, drift Monte Carlo bias is O(1/√25) ≈ 0.2 and the Euler–Maruyama discretization bias is ~1/50, leaving a residual bias near the test's `atol=0.1`. A 20-daily-seed sweep showed the original config flakes at 5% (1/20).
- Fix: bump `schrodinger_follmer(logp_model, 50, 25)` → `schrodinger_follmer(logp_model, 100, 100)`. Worst max-diff across the same 20-seed sweep drops from **0.131 → 0.060** (well under `atol=0.1`); flakes go from 1/20 → 0/20. Cost: ~0.25 s per test invocation.

## Test plan

- [x] Reproduce failure locally on stable JAX with `(50, 25)` config: identical numeric mismatch as CI.
- [x] Sweep 20 contiguous daily seeds with `(50, 25)`: 1/20 fails.
- [x] Sweep 20 contiguous daily seeds with `(100, 100)`: 0/20 fails, max diff 0.060.
- [x] `uv run pre-commit run --files tests/vi/test_schrodinger_follmer.py` clean.
- [x] `JAX_PLATFORM_NAME=cpu uv run pytest tests/vi/test_schrodinger_follmer.py -v`: 4 passed, 1 skipped (pmap variant).
- [ ] JAX-nightly CI run on this branch (verifies fix carries over to nightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)