### PR TITLE
Surface L-BFGS diagnostics in laplace kernel Info (#925)

### DIFF
--- a/blackjax/mcmc/laplace_dynamic_hmc.py
+++ b/blackjax/mcmc/laplace_dynamic_hmc.py
@@ -55,11 +55,16 @@ import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
 from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
 from blackjax.mcmc.dynamic_hmc import DynamicHMCState
-from blackjax.mcmc.laplace_marginal import LaplaceMarginal, laplace_marginal_factory
+from blackjax.mcmc.laplace_marginal import (
+    LaplaceHMCInfo,
+    LaplaceMarginal,
+    laplace_marginal_factory,
+)
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
 __all__ = [
     "LaplaceDynamicHMCState",
+    "LaplaceHMCInfo",
     "init",
     "build_kernel",
     "as_top_level_api",
@@ -146,7 +151,7 @@ def build_kernel(
     Returns
     -------
     A kernel
-    ``(rng_key, state, laplace, step_size, inverse_mass_matrix) -> (LaplaceDynamicHMCState, HMCInfo)``.
+    ``(rng_key, state, laplace, step_size, inverse_mass_matrix) -> (LaplaceDynamicHMCState, LaplaceHMCInfo)``.
     """
     dynamic_kernel = dynamic_hmc.build_kernel(
         integrator,
@@ -163,8 +168,12 @@ def build_kernel(
         step_size: float,
         inverse_mass_matrix: metrics.MetricTypes,
         integration_steps_params: tuple = (),
-    ) -> tuple[LaplaceDynamicHMCState, hmc.HMCInfo]:
-        """One Laplace dynamic-HMC transition."""
+    ) -> tuple[LaplaceDynamicHMCState, LaplaceHMCInfo]:
+        """One Laplace dynamic-HMC transition.
+
+        L-BFGS diagnostics from the post-accept ``theta*`` refresh are
+        surfaced in the returned :class:`~blackjax.mcmc.laplace_marginal.LaplaceHMCInfo`.
+        """
         theta_prev = state.theta_star
 
         def logdensity_fn(phi):
@@ -177,7 +186,7 @@ def build_kernel(
             state.logdensity_grad,
             state.random_generator_arg,
         )
-        new_dynamic_state, info = dynamic_kernel(
+        new_dynamic_state, hmc_info = dynamic_kernel(
             rng_key,
             dynamic_state,
             logdensity_fn,
@@ -186,7 +195,9 @@ def build_kernel(
             integration_steps_params,
         )
 
-        new_theta_star = laplace.solve_theta(new_dynamic_state.position, theta_prev)
+        new_theta_star, lbfgs_diag = laplace.solve_theta_with_info(
+            new_dynamic_state.position, theta_prev
+        )
 
         new_state = LaplaceDynamicHMCState(
             new_dynamic_state.position,
@@ -195,7 +206,20 @@ def build_kernel(
             new_theta_star,
             new_dynamic_state.random_generator_arg,
         )
-        return new_state, info
+        new_info = LaplaceHMCInfo(
+            momentum=hmc_info.momentum,
+            acceptance_rate=hmc_info.acceptance_rate,
+            is_accepted=hmc_info.is_accepted,
+            is_divergent=hmc_info.is_divergent,
+            energy=hmc_info.energy,
+            proposal=hmc_info.proposal,
+            num_integration_steps=hmc_info.num_integration_steps,
+            lbfgs_iter_num=lbfgs_diag.iter_num,
+            lbfgs_error=lbfgs_diag.error,
+            lbfgs_converged=lbfgs_diag.converged,
+            lbfgs_hit_maxiter=lbfgs_diag.hit_maxiter,
+        )
+        return new_state, new_info
 
     return kernel
 
@@ -256,7 +280,9 @@ def as_top_level_api(
     Returns
     -------
     A :class:`~blackjax.base.SamplingAlgorithm` whose ``step`` returns a
-    :class:`LaplaceDynamicHMCState` and :class:`~blackjax.mcmc.hmc.HMCInfo`.
+    :class:`LaplaceDynamicHMCState` and
+    :class:`~blackjax.mcmc.laplace_marginal.LaplaceHMCInfo` (all standard
+    HMCInfo fields plus L-BFGS diagnostics ``lbfgs_hit_maxiter``, etc.).
 
     Examples
     --------

--- a/blackjax/mcmc/laplace_hmc.py
+++ b/blackjax/mcmc/laplace_hmc.py
@@ -54,11 +54,16 @@ import blackjax.mcmc.hmc as hmc
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
 from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
-from blackjax.mcmc.laplace_marginal import LaplaceMarginal, laplace_marginal_factory
+from blackjax.mcmc.laplace_marginal import (
+    LaplaceHMCInfo,
+    LaplaceMarginal,
+    laplace_marginal_factory,
+)
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
 
 __all__ = [
     "LaplaceHMCState",
+    "LaplaceHMCInfo",
     "init",
     "build_kernel",
     "as_top_level_api",
@@ -130,7 +135,7 @@ def build_kernel(
 
     Returns
     -------
-    A kernel ``(rng_key, state, laplace, step_size, inverse_mass_matrix, num_integration_steps) -> (LaplaceHMCState, HMCInfo)``.
+    A kernel ``(rng_key, state, laplace, step_size, inverse_mass_matrix, num_integration_steps) -> (LaplaceHMCState, LaplaceHMCInfo)``.
     """
     hmc_kernel = hmc.build_kernel(integrator, divergence_threshold, build_proposal)
 
@@ -141,13 +146,14 @@ def build_kernel(
         step_size: float,
         inverse_mass_matrix: metrics.MetricTypes,
         num_integration_steps: int,
-    ) -> tuple[LaplaceHMCState, hmc.HMCInfo]:
+    ) -> tuple[LaplaceHMCState, LaplaceHMCInfo]:
         """One Laplace-HMC transition.
 
         All log-density evaluations during the HMC trajectory warm-start
         L-BFGS from ``state.theta_star``.  After accept/reject, L-BFGS is
         called once more at the accepted position to refresh ``theta_star``
-        for the next step.
+        for the next step.  The L-BFGS diagnostics from that post-accept
+        solve are surfaced in the returned :class:`LaplaceHMCInfo`.
         """
         theta_prev = state.theta_star
 
@@ -159,7 +165,7 @@ def build_kernel(
         hmc_state = hmc.HMCState(
             state.position, state.logdensity, state.logdensity_grad
         )
-        new_hmc_state, info = hmc_kernel(
+        new_hmc_state, hmc_info = hmc_kernel(
             rng_key,
             hmc_state,
             logdensity_fn,
@@ -170,7 +176,10 @@ def build_kernel(
 
         # Refresh theta_star at the accepted position.  Use theta_prev as warm
         # start — cheap when phi moved only slightly (typical HMC behaviour).
-        new_theta_star = laplace.solve_theta(new_hmc_state.position, theta_prev)
+        # solve_theta_with_info surfaces L-BFGS diagnostics for this solve.
+        new_theta_star, lbfgs_diag = laplace.solve_theta_with_info(
+            new_hmc_state.position, theta_prev
+        )
 
         new_state = LaplaceHMCState(
             new_hmc_state.position,
@@ -178,7 +187,20 @@ def build_kernel(
             new_hmc_state.logdensity_grad,
             new_theta_star,
         )
-        return new_state, info
+        new_info = LaplaceHMCInfo(
+            momentum=hmc_info.momentum,
+            acceptance_rate=hmc_info.acceptance_rate,
+            is_accepted=hmc_info.is_accepted,
+            is_divergent=hmc_info.is_divergent,
+            energy=hmc_info.energy,
+            proposal=hmc_info.proposal,
+            num_integration_steps=hmc_info.num_integration_steps,
+            lbfgs_iter_num=lbfgs_diag.iter_num,
+            lbfgs_error=lbfgs_diag.error,
+            lbfgs_converged=lbfgs_diag.converged,
+            lbfgs_hit_maxiter=lbfgs_diag.hit_maxiter,
+        )
+        return new_state, new_info
 
     return kernel
 
@@ -237,7 +259,10 @@ def as_top_level_api(
     -------
     A :class:`~blackjax.base.SamplingAlgorithm` whose ``step`` returns a
     :class:`LaplaceHMCState` (with ``theta_star`` field) and
-    :class:`~blackjax.mcmc.hmc.HMCInfo`.
+    :class:`~blackjax.mcmc.laplace_marginal.LaplaceHMCInfo` (includes all
+    standard :class:`~blackjax.mcmc.hmc.HMCInfo` fields plus L-BFGS
+    diagnostics ``lbfgs_iter_num``, ``lbfgs_error``, ``lbfgs_converged``,
+    ``lbfgs_hit_maxiter``).
 
     Examples
     --------

--- a/blackjax/mcmc/laplace_marginal.py
+++ b/blackjax/mcmc/laplace_marginal.py
@@ -225,27 +225,15 @@ def laplace_marginal_factory(
     _gtol: float = optimizer_kwargs.get("gtol", 1e-8)
 
     # ------------------------------------------------------------------
-    # solve_theta: pure L-BFGS mode-finding, no custom VJP
-    # ------------------------------------------------------------------
-    def solve_theta(
-        phi: ArrayLikeTree, theta_prev: ArrayTree | None = None
-    ) -> ArrayTree:
-        """Find theta*(phi) via L-BFGS.  Warm-starts from theta_prev if given."""
-        initial = theta_prev if theta_prev is not None else theta_init
-
-        def objective(theta):
-            return -log_joint_fn(theta, phi)
-
-        result, _ = minimize_lbfgs(objective, initial, **optimizer_kwargs)
-        return result.params
-
-    # ------------------------------------------------------------------
-    # solve_theta_with_info: same solve, also returns LBFGSDiagnostics
+    # solve_theta_with_info: sole minimize_lbfgs call site
     # ------------------------------------------------------------------
     def solve_theta_with_info(
         phi: ArrayLikeTree, theta_prev: ArrayTree | None = None
     ) -> tuple[ArrayTree, LBFGSDiagnostics]:
         """Find theta*(phi) and return L-BFGS convergence diagnostics.
+
+        This is the single ``minimize_lbfgs`` call site.  All other
+        solve functions delegate here.
 
         Parameters
         ----------
@@ -279,6 +267,20 @@ def laplace_marginal_factory(
             hit_maxiter=result.state.iter_num >= _maxiter,
         )
         return result.params, diagnostics
+
+    # ------------------------------------------------------------------
+    # solve_theta: thin delegating wrapper — backward-compat API
+    # ------------------------------------------------------------------
+    def solve_theta(
+        phi: ArrayLikeTree, theta_prev: ArrayTree | None = None
+    ) -> ArrayTree:
+        """Find theta*(phi) via L-BFGS.  Warm-starts from theta_prev if given.
+
+        Delegates to :func:`solve_theta_with_info` and discards the
+        diagnostics.  Exists as a backward-compatible API for callers
+        (e.g. ``init()``) that only need ``theta_star``.
+        """
+        return solve_theta_with_info(phi, theta_prev)[0]
 
     # ------------------------------------------------------------------
     # get_theta_star: same solve, wrapped in custom_root for IFT gradient

--- a/blackjax/mcmc/laplace_marginal.py
+++ b/blackjax/mcmc/laplace_marginal.py
@@ -37,16 +37,74 @@ Margossian, "General adjoint-differentiated Laplace approximation", 2023.
 arXiv:2306.14976.
 """
 import dataclasses
-from typing import Callable
+from typing import Any, Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
-from blackjax.optimizers.lbfgs import minimize_lbfgs
-from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
+from blackjax.optimizers.lbfgs import LBFGSDiagnostics, minimize_lbfgs
+from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
-__all__ = ["LaplaceMarginal", "laplace_marginal_factory"]
+__all__ = ["LaplaceHMCInfo", "LaplaceMarginal", "laplace_marginal_factory"]
+
+
+class LaplaceHMCInfo(NamedTuple):
+    """Info returned by any ``laplace_*hmc`` kernel step.
+
+    Contains all standard :class:`~blackjax.mcmc.hmc.HMCInfo` fields for
+    backward compatibility, plus L-BFGS convergence diagnostics from the
+    ``theta*`` refresh that occurs after each accept/reject step.
+
+    The L-BFGS diagnostics reflect the **post-accept-reject warm-started solve**
+    — i.e., the single explicit :meth:`~LaplaceMarginal.solve_theta_with_info`
+    call at the end of each kernel step, not the leapfrog-interior solves (those
+    happen inside ``jax.lax.custom_root`` and are not directly accessible).
+
+    momentum
+        Momentum sampled at the start of the trajectory.
+    acceptance_rate
+        Metropolis acceptance probability for this transition.
+    is_accepted
+        Whether the proposed position was accepted.
+    is_divergent
+        Whether the energy difference exceeded the divergence threshold.
+    energy
+        Total energy (kinetic + potential) of the transition.
+    proposal
+        The proposed integrator state (position + momentum at trajectory end).
+    num_integration_steps
+        Number of leapfrog steps taken.
+    lbfgs_iter_num
+        Number of L-BFGS iterations at the post-accept ``theta*`` refresh.
+    lbfgs_error
+        Final gradient norm ``||∇f(theta*)||₂`` at the post-accept refresh.
+        Large values (>> ``gtol``) indicate a non-converged inner solve.
+    lbfgs_converged
+        ``True`` iff ``lbfgs_error <= gtol``.  May be ``False`` for well-behaved
+        warm-started solves that land near (but not below) ``gtol``; prefer
+        ``lbfgs_hit_maxiter`` as the primary non-convergence alarm.
+    lbfgs_hit_maxiter
+        ``True`` iff the L-BFGS solver exhausted its iteration budget
+        (``iter_num >= maxiter``).  **This is the direct signal for the
+        silent-non-convergence bug diagnosed in blackjax issue #925.**
+        When ``True``, ``theta*`` may be a poor MAP estimate and the Laplace
+        log-marginal (and its gradient) is unreliable for this step.
+    """
+
+    # ---- HMCInfo fields (field names and order preserved for compat) ----
+    momentum: ArrayTree
+    acceptance_rate: float
+    is_accepted: bool
+    is_divergent: bool
+    energy: float
+    proposal: Any  # integrators.IntegratorState
+    num_integration_steps: int
+    # ---- L-BFGS diagnostics (new in #925) ----
+    lbfgs_iter_num: Array
+    lbfgs_error: Array
+    lbfgs_converged: Array
+    lbfgs_hit_maxiter: Array
 
 
 @dataclasses.dataclass(frozen=True)
@@ -56,10 +114,14 @@ class LaplaceMarginal:
     Each attribute is a plain callable, testable and reusable independently.
     The dataclass is a named container — there is no mutable state.
 
-    The four callables are:
+    The five callables are:
 
     - ``solve_theta(phi, theta_prev=None) -> theta_star``: finds the mode of
       ``p(theta | phi, y)`` via L-BFGS.  No custom VJP; useful for warm-starting.
+    - ``solve_theta_with_info(phi, theta_prev=None) -> (theta_star, LBFGSDiagnostics)``:
+      same as ``solve_theta`` but also returns per-call L-BFGS diagnostics
+      (``iter_num``, ``error``, ``converged``, ``hit_maxiter``).  Used inside
+      the laplace kernel to populate :class:`LaplaceHMCInfo`.
     - ``get_theta_star(phi, theta_prev=None) -> theta_star``: same as
       ``solve_theta`` but wrapped in ``jax.lax.custom_root`` for IFT gradients.
     - ``log_marginal(phi, theta_prev=None) -> (lp, theta_star)``: evaluates the
@@ -70,6 +132,7 @@ class LaplaceMarginal:
     """
 
     solve_theta: Callable
+    solve_theta_with_info: Callable
     get_theta_star: Callable
     log_marginal: Callable
     sample_theta: Callable
@@ -157,6 +220,10 @@ def laplace_marginal_factory(
     theta_flat_init, unravel_theta = ravel_pytree(theta_init)
     d = theta_flat_init.shape[0]
 
+    # Extract optimizer settings used to compute diagnostics.
+    _maxiter: int = optimizer_kwargs.get("maxiter", 30)
+    _gtol: float = optimizer_kwargs.get("gtol", 1e-8)
+
     # ------------------------------------------------------------------
     # solve_theta: pure L-BFGS mode-finding, no custom VJP
     # ------------------------------------------------------------------
@@ -171,6 +238,47 @@ def laplace_marginal_factory(
 
         result, _ = minimize_lbfgs(objective, initial, **optimizer_kwargs)
         return result.params
+
+    # ------------------------------------------------------------------
+    # solve_theta_with_info: same solve, also returns LBFGSDiagnostics
+    # ------------------------------------------------------------------
+    def solve_theta_with_info(
+        phi: ArrayLikeTree, theta_prev: ArrayTree | None = None
+    ) -> tuple[ArrayTree, LBFGSDiagnostics]:
+        """Find theta*(phi) and return L-BFGS convergence diagnostics.
+
+        Parameters
+        ----------
+        phi
+            Hyperparameter value at which to find the MAP of theta.
+        theta_prev
+            Warm-start hint (previous theta*).  ``None`` → cold start from
+            ``theta_init``.
+
+        Returns
+        -------
+        theta_star
+            MAP estimate of theta at ``phi``.
+        diagnostics
+            :class:`~blackjax.optimizers.lbfgs.LBFGSDiagnostics` with fields
+            ``iter_num``, ``error``, ``converged``, and ``hit_maxiter``.
+            ``hit_maxiter=True`` is the primary non-convergence alarm: it fires
+            when the optimizer exhausted its ``maxiter`` budget, indicating that
+            ``theta_star`` may be a poor MAP estimate.
+        """
+        initial = theta_prev if theta_prev is not None else theta_init
+
+        def objective(theta):
+            return -log_joint_fn(theta, phi)
+
+        result, _ = minimize_lbfgs(objective, initial, **optimizer_kwargs)
+        diagnostics = LBFGSDiagnostics(
+            iter_num=result.state.iter_num,
+            error=result.state.error,
+            converged=result.state.error <= _gtol,
+            hit_maxiter=result.state.iter_num >= _maxiter,
+        )
+        return result.params, diagnostics
 
     # ------------------------------------------------------------------
     # get_theta_star: same solve, wrapped in custom_root for IFT gradient
@@ -272,6 +380,7 @@ def laplace_marginal_factory(
 
     return LaplaceMarginal(
         solve_theta=solve_theta,
+        solve_theta_with_info=solve_theta_with_info,
         get_theta_star=get_theta_star,
         log_marginal=log_marginal,
         sample_theta=sample_theta,

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -24,6 +24,7 @@ from blackjax.types import Array, ArrayLikeTree
 
 __all__ = [
     "LBFGSHistory",
+    "LBFGSDiagnostics",
     "LbfgsState",
     "OptStep",
     "minimize_lbfgs",
@@ -32,6 +33,38 @@ __all__ = [
     "lbfgs_inverse_hessian_formula_2",
     "bfgs_sample",
 ]
+
+
+class LBFGSDiagnostics(NamedTuple):
+    """Per-call convergence diagnostics from a single :func:`minimize_lbfgs` run.
+
+    These fields are surfaced through the kernel ``Info`` NamedTuple of
+    Laplace-marginal samplers (:class:`~blackjax.mcmc.laplace_marginal.LaplaceHMCInfo`)
+    so that callers can detect non-convergence of the inner L-BFGS solve at
+    every MCMC step without resorting to callbacks or host-side introspection.
+
+    iter_num
+        Number of L-BFGS iterations actually taken (scalar int).  Equal to
+        ``maxiter`` when the iteration budget is exhausted — see ``hit_maxiter``.
+    error
+        Final gradient norm ``||∇f(x*)||₂`` (scalar float).  Small values
+        indicate convergence to a stationary point.  A value substantially
+        above ``gtol`` signals a non-converged solve.
+    converged
+        ``True`` iff ``error <= gtol``.  Note: warm-started solves can land at
+        ``error ~ 1e-6`` (fine in practice) and still return ``converged=False``
+        if ``gtol=1e-8``.  Prefer ``hit_maxiter`` as the primary bug-signature.
+    hit_maxiter
+        ``True`` iff ``iter_num >= maxiter``.  **This is the actionable
+        non-convergence signal**: it fires exactly when the optimizer exhausted
+        the budget without stopping early.  This is the direct descendant of the
+        ``maxiter=30`` silent-failure diagnosed in blackjax issue #925.
+    """
+
+    iter_num: Array
+    error: Array
+    converged: Array
+    hit_maxiter: Array
 
 
 class LBFGSHistory(NamedTuple):

--- a/tests/mcmc/test_laplace_dynamic_hmc.py
+++ b/tests/mcmc/test_laplace_dynamic_hmc.py
@@ -19,9 +19,9 @@ import jax.scipy.stats as stats
 from absl.testing import absltest
 
 import blackjax
-from blackjax.mcmc.hmc import HMCInfo, multinomial_hmc_proposal
+from blackjax.mcmc.hmc import multinomial_hmc_proposal
 from blackjax.mcmc.laplace_dynamic_hmc import LaplaceDynamicHMCState
-from blackjax.mcmc.laplace_marginal import laplace_marginal_factory
+from blackjax.mcmc.laplace_marginal import LaplaceHMCInfo, laplace_marginal_factory
 from tests.fixtures import BlackJAXTest
 
 
@@ -102,9 +102,16 @@ class TestLaplaceDHMCKernel(BlackJAXTest):
         new_state, _ = self.sampler.step(self.next_key(), self.state)
         self.assertIsInstance(new_state, LaplaceDynamicHMCState)
 
-    def test_step_returns_hmc_info(self):
+    def test_step_returns_laplace_hmc_info(self):
+        """laplace_dhmc kernel returns LaplaceHMCInfo (superset of HMCInfo)."""
         _, info = self.sampler.step(self.next_key(), self.state)
-        self.assertIsInstance(info, HMCInfo)
+        self.assertIsInstance(info, LaplaceHMCInfo)
+        # Backward-compat: all HMCInfo fields are accessible directly.
+        self.assertTrue(jnp.isfinite(info.acceptance_rate))
+        self.assertIn(bool(info.is_divergent), (True, False))
+        # New L-BFGS diagnostic fields.
+        self.assertIn(bool(info.lbfgs_hit_maxiter), (True, False))
+        self.assertGreaterEqual(float(info.lbfgs_error), 0.0)
 
     def test_step_all_fields_finite(self):
         new_state, _ = self.sampler.step(self.next_key(), self.state)

--- a/tests/mcmc/test_laplace_hmc.py
+++ b/tests/mcmc/test_laplace_hmc.py
@@ -21,7 +21,7 @@ from absl.testing import absltest
 
 import blackjax
 from blackjax.mcmc.laplace_hmc import LaplaceHMCState, as_top_level_api, init
-from blackjax.mcmc.laplace_marginal import laplace_marginal_factory
+from blackjax.mcmc.laplace_marginal import LaplaceHMCInfo, laplace_marginal_factory
 from blackjax.util import run_inference_algorithm
 from tests.fixtures import BlackJAXTest
 
@@ -458,6 +458,152 @@ class TestLaplaceMHMC(BlackJAXTest):
         self.assertEqual(
             float(info_alias.acceptance_rate), float(info_explicit.acceptance_rate)
         )
+
+
+class TestLaplaceHMCDiagnostics(BlackJAXTest):
+    """Tests for LaplaceHMCInfo L-BFGS diagnostics (blackjax issue #925).
+
+    The primary regression check: ``lbfgs_hit_maxiter`` must fire when the
+    optimizer exhausts its budget.  This reproduces the gp_regression
+    silent-non-convergence bug in miniature (maxiter=30 → iter_num=30 →
+    hit_maxiter=True, but the chain silently continued with a poor theta*).
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.n = 4
+        self.y = jax.random.normal(self.next_key(), (self.n,))
+        self.theta_init = jnp.zeros(self.n)
+        self.log_joint, _ = make_gaussian_model(self.y)
+
+    def _make_sampler(self, maxiter, phi_init=0.0, step_size=0.05):
+        sampler = as_top_level_api(
+            self.log_joint,
+            self.theta_init,
+            step_size=step_size,
+            inverse_mass_matrix=jnp.ones(1),
+            num_integration_steps=2,
+            maxiter=maxiter,
+        )
+        state = sampler.init(jnp.array(phi_init))
+        return sampler, state
+
+    # ------------------------------------------------------------------
+    # 1. Field existence and type sanity
+    # ------------------------------------------------------------------
+
+    def test_info_is_laplace_hmc_info(self):
+        """step() must return LaplaceHMCInfo, not plain HMCInfo."""
+        sampler, state = self._make_sampler(maxiter=200)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertIsInstance(info, LaplaceHMCInfo)
+
+    def test_lbfgs_fields_present_and_finite(self):
+        """All four lbfgs_* fields must be present and finite."""
+        sampler, state = self._make_sampler(maxiter=200)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertTrue(jnp.isfinite(info.lbfgs_iter_num))
+        self.assertTrue(jnp.isfinite(info.lbfgs_error))
+        # lbfgs_error is a gradient norm — must be non-negative
+        self.assertGreaterEqual(float(info.lbfgs_error), 0.0)
+        # iter_num > 0 (at least one L-BFGS step was taken)
+        self.assertGreater(int(info.lbfgs_iter_num), 0)
+
+    def test_backward_compat_hmc_fields(self):
+        """Existing HMCInfo field names must remain accessible on LaplaceHMCInfo."""
+        sampler, state = self._make_sampler(maxiter=200)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertTrue(jnp.isfinite(info.acceptance_rate))
+        self.assertIn(bool(info.is_accepted), (True, False))
+        self.assertIn(bool(info.is_divergent), (True, False))
+        self.assertTrue(jnp.isfinite(info.energy))
+
+    # ------------------------------------------------------------------
+    # 2. hit_maxiter — the bug-signature test (reproduces #925 in miniature)
+    # ------------------------------------------------------------------
+
+    def test_hit_maxiter_fires_with_maxiter_1(self):
+        """maxiter=1: solver always exhausts its budget → hit_maxiter=True.
+
+        This is the miniature version of the gp_regression expG diagnosis:
+        with maxiter=30 the L-BFGS ceiling was hit silently.  Here we use
+        maxiter=1 to make it deterministic.
+        """
+        # Use phi_init=3.0 so theta*(phi) is far from theta_init=zeros,
+        # making the warm-start poor and the gradient large after 1 step.
+        sampler, state = self._make_sampler(maxiter=1, phi_init=3.0, step_size=0.01)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertTrue(
+            bool(info.lbfgs_hit_maxiter),
+            "Expected lbfgs_hit_maxiter=True with maxiter=1, "
+            f"got iter_num={int(info.lbfgs_iter_num)}",
+        )
+
+    def test_hit_maxiter_false_with_sufficient_budget(self):
+        """maxiter=200: solver converges well before the budget → hit_maxiter=False.
+
+        The Gaussian-Gaussian model has a smooth, well-conditioned inner
+        objective.  With adequate maxiter, the warm-started solve finishes
+        in a handful of steps.
+        """
+        sampler, state = self._make_sampler(maxiter=200)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertFalse(
+            bool(info.lbfgs_hit_maxiter),
+            "Expected lbfgs_hit_maxiter=False with maxiter=200, "
+            f"got iter_num={int(info.lbfgs_iter_num)}",
+        )
+
+    def test_error_above_gtol_when_hit_maxiter(self):
+        """When hit_maxiter=True, lbfgs_error should be above the default gtol.
+
+        Note: for the simple Gaussian model the inner problem is nearly
+        quadratic and L-BFGS can make a very effective step even in 1
+        iteration, so the error may be small in absolute terms.  The primary
+        bug-detection signal is ``hit_maxiter`` (budget exhausted), not the
+        magnitude of the error.  We assert error > gtol=1e-8 as a sanity
+        check that the field is physically meaningful.
+        """
+        sampler, state = self._make_sampler(maxiter=1, phi_init=5.0, step_size=0.01)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertTrue(
+            bool(info.lbfgs_hit_maxiter),
+            "Precondition: hit_maxiter must be True with maxiter=1",
+        )
+        # Error must be non-negative; for a non-trivially-converged solve it
+        # should sit above the default gtol (1e-8).
+        self.assertGreater(
+            float(info.lbfgs_error),
+            1e-8,
+            "lbfgs_error should be above gtol when hit_maxiter=True, "
+            "got " + str(float(info.lbfgs_error)),
+        )
+
+    def test_error_small_when_converged(self):
+        """With adequate maxiter, lbfgs_error should be near machine precision."""
+        sampler, state = self._make_sampler(maxiter=200)
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        # The well-conditioned Gaussian model should converge to << 1e-3.
+        self.assertLess(float(info.lbfgs_error), 1e-3)
+
+    # ------------------------------------------------------------------
+    # 3. laplace_mhmc also returns LaplaceHMCInfo
+    # ------------------------------------------------------------------
+
+    def test_laplace_mhmc_also_returns_laplace_hmc_info(self):
+        """The multinomial variant (laplace_mhmc) shares the same Info type."""
+        sampler = blackjax.laplace_mhmc(
+            self.log_joint,
+            self.theta_init,
+            step_size=0.05,
+            inverse_mass_matrix=jnp.ones(1),
+            num_integration_steps=2,
+            maxiter=200,
+        )
+        state = sampler.init(jnp.array(0.0))
+        _, info = jax.jit(sampler.step)(self.next_key(), state)
+        self.assertIsInstance(info, LaplaceHMCInfo)
+        self.assertFalse(bool(info.lbfgs_hit_maxiter))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the silent non-convergence problem diagnosed in the gp_regression benchmarking arc (tuningfork PR #61): `laplace_hmc`/`laplace_mhmc`/`laplace_dhmc`/`laplace_dmhmc` kernels silently discarded the L-BFGS optimizer state after each `theta*` refresh. When `maxiter=30` (the default) was too small for the inner problem, the chain ran normally but on poor MAP estimates — no observable signal.

This PR surfaces the optimizer output through the kernel `Info` NamedTuple, additive-only, no breaking changes to existing signatures.

## Changes

**`blackjax/optimizers/lbfgs.py`**
- Add `LBFGSDiagnostics(NamedTuple)`: `iter_num`, `error`, `converged`, `hit_maxiter`
- `hit_maxiter = iter_num >= maxiter` is the primary non-convergence alarm

**`blackjax/mcmc/laplace_marginal.py`**
- Add `LaplaceHMCInfo(NamedTuple)`: all 7 `HMCInfo` fields (unchanged positions) + `lbfgs_iter_num`, `lbfgs_error`, `lbfgs_converged`, `lbfgs_hit_maxiter`
- Add `solve_theta_with_info` method to `LaplaceMarginal` dataclass + factory: same as `solve_theta` but returns `(theta_star, LBFGSDiagnostics)`
- `solve_theta` signature is **unchanged**

**`blackjax/mcmc/laplace_hmc.py`** and **`blackjax/mcmc/laplace_dynamic_hmc.py`**
- Kernels now call `solve_theta_with_info` instead of `solve_theta` for the post-accept `theta*` refresh
- Return `LaplaceHMCInfo` instead of `HMCInfo` — all existing field access (`info.acceptance_rate`, `info.is_divergent`, etc.) still works

**`tests/mcmc/test_laplace_hmc.py`**
- Add `TestLaplaceHMCDiagnostics` (8 tests) including the catches-the-bug test: `maxiter=1` → `hit_maxiter=True` (deterministic); `maxiter=200` → `hit_maxiter=False`

**`tests/mcmc/test_laplace_dynamic_hmc.py`**
- Update `test_step_returns_hmc_info` → `test_step_returns_laplace_hmc_info` to expect `LaplaceHMCInfo`

## The bug signature

```python
# Before: silent failure
result, _ = minimize_lbfgs(objective, initial, maxiter=30)  # hits cap silently
return result.params  # poor MAP estimate, no warning

# After: user can detect it
_, info = jax.jit(sampler.step)(rng_key, state)
if info.lbfgs_hit_maxiter:
    # Budget exhausted — theta* may be unreliable
    # Solution: increase maxiter kwarg (e.g. maxiter=100 or maxiter=500)
```

## Design notes

- Diagnostics reflect the **post-accept-reject `theta*` refresh** only (one per step). The leapfrog-interior solves are inside `jax.lax.custom_root` and would require significant rearchitecting to expose — documented as a known limitation.
- `converged = error <= gtol` is included but `hit_maxiter` is the primary signal: a warm-started solve can have `converged=False` at `error~1e-6` (fine in practice) while `hit_maxiter=False` correctly signals "budget not exhausted."
- `LaplaceHMCInfo` defined in `laplace_marginal.py` (shared by both `laplace_hmc.py` and `laplace_dynamic_hmc.py` to avoid circular imports).
- Pathfinder intentionally uses the full L-BFGS history (`PathfinderInfo.path`) — out of scope for this PR.

## Test results

- `pre-commit run --all-files`: all hooks pass
- `pytest tests/mcmc/test_laplace_hmc.py tests/mcmc/test_laplace_dynamic_hmc.py tests/mcmc/test_laplace_marginal.py`: 59 passed / 0 failed

Closes #925.

Reference: tuningfork arc [gp_regression × laplace_mhmc](https://github.com/blackjax-devs/tuningfork/pull/61) — expG diagnosed `iter_num=30` (ceiling hit) with gradient norms ~190 as the root cause; expH confirmed `maxiter=300` fixed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)