### PR TITLE
feat(laplace): laplace_lbfgs_grad_evals() utility for benchmark grad-count denominators

### DIFF
--- a/blackjax/mcmc/laplace_marginal.py
+++ b/blackjax/mcmc/laplace_marginal.py
@@ -168,8 +168,6 @@ def laplace_lbfgs_grad_evals(info: "LaplaceHMCInfo") -> "Array":
     can be extracted from ``chain_stats["lbfgs_iter_num"]`` when the harness
     captures that field.
     """
-    import jax.numpy as jnp
-
     return jnp.asarray(
         (info.num_integration_steps + 1) * info.lbfgs_iter_num, dtype=jnp.int32
     )

--- a/blackjax/mcmc/laplace_marginal.py
+++ b/blackjax/mcmc/laplace_marginal.py
@@ -46,7 +46,12 @@ from jax.flatten_util import ravel_pytree
 from blackjax.optimizers.lbfgs import LBFGSDiagnostics, minimize_lbfgs
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
-__all__ = ["LaplaceHMCInfo", "LaplaceMarginal", "laplace_marginal_factory"]
+__all__ = [
+    "LaplaceHMCInfo",
+    "LaplaceMarginal",
+    "laplace_marginal_factory",
+    "laplace_lbfgs_grad_evals",
+]
 
 
 class LaplaceHMCInfo(NamedTuple):
@@ -77,6 +82,26 @@ class LaplaceHMCInfo(NamedTuple):
         Number of leapfrog steps taken.
     lbfgs_iter_num
         Number of L-BFGS iterations at the post-accept ``theta*`` refresh.
+
+        .. note:: **Using this field for gradient-evaluation accounting**
+
+            The leapfrog-interior L-BFGS solves happen inside
+            :func:`jax.lax.custom_root` and are not directly observable.
+            ``lbfgs_iter_num`` (the post-accept refresh) is the **best
+            available proxy** for the per-leapfrog inner iteration count,
+            because warm-started solves from nearby ``phi`` values converge
+            in a similar number of iterations.
+
+            To estimate total inner gradient evaluations per kernel step
+            (for a grad-count denominator), use :func:`laplace_lbfgs_grad_evals`:
+
+            .. code:: python
+
+                total_inner_grads = laplace_lbfgs_grad_evals(info)
+                # ≈ (num_integration_steps + 1) × lbfgs_iter_num
+
+            The ``+1`` accounts for the post-accept refresh itself.
+
     lbfgs_error
         Final gradient norm ``||∇f(theta*)||₂`` at the post-accept refresh.
         Large values (>> ``gtol``) indicate a non-converged inner solve.
@@ -105,6 +130,49 @@ class LaplaceHMCInfo(NamedTuple):
     lbfgs_error: Array
     lbfgs_converged: Array
     lbfgs_hit_maxiter: Array
+
+
+def laplace_lbfgs_grad_evals(info: "LaplaceHMCInfo") -> "Array":
+    """Estimated total inner L-BFGS gradient evaluations for one kernel step.
+
+    The Laplace-HMC family requires an inner L-BFGS solve at each leapfrog step
+    to find ``theta*(phi)`` and at the post-accept ``theta*`` refresh.
+    The leapfrog-interior solves run inside :func:`jax.lax.custom_root` and
+    are not directly observable; ``info.lbfgs_iter_num`` (the post-accept
+    refresh) is used as a proxy because warm-started solves from nearby ``phi``
+    values converge in a similar number of iterations.
+
+    The formula is::
+
+        total_inner_grads ≈ (num_integration_steps + 1) × lbfgs_iter_num
+
+    where the ``+1`` accounts for the post-accept refresh itself.
+
+    Parameters
+    ----------
+    info
+        :class:`LaplaceHMCInfo` returned by any ``laplace_*hmc`` kernel step.
+
+    Returns
+    -------
+    Array
+        Scalar JAX array with the estimated inner gradient evaluation count
+        for this step.
+
+    Notes
+    -----
+    Use this as the ``grad_count_per_step`` callable in benchmark harnesses
+    to replace the heuristic ``num_integration_steps × 5``.  The measured
+    ``lbfgs_iter_num`` will differ per recipe depending on ``maxiter``,
+    ``gtol``, model curvature, and step size.  Mean values across a chain
+    can be extracted from ``chain_stats["lbfgs_iter_num"]`` when the harness
+    captures that field.
+    """
+    import jax.numpy as jnp
+
+    return jnp.asarray(
+        (info.num_integration_steps + 1) * info.lbfgs_iter_num, dtype=jnp.int32
+    )
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
## Summary

`LaplaceHMCInfo` already carries `lbfgs_iter_num` (from #925/#926) but there was no utility to convert it to a total inner-grad count per step, and no documentation connecting the field to benchmark gradient accounting. The tuningfork benchmark harness hardcoded `× 5` because this connection was missing.

**What changed:**
- Added `laplace_lbfgs_grad_evals(info: LaplaceHMCInfo) -> Array` to `blackjax/mcmc/laplace_marginal.py`
- Formula: `(num_integration_steps + 1) × lbfgs_iter_num`
  - `num_integration_steps` leapfrog steps × `lbfgs_iter_num` inner iters each (proxy: post-accept count, since leapfrog-interior solves via `custom_root` are not directly observable)  
  - `+1` for the post-accept refresh itself
- Updated `LaplaceHMCInfo.lbfgs_iter_num` docstring with a note explaining the grad-counting usage and the `custom_root` observability constraint
- Exported in `__all__`

**Usage in benchmark harnesses:**
```python
from blackjax.mcmc.laplace_marginal import laplace_lbfgs_grad_evals
# Replace hardcoded ×5 with the measured proxy:
grad_count_per_step = laplace_lbfgs_grad_evals
```

**Why `(num_integration_steps + 1) × lbfgs_iter_num`?**
The leapfrog-interior L-BFGS solves happen inside `jax.lax.custom_root` and are not directly observable. The post-accept refresh count (`lbfgs_iter_num`) is the best available proxy because warm-started solves from nearby `phi` values converge in similar iteration counts. Benchmark harnesses that capture `lbfgs_iter_num` in chain_stats can compute `mean(lbfgs_iter_num)` to verify whether ×5 is accurate for a given model/recipe.

## Test plan

- [x] `pre-commit run --all-files` — clean
- [x] `pytest tests/mcmc/test_laplace_marginal.py tests/mcmc/test_laplace_hmc.py -p no:xdist` — 39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)