### PR TITLE
test(smc): trim redundant non-divisor batch test to a map_fn/map_kernel unit test

### DIFF
--- a/tests/smc/test_persistent_sampling.py
+++ b/tests/smc/test_persistent_sampling.py
@@ -1102,65 +1102,6 @@ class BatchedPersistentSamplingTest(SMCLinearRegressionTestCase):
         )
 
     @chex.variants(with_jit=True)
-    def test_fixed_schedule_persistent_sampling_non_divisor_batch_size(self) -> None:
-        """batch_size that does not divide num_particles must match batch_size=0.
-
-        Verifies that jax.lax.map handles non-divisor batch sizes correctly
-        (e.g. batch_size=7 over 20 particles).
-        """
-        num_particles = 20
-        num_dim = 2
-        num_tempering_steps = 3
-
-        _, init_key = jax.random.split(self.key)
-        init_particles = jax.random.normal(init_key, shape=(num_particles, num_dim))
-        lambda_schedule = np.array([0.1, 0.5, 1.0])
-
-        def logprior_fn(x: jax.Array) -> jax.Array:
-            return jnp.sum(stats.norm.logpdf(x))
-
-        def loglikelihood_fn(x: jax.Array) -> jax.Array:
-            return jnp.sum(stats.norm.logpdf(x, loc=1.0))
-
-        hmc_init = blackjax.hmc.init
-        hmc_kernel = blackjax.hmc.build_kernel()
-        hmc_parameters = extend_params(
-            {
-                "step_size": 10e-2,
-                "inverse_mass_matrix": jnp.eye(num_dim),
-                "num_integration_steps": 10,
-            }
-        )
-
-        def run(batch_size):
-            ps = persistent_sampling_smc(
-                logprior_fn=logprior_fn,
-                loglikelihood_fn=loglikelihood_fn,
-                n_schedule=num_tempering_steps,
-                mcmc_step_fn=hmc_kernel,
-                mcmc_init_fn=hmc_init,
-                mcmc_parameters=hmc_parameters,
-                resampling_fn=resampling.systematic,
-                num_mcmc_steps=5,
-                batch_size=batch_size,
-            )
-            _, sample_key = jax.random.split(self.key)
-            return self.variant(partial(inference_loop_fixed, kernel=ps.step))(
-                rng_key=sample_key,
-                initial_state=jax.jit(ps.init)(init_particles),
-                tempering_schedule=lambda_schedule,
-            )
-
-        result_full = run(batch_size=0)
-        result_non_divisor = run(batch_size=7)
-
-        jax.tree.map(
-            lambda a, b: np.testing.assert_allclose(a, b, rtol=1e-5),
-            result_full.particles,
-            result_non_divisor.particles,
-        )
-
-    @chex.variants(with_jit=True)
     def test_adaptive_persistent_sampling_batched(self) -> None:
         """adaptive_persistent_sampling_smc with batch_size > 0 should converge."""
         (

--- a/tests/smc/test_smc.py
+++ b/tests/smc/test_smc.py
@@ -10,7 +10,7 @@ from absl.testing import absltest
 
 import blackjax
 import blackjax.smc.resampling as resampling
-from blackjax.smc.base import extend_params, init, step
+from blackjax.smc.base import extend_params, init, map_fn, map_kernel, step
 from blackjax.smc.tempered import update_and_take_last
 from blackjax.smc.waste_free import update_waste_free
 from tests.fixtures import BlackJAXTest
@@ -192,6 +192,36 @@ class BatchedSMCTest(BlackJAXTest):
         pos_batched, _ = self.variant(waste_free_fn_batched)(keys, resampled, {})
 
         np.testing.assert_allclose(pos_full, pos_batched, rtol=1e-5)
+
+    @chex.variants(with_jit=True)
+    def test_map_fn_non_divisor_batch_size(self):
+        """base.map_fn with a batch_size that doesn't divide N matches vmap."""
+        xs = jax.random.normal(self.next_key(), shape=(20, 3))
+
+        def fn(x):
+            return jnp.sum(x**2)
+
+        out_full = self.variant(map_fn(fn, batch_size=0))(xs)
+        out_batched = self.variant(map_fn(fn, batch_size=7))(xs)
+        np.testing.assert_allclose(out_full, out_batched, rtol=1e-6)
+
+    @chex.variants(with_jit=True)
+    def test_map_kernel_non_divisor_batch_size(self):
+        """base.map_kernel with a batch_size that doesn't divide N matches vmap."""
+        n = 20
+        a = jax.random.normal(self.next_key(), shape=(n, 3))
+        b = jax.random.normal(self.next_key(), shape=(n,))
+
+        def kernel(x, y):
+            return jnp.sum(x) + y, y * 2.0
+
+        out_full = self.variant(lambda a, b: map_kernel(kernel, 0)(a, b))(a, b)
+        out_batched = self.variant(lambda a, b: map_kernel(kernel, 7)(a, b))(a, b)
+        jax.tree.map(
+            lambda u, v: np.testing.assert_allclose(u, v, rtol=1e-6),
+            out_full,
+            out_batched,
+        )
 
 
 class ExtendParamsTest(BlackJAXTest):


### PR DESCRIPTION
## Summary

- Follow-up to #929: After the batching dispatch was centralized into `base.map_fn` / `base.map_kernel`, non-divisor batch_size handling is now a property of those helpers, not of persistent sampling.
- Replaced the full-inference-loop `test_fixed_schedule_persistent_sampling_non_divisor_batch_size` (57 lines) with two direct, cheap unit tests on `map_fn` / `map_kernel` (N=20, batch_size=7 vs vmap).
- Kept the existing end-to-end `test_fixed_schedule_persistent_sampling_batch_equivalence` for integration coverage.

## Test plan

- [x] `JAX_PLATFORM_NAME=cpu pytest tests/smc/test_smc.py` — all 7 tests pass (including 2 new unit tests)
- [x] `JAX_PLATFORM_NAME=cpu pytest tests/smc/test_persistent_sampling.py` — all 35 tests pass (removed method verified)
- [x] Pre-commit: all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)