### PR TITLE
fix(eca): replace keys_sampling.T with jnp.swapaxes to fix old-style PRNGKey shape corruption

### DIFF
--- a/blackjax/eca.py
+++ b/blackjax/eca.py
@@ -203,9 +203,14 @@ def run_eca(
         # run sampling
         xs = (
             jnp.arange(num_steps),
-            keys_sampling.T,
+            jnp.swapaxes(keys_sampling, 0, 1),
             keys_adaptation,
         )  # keys for all steps that will be performed. keys_sampling.shape = (num_steps, chains_per_device), keys_adaptation.shape = (num_steps, )
+        # Note: jnp.swapaxes(keys_sampling, 0, 1) is used instead of keys_sampling.T
+        # because .T reverses ALL axes, which corrupts old-style PRNGKey arrays that
+        # have a trailing uint32[2] dimension: .T on shape (chains, steps, 2) gives
+        # (2, steps, chains) instead of (steps, chains, 2). jnp.swapaxes only swaps
+        # the first two axes, leaving any trailing key-representation dims intact.
 
         if early_stop:
             final_state_all, info_history, counter = while_with_info(

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -778,6 +778,58 @@ class LinearRegressionTest(chex.TestCase):
         np.testing.assert_allclose(np.mean(scale_samples), 1.0, atol=1e-1)
         np.testing.assert_allclose(np.mean(coefs_samples), 3.0, atol=1e-1)
 
+    @parameterized.named_parameters(
+        {"testcase_name": "typed_key", "use_typed_key": True},
+        {"testcase_name": "legacy_prngkey", "use_typed_key": False},
+    )
+    def test_laps_key_style(self, use_typed_key):
+        """Regression test: LAPS/ECA must work with both typed and legacy PRNGKey styles.
+
+        ``eca.py`` previously used ``keys_sampling.T`` which reverses ALL axes.
+        For old-style PRNGKey arrays, the shape is (num_chains, num_steps, 2)
+        and ``.T`` produced (2, num_steps, num_chains) — corrupting the key data.
+        The fix uses ``jnp.swapaxes(keys_sampling, 0, 1)`` which only swaps the
+        first two axes, leaving any trailing key-representation dims intact.
+        """
+        init_key0, init_key1, inference_key = jax.random.split(self.key, 3)
+        x_data = jax.random.normal(init_key0, shape=(200, 1))
+        y_data = 3 * x_data + jax.random.normal(init_key1, shape=x_data.shape)
+
+        logposterior_fn_ = functools.partial(
+            self.regression_logprob, x=x_data, preds=y_data
+        )
+        logposterior_fn = lambda x: logposterior_fn_(log_scale=x[0], coefs=x[1])
+
+        # Convert inference_key to the requested style
+        if not use_typed_key:
+            # Force legacy uint32[2] representation
+            inference_key = jax.random.PRNGKey(int(jax.random.bits(inference_key)))
+
+        # A short run (few steps) is sufficient to exercise the transpose path;
+        # we only check that the call completes and returns plausible shapes.
+        info, grads_per_step, _acc_prob, final_state = run_laps(
+            logdensity_fn=logposterior_fn,
+            sample_init=lambda key: jax.random.normal(key, shape=(2,)),
+            ndims=2,
+            num_steps1=50,
+            num_steps2=50,
+            num_chains=10,
+            mesh=jax.sharding.Mesh(jax.devices()[:1], "chains"),
+            rng_key=inference_key,
+            early_stop=False,
+            diagonal_preconditioning=True,
+            integrator_coefficients=None,
+            steps_per_sample=5,
+            r_end=0.5,
+            diagnostics=False,
+            superchain_size=1,
+        )
+        # Verify shapes are sane — the key-corruption bug produced wrong shapes.
+        assert final_state.position.shape == (10, 2), (
+            f"Unexpected shape {final_state.position.shape} with "
+            f"{'typed' if use_typed_key else 'legacy'} key"
+        )
+
     def test_barker(self):
         """Test the Barker kernel."""
         init_key0, init_key1, inference_key = jax.random.split(self.key, 3)


### PR DESCRIPTION
## Problem

`eca.py:206` uses `keys_sampling.T` to transpose the keys from shape `(chains_per_device, num_steps)` to `(num_steps, chains_per_device)` before passing them to `lax.scan`.

This works for **new-style typed keys** (shape is `(chains_per_device, num_steps)`; `.T` gives `(num_steps, chains_per_device)` ✓).

It **silently corrupts** **old-style `PRNGKey` arrays**: the internal uint32 representation adds a trailing dim, so the shape is `(chains_per_device, num_steps, 2)`. Calling `.T` reverses **all** axes → `(2, num_steps, chains_per_device)` instead of `(num_steps, chains_per_device, 2)`. The key data is corrupted: all chains receive keys drawn from a wrong distribution.

## Fix

Replace `keys_sampling.T` with `jnp.swapaxes(keys_sampling, 0, 1)` at `eca.py:206`.

`jnp.swapaxes(arr, 0, 1)` swaps axes 0 and 1 only, leaving any trailing dimensions intact. It is semantically identical to `.T` for 2-D typed key arrays and correct for 3-D legacy `PRNGKey` arrays.

## Test

Added `test_laps_key_style` (parametrized over `use_typed_key=True/False`) in `tests/mcmc/test_sampling.py`. Exercises the transpose path via a short LAPS run and asserts `final_state.position.shape == (num_chains, ndims)` — the corruption would produce a shape mismatch or downstream error. Both variants pass (3 tests total with the existing `test_laps`).

## Related

This is Issue 1 of a two-issue cluster found during `tuningfork` benchmarking. Issue 2 (sharded-closure capture in `ensemble_execute_fn`) is being investigated separately.