### PR TITLE
feat(adaptation): mclmc_lrd_adaptation — Scheme A pilot-free LRD warmup

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -8,6 +8,7 @@ from .adaptation.adjusted_mclmc_adaptation import adjusted_mclmc_find_L_and_step
 from .adaptation.chees_adaptation import chees_adaptation
 from .adaptation.low_rank_adaptation import window_adaptation_low_rank
 from .adaptation.mclmc_adaptation import mclmc_find_L_and_step_size
+from .adaptation.mclmc_lrd_adaptation import mclmc_lrd_adaptation
 from .adaptation.meads_adaptation import meads_adaptation
 from .adaptation.pathfinder_adaptation import pathfinder_adaptation
 from .adaptation.window_adaptation import window_adaptation
@@ -262,6 +263,7 @@ __all__ = [
     "chees_adaptation",
     "pathfinder_adaptation",
     "mclmc_find_L_and_step_size",  # mclmc adaptation
+    "mclmc_lrd_adaptation",  # mclmc LRD adaptation (Scheme A, pilot-free)
     "adjusted_mclmc_find_L_and_step_size",  # adjusted mclmc adaptation
     "adaptive_tempered_smc",  # smc
     "tempered_smc",

--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -8,7 +8,7 @@ from .adaptation.adjusted_mclmc_adaptation import adjusted_mclmc_find_L_and_step
 from .adaptation.chees_adaptation import chees_adaptation
 from .adaptation.low_rank_adaptation import window_adaptation_low_rank
 from .adaptation.mclmc_adaptation import mclmc_find_L_and_step_size
-from .adaptation.mclmc_lrd_adaptation import mclmc_lrd_adaptation
+from .adaptation.mclmc_lrd_adaptation import mclmc_lrd_warmup
 from .adaptation.meads_adaptation import meads_adaptation
 from .adaptation.pathfinder_adaptation import pathfinder_adaptation
 from .adaptation.window_adaptation import window_adaptation
@@ -263,7 +263,7 @@ __all__ = [
     "chees_adaptation",
     "pathfinder_adaptation",
     "mclmc_find_L_and_step_size",  # mclmc adaptation
-    "mclmc_lrd_adaptation",  # mclmc LRD adaptation (Scheme A, pilot-free)
+    "mclmc_lrd_warmup",  # mclmc LRD warmup (Scheme A, pilot-free)
     "adjusted_mclmc_find_L_and_step_size",  # adjusted mclmc adaptation
     "adaptive_tempered_smc",  # smc
     "tempered_smc",

--- a/blackjax/adaptation/__init__.py
+++ b/blackjax/adaptation/__init__.py
@@ -12,7 +12,7 @@ __all__ = [
     "chees_adaptation",
     "low_rank_adaptation",
     "mclmc_adaptation",
-    "mclmc_lrd_adaptation",
+    "mclmc_lrd_adaptation",  # module; public function is mclmc_lrd_warmup
     "meads_adaptation",
     "window_adaptation",
     "pathfinder_adaptation",

--- a/blackjax/adaptation/__init__.py
+++ b/blackjax/adaptation/__init__.py
@@ -2,6 +2,7 @@ from . import (
     chees_adaptation,
     low_rank_adaptation,
     mclmc_adaptation,
+    mclmc_lrd_adaptation,
     meads_adaptation,
     pathfinder_adaptation,
     window_adaptation,
@@ -10,8 +11,9 @@ from . import (
 __all__ = [
     "chees_adaptation",
     "low_rank_adaptation",
+    "mclmc_adaptation",
+    "mclmc_lrd_adaptation",
     "meads_adaptation",
     "window_adaptation",
     "pathfinder_adaptation",
-    "mclmc_adaptation",
 ]

--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -11,13 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Pilot-free (Scheme A) MCLMC adaptation with Low-Rank Diagonal preconditioning.
+"""Pilot-free (Scheme A) MCLMC warmup with Low-Rank Diagonal preconditioning.
 
 Overview
 --------
-This module implements the **Scheme A** warmup for MCLMC.  Phases 1–3 are
-shared between the unadjusted and adjusted inner kernels; only Phase 4
-switches:
+This module implements the **Scheme A** warmup for MCLMC via
+:func:`mclmc_lrd_warmup`.  Phases 1–3 are shared between the unadjusted and
+adjusted inner kernels; only Phase 4 switches:
 
 1. **Pilot phase** — a single unadjusted MCLMC chain with diagonal
    preconditioning (via
@@ -41,31 +41,36 @@ switches:
    would exceed it.  Without this guard, under-mixed pilots produce
    rank-deficient SVDs and the LRD metric degrades sampling quality.
 
-3. **Unadjusted LRD tuning** —
+3. **Multi-chain unadjusted LRD tuning** —
    :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
-   is re-run with the LRD metric kernel
-   (``diagonal_preconditioning=False``), so step size and trajectory length
-   *L* are calibrated to the true posterior geometry.
+   is run in parallel over ``num_chains`` independent chains (all starting
+   from the pilot's final position, with per-chain PRNG keys) with the LRD
+   metric kernel (``diagonal_preconditioning=False``).  The per-chain
+   ``(L, step_size)`` values are averaged to give stable estimates of the
+   trajectory length and step size in LRD geometry.
 
 4. **Inner-kernel dispatch** (controlled by ``inner_kernel``):
 
-   * ``"mclmc"`` *(default)*: returns Phase-3 ``(L, step_size)`` directly.
+   * ``"mclmc"`` *(default)*: returns the Phase-3 mean
+     ``(L, step_size)`` directly.
 
    * ``"adjusted_mclmc"`` *(experimental)*: warm-starts
      :func:`~blackjax.adaptation.adjusted_mclmc_adaptation.adjusted_mclmc_find_L_and_step_size`
-     from the unadjusted LRD-tuned parameters.  **Two hard constraints are
-     enforced automatically** to avoid known failure modes:
+     across ``num_chains`` parallel chains from the Phase-3 mean parameters.
+     **Two hard constraints are enforced automatically** to avoid known
+     failure modes:
 
-     - ``params`` is set to ``MCLMCAdaptationState(L=L_init, step_size=...,
-       inverse_mass_matrix=lrd_imm)`` so that the sqrt(dim) default L
-       initialisation (which ignores the baked-in LRD metric) is never
-       used.
+     - ``params`` is set to
+       ``MCLMCAdaptationState(L=L_init, step_size=..., inverse_mass_matrix=lrd_imm)``
+       so that the ``sqrt(dim)`` default L initialisation (which ignores the
+       baked-in LRD metric) is never used.
      - ``frac_tune2=0.0`` disables the variance-based *L* estimator, which
        computes original-space ``trace(Σ)`` and is incompatible with an
        externally-baked LRD IMM.
 
      ``L_init`` is floored at ``floor_factor * step_unadj`` (default
-     ``floor_factor=1.15``) to prevent degenerate one-step trajectories.
+     ``floor_factor=1.15``) to prevent the Dual-Averaging ceiling
+     ``(L / 1.1)`` from binding below the oracle step size.
 
 Stan-window analogy
 -------------------
@@ -94,8 +99,8 @@ Limitations
   recommended escape hatch but is out of scope here.
 * **Adjusted path experimental.** The ``inner_kernel="adjusted_mclmc"``
   branch is certified on german_credit but has not yet been validated across
-  a broad benchmark suite.  ill_cond_50 evidence is ongoing.  Treat as
-  experimental; the unadjusted default is the stable path.
+  a broad benchmark suite.  Treat as experimental; the unadjusted default is
+  the stable path.
 """
 
 import warnings
@@ -119,14 +124,14 @@ from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 
 __all__ = [
     "MCLMCLRDAdaptationState",
-    "mclmc_lrd_adaptation",
+    "mclmc_lrd_warmup",
 ]
 
 _VALID_INNER_KERNELS = frozenset({"mclmc", "adjusted_mclmc"})
 
 
 class MCLMCLRDAdaptationState(NamedTuple):
-    """Result of :func:`mclmc_lrd_adaptation`.
+    """Result of :func:`mclmc_lrd_warmup`.
 
     L
         Adapted momentum decoherence length from the final tuning phase.
@@ -153,6 +158,16 @@ class MCLMCLRDAdaptationState(NamedTuple):
         ``pilot_num_grad_evals``
             Total gradient evaluations consumed by the pilot phase
             (warmup + samples; unadjusted MCLMC costs 2 grads/step).
+        ``pilot_L``
+            Trajectory length L adapted during the diagonal pilot warmup.
+        ``pilot_step_size``
+            Step size adapted during the diagonal pilot warmup.
+        ``lrd_L``
+            Mean trajectory length L across ``num_chains`` chains after
+            Phase-3 unadjusted LRD tuning.
+        ``lrd_step_size``
+            Mean step size across ``num_chains`` chains after Phase-3
+            unadjusted LRD tuning.
     """
 
     L: float
@@ -202,7 +217,46 @@ def _extract_lrd_from_samples(
     return sigma, U_k, lam_k
 
 
-def mclmc_lrd_adaptation(
+def _check_da_ceiling_warning(
+    final_step_size: float,
+    L_init: float,
+    floor_factor: float,
+) -> None:
+    """Emit a UserWarning when the adapted step_size is at or near L_init/1.1.
+
+    This is the Dual-Averaging (DA) ceiling signature: when
+    ``step_size >= L_init / 1.1 * 0.999``, the step-size tuner may have been
+    constrained by the ceiling rather than converged to the optimal value.
+
+    Parameters
+    ----------
+    final_step_size
+        Mean adapted step size across chains from the adjusted Phase-4 tuning.
+    L_init
+        The floor-guarded L_init value used for the adjusted warm-start.
+    floor_factor
+        Current ``floor_factor`` value; included in the warning message.
+    """
+    da_clamp = L_init / 1.1
+    step_ratio = final_step_size / da_clamp
+    if step_ratio >= 0.999:
+        step_s = round(final_step_size, 4)
+        clamp_s = round(da_clamp, 4)
+        ratio_s = round(step_ratio, 3)
+        warnings.warn(
+            f"mclmc_lrd_warmup (adjusted_mclmc path): adapted step_size "
+            f"({step_s}) is at or near the DA ceiling "
+            f"L_init/1.1={clamp_s} (ratio={ratio_s}). "
+            "The step-size tuner may have been constrained rather than "
+            "converged. Consider raising `floor_factor` "
+            f"(current value: {floor_factor}) — e.g. to 1.5 for "
+            "high-condition-number targets.",
+            UserWarning,
+            stacklevel=3,  # points to caller of mclmc_lrd_warmup
+        )
+
+
+def mclmc_lrd_warmup(
     logdensity_fn,
     position,
     rng_key,
@@ -211,17 +265,18 @@ def mclmc_lrd_adaptation(
     pilot_num_warmup: int = 1000,
     pilot_num_samples: int = 5000,
     lrd_num_steps: int = 1000,
+    num_chains: int = 4,
     inner_kernel: str = "mclmc",
     floor_factor: float = 1.15,
     adjusted_target: float = 0.9,
 ):
-    """Scheme A (pilot-free) MCLMC adaptation with Low-Rank Diagonal preconditioning.
+    """Scheme A (pilot-free) MCLMC warmup with Low-Rank Diagonal preconditioning.
 
     Runs a cheap diagonal unadjusted MCLMC pilot to reach the typical set and
     collect geometry samples, extracts a low-rank diagonal (LRD) inverse mass
-    matrix via thin SVD, then tunes step size and trajectory length L against
-    the LRD metric kernel.  The inner kernel for the final tuning phase is
-    controlled by ``inner_kernel``.
+    matrix via thin SVD, then calibrates step size and trajectory length L
+    across ``num_chains`` parallel chains with the LRD metric kernel.  The
+    inner kernel for the final tuning phase is controlled by ``inner_kernel``.
 
     Parameters
     ----------
@@ -245,23 +300,30 @@ def mclmc_lrd_adaptation(
     lrd_num_steps
         Number of steps passed to the LRD tuning call(s) in Phase 3 (and
         Phase 4 for the adjusted path).
+    num_chains
+        Number of parallel chains for Phase 3 (unadjusted LRD tuning) and
+        Phase 4 (adjusted tuning when ``inner_kernel="adjusted_mclmc"``).
+        All chains start from the pilot's final position; per-chain PRNG keys
+        give independent trajectories.  Per-chain L and step_size are averaged
+        for a stable multi-chain estimate.  Default ``4``.
     inner_kernel
         Which inner kernel to use for the final tuning phase.  One of:
 
-        * ``"mclmc"`` *(default, stable)*: unadjusted MCLMC.  Phase 3
-          output ``(L, step_size)`` is returned directly.
-        * ``"adjusted_mclmc"`` *(experimental)*: after Phase 3 unadjusted
-          LRD tuning, warms-start
+        * ``"mclmc"`` *(default, stable)*: unadjusted MCLMC.  Phase-3
+          mean ``(L, step_size)`` is returned directly.
+        * ``"adjusted_mclmc"`` *(experimental)*: after Phase-3 unadjusted
+          LRD tuning, warm-starts
           :func:`~blackjax.adaptation.adjusted_mclmc_adaptation.adjusted_mclmc_find_L_and_step_size`
-          with ``frac_tune2=0.0`` (variance-based *L* estimator disabled)
-          and ``diagonal_preconditioning=False``.
+          across ``num_chains`` chains with ``frac_tune2=0.0``
+          (variance-based *L* estimator disabled) and
+          ``diagonal_preconditioning=False``.
 
     floor_factor
         For ``inner_kernel="adjusted_mclmc"`` only: the L initialisation
         floor is ``max(L_unadj, floor_factor * step_unadj)``.  Default
-        ``1.15``; increase (e.g. to ``1.5``) for high-condition-number
-        targets where the unadjusted trajectory length may be too short for
-        the adjusted integrator.  Ignored when ``inner_kernel="mclmc"``.
+        ``1.15``; the guard ensures the Dual-Averaging ceiling ``L / 1.1``
+        cannot bind below the oracle step size.  Ignored when
+        ``inner_kernel="mclmc"``.
     adjusted_target
         Target acceptance rate for the adjusted MCLMC tuning phase.
         Default ``0.9``.  Ignored when ``inner_kernel="mclmc"``.
@@ -272,8 +334,7 @@ def mclmc_lrd_adaptation(
         A :class:`MCLMCLRDAdaptationState` NamedTuple with fields ``L``,
         ``step_size``, ``inverse_mass_matrix`` (a
         :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`), and
-        ``diagnostics`` (``inner_kernel``, ``n_eff``, ``k_safe``,
-        ``k_used``, ``pilot_num_grad_evals``).
+        ``diagnostics`` (see :class:`MCLMCLRDAdaptationState` for keys).
 
     Raises
     ------
@@ -288,24 +349,24 @@ def mclmc_lrd_adaptation(
         import jax
         import jax.numpy as jnp
         import blackjax
-        from blackjax.adaptation.mclmc_lrd_adaptation import mclmc_lrd_adaptation
 
         logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
         position = jnp.zeros(10)
         rng_key = jax.random.key(42)
 
         # Unadjusted (stable default):
-        result = mclmc_lrd_adaptation(
+        result = blackjax.mclmc_lrd_warmup(
             logdensity_fn, position, rng_key,
             k=4, pilot_num_warmup=500, pilot_num_samples=2000,
-            lrd_num_steps=1000,
+            lrd_num_steps=1000, num_chains=4,
         )
 
         # Adjusted (experimental):
-        result_adj = mclmc_lrd_adaptation(
+        result_adj = blackjax.mclmc_lrd_warmup(
             logdensity_fn, position, rng_key,
             k=4, pilot_num_warmup=500, pilot_num_samples=2000,
-            lrd_num_steps=1000, inner_kernel="adjusted_mclmc",
+            lrd_num_steps=1000, num_chains=4,
+            inner_kernel="adjusted_mclmc",
         )
 
         # Build the production kernel from the unadjusted result:
@@ -326,7 +387,9 @@ def mclmc_lrd_adaptation(
 
     # Five independent keys — no reuse across init / pilot warmup / pilot
     # sampling / LRD tuning / adjusted tuning.
-    init_key, warmup_key, sample_key, lrd_key, adj_key = jax.random.split(rng_key, 5)
+    init_key, warmup_key, sample_key, lrd_subkey, adj_subkey = jax.random.split(
+        rng_key, 5
+    )
 
     # ------------------------------------------------------------------
     # Phase 1: diagonal pilot — reach typical set + collect geometry samples
@@ -342,6 +405,9 @@ def mclmc_lrd_adaptation(
         logdensity_fn=logdensity_fn,
         diagonal_preconditioning=True,
     )
+
+    pilot_L = float(pilot_params.L)
+    pilot_step_size_val = float(pilot_params.step_size)
 
     # Collect pilot_num_samples draws with the adapted diagonal kernel.
     def _pilot_step(state, key):
@@ -383,7 +449,7 @@ def mclmc_lrd_adaptation(
     if k_used < k:
         n_eff_rounded = round(n_eff, 1)
         warnings.warn(
-            f"mclmc_lrd_adaptation: requested k={k} exceeds the rank-safety "
+            f"mclmc_lrd_warmup: requested k={k} exceeds the rank-safety "
             f"bound k_safe=floor(n_eff/2)={k_safe} "
             f"(n_eff={n_eff_rounded} from {pilot_num_samples} pilot draws). "
             f"Clamping to k_used={k_used}. "
@@ -399,10 +465,10 @@ def mclmc_lrd_adaptation(
     lrd_imm = LowRankInverseMassMatrix(sigma=sigma, U=U_k, lam=lam_k)
 
     # ------------------------------------------------------------------
-    # Phase 3: unadjusted LRD tuning — calibrate L and step_size with LRD
-    # metric.  The kernel wrapper routes the inverse_mass_matrix argument
-    # through lrd_imm so diagonal_preconditioning=False does not overwrite
-    # it inside the tuner.
+    # Phase 3: multi-chain unadjusted LRD tuning
+    # num_chains independent chains, all starting from pilot's final position
+    # with per-chain PRNG keys for independent trajectories.  L and step_size
+    # are averaged across chains for a stable multi-chain estimate.
     # ------------------------------------------------------------------
     def lrd_kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size):
         return base_kernel(
@@ -420,22 +486,49 @@ def mclmc_lrd_adaptation(
         step_size=pilot_params.step_size,
         inverse_mass_matrix=pilot_params.inverse_mass_matrix,  # placeholder; overridden
     )
-    _, lrd_params, _ = mclmc_find_L_and_step_size(
-        mclmc_kernel=lrd_kernel,
-        num_steps=lrd_num_steps,
-        state=state_after_warmup,
-        rng_key=lrd_key,
-        logdensity_fn=logdensity_fn,
-        diagonal_preconditioning=False,
-        params=lrd_init_params,
+
+    # Split into 2*num_chains keys: first half for chain init, second for tuning.
+    lrd_all_keys = jax.random.split(lrd_subkey, 2 * num_chains)
+    lrd_init_keys = lrd_all_keys[:num_chains]
+    lrd_tune_keys = lrd_all_keys[num_chains:]
+
+    # Replicate position for all chains (same start, different momenta via keys).
+    chain_positions = jax.tree.map(
+        lambda x: jnp.stack([x] * num_chains),
+        state_after_warmup.position,
     )
+
+    @jax.vmap
+    def _lrd_init_one(k, x0):
+        return _mclmc_mod.init(x0, logdensity_fn, k)
+
+    lrd_init_states = _lrd_init_one(lrd_init_keys, chain_positions)
+
+    @jax.vmap
+    def _lrd_tune_one(k, state):
+        _, params, _ = mclmc_find_L_and_step_size(
+            mclmc_kernel=lrd_kernel,
+            num_steps=lrd_num_steps,
+            state=state,
+            rng_key=k,
+            logdensity_fn=logdensity_fn,
+            diagonal_preconditioning=False,
+            params=lrd_init_params,
+        )
+        return params
+
+    lrd_params_all = _lrd_tune_one(lrd_tune_keys, lrd_init_states)
+
+    # Multi-chain mean for stable L and step_size estimates.
+    lrd_L = float(jnp.mean(lrd_params_all.L))
+    lrd_step_size = float(jnp.mean(lrd_params_all.step_size))
 
     # ------------------------------------------------------------------
     # Phase 4: inner-kernel dispatch
     # ------------------------------------------------------------------
     if inner_kernel == "mclmc":
-        final_L = lrd_params.L
-        final_step_size = lrd_params.step_size
+        final_L = jnp.array(lrd_L)
+        final_step_size = jnp.array(lrd_step_size)
 
     else:  # inner_kernel == "adjusted_mclmc"
         # Build the adjusted kernel wrapper — routes inverse_mass_matrix
@@ -459,39 +552,56 @@ def mclmc_lrd_adaptation(
                 inverse_mass_matrix=lrd_imm,  # always route through LRD
             )
 
-        # L_init floor: prevents degenerate one-step trajectories.
+        # L_init floor guard: prevents DA ceiling from binding below oracle.
         # Hard constraints enforced here (see module docstring):
-        #   1) params != None  →  no sqrt(dim) default L init
-        #   2) frac_tune2=0.0  →  variance-based L estimator disabled
-        L_init = max(float(lrd_params.L), floor_factor * float(lrd_params.step_size))
-        # Note: inverse_mass_matrix is a placeholder — adj_lrd_kernel always
-        # routes through lrd_imm; using the diagonal pilot IMM keeps the field
-        # consistent with MCLMCAdaptationState's existing usage (jnp array).
+        #   C1) params != None  →  no sqrt(dim) default L init
+        #   C2) frac_tune2=0.0  →  variance-based L estimator disabled
+        L_init = max(lrd_L, floor_factor * lrd_step_size)
+
+        # Note: inverse_mass_matrix is a placeholder in adj_init_params —
+        # adj_lrd_kernel always routes through lrd_imm; using the diagonal
+        # pilot IMM keeps the field consistent with MCLMCAdaptationState's
+        # existing dtype contract (jnp array).
         adj_init_params = MCLMCAdaptationState(
-            L=L_init,
-            step_size=float(lrd_params.step_size),
+            L=jnp.array(L_init),
+            step_size=jnp.array(lrd_step_size),
             inverse_mass_matrix=pilot_params.inverse_mass_matrix,
         )
 
-        # adjusted_mclmc.init takes (position, logdensity_fn) — no rng_key.
-        adj_init_state = _adj_mclmc_mod.init(
-            position=state_after_warmup.position,
-            logdensity_fn=logdensity_fn,
-        )
+        # Multi-chain adjusted tuning — same num_chains chains, starting
+        # from the pilot's final position.
+        adj_tune_keys = jax.random.split(adj_subkey, num_chains)
 
-        _, adj_params, _ = adjusted_mclmc_find_L_and_step_size(
-            mclmc_kernel=adj_lrd_kernel,
-            logdensity_fn=logdensity_fn,
-            num_steps=lrd_num_steps,
-            state=adj_init_state,
-            rng_key=adj_key,
-            target=adjusted_target,
-            frac_tune2=0.0,  # variance-based L estimator incompatible with baked-in LRD IMM
-            diagonal_preconditioning=False,  # don't overwrite LRD IMM
-            params=adj_init_params,
-        )
-        final_L = adj_params.L
-        final_step_size = adj_params.step_size
+        @jax.vmap
+        def _adj_init_one(x0):
+            return _adj_mclmc_mod.init(x0, logdensity_fn)
+
+        adj_init_states = _adj_init_one(chain_positions)
+
+        @jax.vmap
+        def _adj_tune_one(k, state):
+            _, params, _ = adjusted_mclmc_find_L_and_step_size(
+                mclmc_kernel=adj_lrd_kernel,
+                logdensity_fn=logdensity_fn,
+                num_steps=lrd_num_steps,
+                state=state,
+                rng_key=k,
+                target=adjusted_target,
+                frac_tune2=0.0,  # variance-based L estimator incompatible with LRD IMM
+                diagonal_preconditioning=False,  # don't overwrite LRD IMM
+                params=adj_init_params,
+            )
+            return params
+
+        adj_params_all = _adj_tune_one(adj_tune_keys, adj_init_states)
+
+        # frac_tune2=0.0 → L is fixed at L_init across all chains.
+        # Average step_size across chains for a stable multi-chain estimate.
+        final_step_size = jnp.mean(adj_params_all.step_size)
+        final_L = jnp.array(L_init)  # L is fixed by construction
+
+        # DA-ceiling diagnostic: warn if step_size is at or near L_init/1.1.
+        _check_da_ceiling_warning(float(final_step_size), L_init, floor_factor)
 
     # Gradient accounting: unadjusted MCLMC costs 2 grads/step.
     pilot_num_grad_evals = (pilot_num_warmup + pilot_num_samples) * 2
@@ -502,6 +612,10 @@ def mclmc_lrd_adaptation(
         "k_safe": k_safe,
         "k_used": k_used,
         "pilot_num_grad_evals": pilot_num_grad_evals,
+        "pilot_L": pilot_L,
+        "pilot_step_size": pilot_step_size_val,
+        "lrd_L": lrd_L,
+        "lrd_step_size": lrd_step_size,
     }
 
     return MCLMCLRDAdaptationState(

--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -39,7 +39,10 @@ adjusted inner kernels; only Phase 4 switches:
    az-bulk ESS).  A safe rank bound ``k_safe = floor(n_eff / 2)`` is
    computed, and the requested ``k`` is hard-clamped to ``k_safe`` when it
    would exceed it.  Without this guard, under-mixed pilots produce
-   rank-deficient SVDs and the LRD metric degrades sampling quality.
+   rank-deficient SVDs and the LRD metric degrades sampling quality.  In the
+   extreme under-mix regime (n_eff < 5), the Geyer estimator may exceed
+   az-bulk ESS on the minimum-ESS dimension; ``k_safe`` is still floored to
+   0 → ``k_used=1``, so practical rank clamping is unaffected.
 
 3. **Multi-chain unadjusted LRD tuning** —
    :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
@@ -658,7 +661,9 @@ def mclmc_lrd_warmup(
         # N_sample = effective number of leapfrog steps per trajectory at the
         # final adapted params — the floor-guard inputs that tuningfork cert
         # integration uses to verify trajectory-length bookkeeping.
-        diagnostics["N_sample"] = round(float(final_L) / max(float(final_step_size), 1e-10))
+        diagnostics["N_sample"] = round(
+            float(final_L) / max(float(final_step_size), 1e-10)
+        )
 
     return MCLMCLRDAdaptationState(
         L=final_L,

--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -1,0 +1,373 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pilot-free (Scheme A) MCLMC adaptation with Low-Rank Diagonal preconditioning.
+
+Overview
+--------
+This module implements the **Scheme A** warmup for unadjusted MCLMC:
+
+1. **Pilot phase** — a single unadjusted MCLMC chain with diagonal preconditioning
+   (via :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`)
+   runs for ``pilot_num_warmup + pilot_num_samples`` steps to reach the typical
+   set and collect geometry samples.
+
+2. **LRD extraction** — the pilot draws are standardised and a thin SVD extracts
+   the top-*k* principal directions of the correlation structure.  The result is a
+   :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` ``(sigma, U, lam)``.
+
+   **Rank guard (non-negotiable):** before extraction, the effective sample size
+   of the pilot chain is estimated via :func:`~blackjax.diagnostics.effective_sample_size`
+   (the Geyer monotone-sequence estimator, operating on the ravelled flat-parameter
+   vector; one chain, ``n_pilot_samples`` draws; basis is *not* the az-bulk ESS).
+   A safe rank bound ``k_safe = floor(n_eff / 2)`` is computed, and the requested
+   ``k`` is hard-clamped to ``k_safe`` when it would exceed it.  Without this
+   guard, under-mixed pilots produce rank-deficient SVDs and the LRD metric
+   degrades sampling quality (observed failure mode: ill_cond_50 attempts 1–2 at
+   k=40, n_pilot=1000, n_eff≈30 → k_safe=15; cert passed only once n_pilot≥10k
+   kept k≤n_eff/2).
+
+3. **LRD tuning phase** — :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
+   is re-run with the LRD metric kernel (``diagonal_preconditioning=False``), so
+   the step size and trajectory length L are calibrated to the true posterior
+   geometry.
+
+Stan-window analogy
+-------------------
+The staging mirrors Stan's two-phase warmup: a cheap diagonal (fast) phase
+reaches the typical set first; the LRD (slow) phase then builds the metric from
+draws that are already in the right region.  The key difference is that Scheme A
+uses MCLMC (unadjusted, leapfrog-free) for both phases, eliminating the NUTS
+pilot cost that dominated total gradient expenditure in our benchmarks:
+
+* ill_cond_50 (d=50, κ=1000): k=40, n_pilot=10k → 101.1 % oracle step-size
+  recovery, 2.42× ESS/total-grad vs NUTS-pilot, 72.5 % grad savings.
+* german_credit (d=26): k=8, n_pilot=5k.
+* mvn_10 (d=10): k=4, n_pilot=2k.
+
+Limitations
+-----------
+* **Unadjusted only.** Adjusted MCLMC (MCMC-correct) research is still in
+  flight; the LRD metric has not yet been validated with the adjusted kernel.
+  A future ``mclmc_lrd_adaptation_adjusted`` variant is the intended hook.
+* **Single-chain pilot.** The pilot is single-chain; overdispersed multi-chain
+  initialisation would give stronger geometry coverage and tighter n_eff
+  estimates.  This is a known limitation for the rank guard's tightness.
+* **NUTS-pilot fallback.** When the target has funnel-class geometry (e.g.
+  stoch_vol), the MCLMC pilot may under-mix even with n_eff/2 clamping.  A
+  NUTS-pilot fallback (replacing Phase 1 with
+  :func:`~blackjax.adaptation.window_adaptation.window_adaptation`) is the
+  recommended escape hatch but is out of scope here.
+"""
+
+import warnings
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+
+import blackjax.mcmc.mclmc as _mclmc_mod
+from blackjax.adaptation.mclmc_adaptation import (
+    MCLMCAdaptationState,
+    mclmc_find_L_and_step_size,
+)
+from blackjax.diagnostics import effective_sample_size
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
+
+__all__ = [
+    "MCLMCLRDAdaptationState",
+    "mclmc_lrd_adaptation",
+]
+
+
+class MCLMCLRDAdaptationState(NamedTuple):
+    """Result of :func:`mclmc_lrd_adaptation`.
+
+    L
+        Adapted momentum decoherence length from the LRD tuning phase.
+    step_size
+        Adapted step size from the LRD tuning phase.
+    inverse_mass_matrix
+        The adapted LRD inverse mass matrix as a
+        :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` NamedTuple
+        ``(sigma, U, lam)``.
+    diagnostics
+        A plain dict with provenance fields:
+
+        ``n_eff``
+            Effective sample size of the pilot chain (Geyer monotone-sequence
+            estimator, blackjax basis, ravelled flat vector).
+        ``k_safe``
+            Floor of ``n_eff / 2`` — the maximum rank that is statistically
+            supported by the pilot.
+        ``k_used``
+            The rank actually passed to SVD after clamping (``min(k, k_safe)``).
+        ``pilot_num_grad_evals``
+            Total gradient evaluations consumed by the pilot phase
+            (warmup + samples; unadjusted MCLMC costs 2 grads/step).
+    """
+
+    L: float
+    step_size: float
+    inverse_mass_matrix: LowRankInverseMassMatrix
+    diagnostics: dict
+
+
+def _extract_lrd_from_samples(
+    flat_positions: Any,
+    k: int,
+) -> tuple:
+    """Extract LRD parameters from a ``(n_samples, d)`` array of pilot draws.
+
+    Parameters
+    ----------
+    flat_positions
+        Shape ``(n_samples, d)``.  Already ravelled to a 2-D float array.
+    k
+        Rank of the LRD approximation (after clamping by the caller).
+
+    Returns
+    -------
+    sigma : shape ``(d,)``
+    U     : shape ``(d, k)``
+    lam   : shape ``(k,)``
+    """
+    mean = jnp.mean(flat_positions, axis=0)  # (d,)
+    sigma = jnp.std(flat_positions, axis=0)  # (d,)
+    sigma = jnp.where(sigma == 0.0, 1.0, sigma)  # avoid div-by-zero in zero-var dims
+
+    standardised = (flat_positions - mean[None, :]) / sigma[None, :]  # (n, d)
+    n = flat_positions.shape[0]
+
+    # Thin SVD: columns of V are the principal directions of standardised draws.
+    # Eigenvalues of the sample correlation matrix: lam_i = s_i^2 / n.
+    _, S, Vt = jnp.linalg.svd(standardised, full_matrices=False)
+    V = Vt.T  # (d, min(n,d))
+    lam = (S**2) / n  # (min(n,d),)
+
+    # Select top-k by |λ - 1| (directions that deviate most from isotropic).
+    sort_idx = jnp.argsort(jnp.abs(lam - 1.0))[::-1]
+    top_idx = sort_idx[:k]
+
+    lam_k = lam[top_idx]  # (k,)
+    U_k = V[:, top_idx]  # (d, k)
+    return sigma, U_k, lam_k
+
+
+def mclmc_lrd_adaptation(
+    logdensity_fn,
+    position,
+    rng_key,
+    *,
+    k: int = 10,
+    pilot_num_warmup: int = 1000,
+    pilot_num_samples: int = 5000,
+    lrd_num_steps: int = 1000,
+):
+    """Scheme A (pilot-free) MCLMC adaptation with Low-Rank Diagonal preconditioning.
+
+    Runs a cheap diagonal unadjusted MCLMC pilot to reach the typical set and
+    collect geometry samples, extracts a low-rank diagonal (LRD) inverse mass
+    matrix via thin SVD, then tunes step size and trajectory length L against
+    the LRD metric kernel.
+
+    Parameters
+    ----------
+    logdensity_fn
+        Log-density of the target distribution.
+    position
+        Initial position (any pytree).
+    rng_key
+        JAX PRNG key.
+    k
+        Requested LRD rank.  Hard-clamped to ``floor(n_eff / 2)`` if the pilot
+        chain is under-mixed; see the rank-guard note in the module docstring.
+    pilot_num_warmup
+        Number of steps for the diagonal pilot warmup phase (used by
+        :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
+        to adapt step size and L with a diagonal mass matrix).
+    pilot_num_samples
+        Number of unadjusted MCLMC draws collected *after* the pilot warmup,
+        used for the SVD geometry estimate.
+    lrd_num_steps
+        Number of steps passed as ``num_steps`` to the second call of
+        :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
+        (LRD tuning phase).
+
+    Returns
+    -------
+    MCLMCLRDAdaptationState
+        A :class:`MCLMCLRDAdaptationState` NamedTuple with fields ``L``,
+        ``step_size``, ``inverse_mass_matrix`` (a
+        :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`), and
+        ``diagnostics`` (``n_eff``, ``k_safe``, ``k_used``,
+        ``pilot_num_grad_evals``).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import jax
+        import blackjax
+        from blackjax.adaptation.mclmc_lrd_adaptation import mclmc_lrd_adaptation
+
+        logdensity_fn = lambda x: -0.5 * jnp.sum(x**2)
+        position = jnp.zeros(10)
+        rng_key = jax.random.key(42)
+
+        result = mclmc_lrd_adaptation(
+            logdensity_fn, position, rng_key,
+            k=4, pilot_num_warmup=500, pilot_num_samples=2000, lrd_num_steps=1000,
+        )
+        # result.L, result.step_size, result.inverse_mass_matrix (LowRankInverseMassMatrix)
+        # result.diagnostics["k_used"], result.diagnostics["n_eff"]
+
+        # Build the LRD kernel and run production sampling:
+        import blackjax.mcmc.mclmc as mclmc_mod
+        lrd_imm = result.inverse_mass_matrix
+        base_kernel = mclmc_mod.build_kernel()
+
+        def lrd_kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size):
+            return base_kernel(rng_key, state, logdensity_fn, lrd_imm, L, step_size)
+
+        init_state = mclmc_mod.init(position, logdensity_fn, jax.random.key(0))
+        next_state, info = lrd_kernel(
+            jax.random.key(1), init_state, logdensity_fn,
+            lrd_imm, result.L, result.step_size,
+        )
+    """
+    pilot_key, lrd_key = jax.random.split(rng_key, 2)
+
+    # ------------------------------------------------------------------
+    # Phase 1: diagonal pilot — reach typical set + collect geometry samples
+    # ------------------------------------------------------------------
+    base_kernel = _mclmc_mod.build_kernel()
+    init_state = _mclmc_mod.init(position, logdensity_fn, pilot_key)
+
+    pilot_warmup_key, pilot_sample_key = jax.random.split(pilot_key, 2)
+    state_after_warmup, pilot_params, _ = mclmc_find_L_and_step_size(
+        mclmc_kernel=base_kernel,
+        num_steps=pilot_num_warmup,
+        state=init_state,
+        rng_key=pilot_warmup_key,
+        logdensity_fn=logdensity_fn,
+        diagonal_preconditioning=True,
+    )
+
+    # Collect pilot_num_samples draws with the adapted diagonal kernel.
+    def _pilot_step(state, key):
+        next_state, _ = base_kernel(
+            rng_key=key,
+            state=state,
+            logdensity_fn=logdensity_fn,
+            inverse_mass_matrix=pilot_params.inverse_mass_matrix,
+            L=pilot_params.L,
+            step_size=pilot_params.step_size,
+        )
+        return next_state, next_state.position
+
+    _, pilot_positions = jax.lax.scan(
+        _pilot_step,
+        state_after_warmup,
+        jax.random.split(pilot_sample_key, pilot_num_samples),
+    )
+
+    # ------------------------------------------------------------------
+    # Rank guard: n_eff via blackjax Geyer ESS on ravelled flat vector.
+    # ESS basis: Geyer monotone-sequence estimator (blackjax.diagnostics.
+    # effective_sample_size), single chain, n_pilot_samples draws.
+    # Shape expected: (chains, draws, d) — we add the chains axis here.
+    # ------------------------------------------------------------------
+    _, unravel_fn = ravel_pytree(jax.tree.map(lambda x: x[0], pilot_positions))
+    flat_pilot = jax.vmap(lambda p: ravel_pytree(p)[0])(pilot_positions)  # (n, d)
+
+    # effective_sample_size expects (chains, draws, d); add singleton chain axis.
+    # Requires ≥2 draws; guard for degenerate pilots.
+    if pilot_num_samples >= 2:
+        ess_per_dim = effective_sample_size(flat_pilot[None, :, :])  # (d,)
+        n_eff = float(jnp.min(ess_per_dim))  # conservative: use min over dims
+    else:
+        n_eff = 0.0  # degenerate: force k_safe=0 → k_used=1
+
+    k_safe = int(n_eff / 2)  # floor(n_eff / 2)
+    k_used = min(k, max(k_safe, 1))  # clamp; always use at least rank 1
+
+    if k_used < k:
+        n_eff_rounded = round(n_eff, 1)
+        warnings.warn(
+            f"mclmc_lrd_adaptation: requested k={k} exceeds the rank-safety "
+            f"bound k_safe=floor(n_eff/2)={k_safe} "
+            f"(n_eff={n_eff_rounded} from {pilot_num_samples} pilot draws). "
+            f"Clamping to k_used={k_used}. "
+            "Increase pilot_num_samples to raise n_eff, or reduce k.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    # ------------------------------------------------------------------
+    # Phase 2: SVD extraction → LowRankInverseMassMatrix
+    # ------------------------------------------------------------------
+    sigma, U_k, lam_k = _extract_lrd_from_samples(flat_pilot, k=k_used)
+    lrd_imm = LowRankInverseMassMatrix(sigma=sigma, U=U_k, lam=lam_k)
+
+    # ------------------------------------------------------------------
+    # Phase 3: LRD tuning — re-tune L and step_size with LRD metric.
+    # The LRD kernel intercepts the inverse_mass_matrix argument passed
+    # by mclmc_find_L_and_step_size and routes it through lrd_imm instead,
+    # so diagonal_preconditioning=False prevents the diagonal IMM from
+    # overwriting lrd_imm inside the tuner.
+    # ------------------------------------------------------------------
+    def lrd_kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size):
+        return base_kernel(
+            rng_key=rng_key,
+            state=state,
+            logdensity_fn=logdensity_fn,
+            inverse_mass_matrix=lrd_imm,  # always route through LRD
+            L=L,
+            step_size=step_size,
+        )
+
+    # Initialise LRD tuning from the pilot's terminal state; pass pilot L/step_size
+    # as a warm start to avoid unnecessary exploration in the tuning phase.
+    lrd_init_params = MCLMCAdaptationState(
+        L=pilot_params.L,
+        step_size=pilot_params.step_size,
+        inverse_mass_matrix=pilot_params.inverse_mass_matrix,  # placeholder; overridden
+    )
+    _, lrd_params, _ = mclmc_find_L_and_step_size(
+        mclmc_kernel=lrd_kernel,
+        num_steps=lrd_num_steps,
+        state=state_after_warmup,
+        rng_key=lrd_key,
+        logdensity_fn=logdensity_fn,
+        diagonal_preconditioning=False,
+        params=lrd_init_params,
+    )
+
+    # Gradient accounting: unadjusted MCLMC costs 2 grads/step.
+    pilot_num_grad_evals = (pilot_num_warmup + pilot_num_samples) * 2
+
+    diagnostics = {
+        "n_eff": n_eff,
+        "k_safe": k_safe,
+        "k_used": k_used,
+        "pilot_num_grad_evals": pilot_num_grad_evals,
+    }
+
+    return MCLMCLRDAdaptationState(
+        L=lrd_params.L,
+        step_size=lrd_params.step_size,
+        inverse_mass_matrix=lrd_imm,
+        diagnostics=diagnostics,
+    )

--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -15,40 +15,66 @@
 
 Overview
 --------
-This module implements the **Scheme A** warmup for unadjusted MCLMC:
+This module implements the **Scheme A** warmup for MCLMC.  Phases 1–3 are
+shared between the unadjusted and adjusted inner kernels; only Phase 4
+switches:
 
-1. **Pilot phase** — a single unadjusted MCLMC chain with diagonal preconditioning
-   (via :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`)
-   runs for ``pilot_num_warmup + pilot_num_samples`` steps to reach the typical
-   set and collect geometry samples.
+1. **Pilot phase** — a single unadjusted MCLMC chain with diagonal
+   preconditioning (via
+   :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`)
+   runs for ``pilot_num_warmup + pilot_num_samples`` steps to reach the
+   typical set and collect geometry samples.
 
-2. **LRD extraction** — the pilot draws are standardised and a thin SVD extracts
-   the top-*k* principal directions of the correlation structure.  The result is a
-   :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` ``(sigma, U, lam)``.
+2. **LRD extraction** — the pilot draws are standardised and a thin SVD
+   extracts the top-*k* principal directions of the correlation structure.
+   The result is a
+   :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` ``(sigma, U,
+   lam)``.
 
-   **Rank guard (non-negotiable):** before extraction, the effective sample size
-   of the pilot chain is estimated via :func:`~blackjax.diagnostics.effective_sample_size`
-   (the Geyer monotone-sequence estimator, operating on the ravelled flat-parameter
-   vector; one chain, ``n_pilot_samples`` draws; basis is *not* the az-bulk ESS).
-   A safe rank bound ``k_safe = floor(n_eff / 2)`` is computed, and the requested
-   ``k`` is hard-clamped to ``k_safe`` when it would exceed it.  Without this
-   guard, under-mixed pilots produce rank-deficient SVDs and the LRD metric
-   degrades sampling quality (observed failure mode: ill_cond_50 attempts 1–2 at
-   k=40, n_pilot=1000, n_eff≈30 → k_safe=15; cert passed only once n_pilot≥10k
-   kept k≤n_eff/2).
+   **Rank guard (non-negotiable):** before extraction, the effective sample
+   size of the pilot chain is estimated via
+   :func:`~blackjax.diagnostics.effective_sample_size` (the Geyer
+   monotone-sequence estimator, operating on the ravelled flat-parameter
+   vector; one chain, ``pilot_num_samples`` draws; basis is *not* the
+   az-bulk ESS).  A safe rank bound ``k_safe = floor(n_eff / 2)`` is
+   computed, and the requested ``k`` is hard-clamped to ``k_safe`` when it
+   would exceed it.  Without this guard, under-mixed pilots produce
+   rank-deficient SVDs and the LRD metric degrades sampling quality.
 
-3. **LRD tuning phase** — :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
-   is re-run with the LRD metric kernel (``diagonal_preconditioning=False``), so
-   the step size and trajectory length L are calibrated to the true posterior
-   geometry.
+3. **Unadjusted LRD tuning** —
+   :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
+   is re-run with the LRD metric kernel
+   (``diagonal_preconditioning=False``), so step size and trajectory length
+   *L* are calibrated to the true posterior geometry.
+
+4. **Inner-kernel dispatch** (controlled by ``inner_kernel``):
+
+   * ``"mclmc"`` *(default)*: returns Phase-3 ``(L, step_size)`` directly.
+
+   * ``"adjusted_mclmc"`` *(experimental)*: warm-starts
+     :func:`~blackjax.adaptation.adjusted_mclmc_adaptation.adjusted_mclmc_find_L_and_step_size`
+     from the unadjusted LRD-tuned parameters.  **Two hard constraints are
+     enforced automatically** to avoid known failure modes:
+
+     - ``params`` is set to ``MCLMCAdaptationState(L=L_init, step_size=...,
+       inverse_mass_matrix=lrd_imm)`` so that the sqrt(dim) default L
+       initialisation (which ignores the baked-in LRD metric) is never
+       used.
+     - ``frac_tune2=0.0`` disables the variance-based *L* estimator, which
+       computes original-space ``trace(Σ)`` and is incompatible with an
+       externally-baked LRD IMM.
+
+     ``L_init`` is floored at ``floor_factor * step_unadj`` (default
+     ``floor_factor=1.15``) to prevent degenerate one-step trajectories.
 
 Stan-window analogy
 -------------------
 The staging mirrors Stan's two-phase warmup: a cheap diagonal (fast) phase
-reaches the typical set first; the LRD (slow) phase then builds the metric from
-draws that are already in the right region.  The key difference is that Scheme A
-uses MCLMC (unadjusted, leapfrog-free) for both phases, eliminating the NUTS
-pilot cost that dominated total gradient expenditure in our benchmarks:
+reaches the typical set first; the LRD (slow) phase then builds the metric
+from draws that are already in the right region.  The key difference is that
+Scheme A uses MCLMC (unadjusted, leapfrog-free) for the pilot, eliminating
+the NUTS pilot cost that dominated total gradient expenditure in our
+benchmarks:
 
 * ill_cond_50 (d=50, κ=1000): k=40, n_pilot=10k → 101.1 % oracle step-size
   recovery, 2.42× ESS/total-grad vs NUTS-pilot, 72.5 % grad savings.
@@ -57,17 +83,19 @@ pilot cost that dominated total gradient expenditure in our benchmarks:
 
 Limitations
 -----------
-* **Unadjusted only.** Adjusted MCLMC (MCMC-correct) research is still in
-  flight; the LRD metric has not yet been validated with the adjusted kernel.
-  A future ``mclmc_lrd_adaptation_adjusted`` variant is the intended hook.
-* **Single-chain pilot.** The pilot is single-chain; overdispersed multi-chain
-  initialisation would give stronger geometry coverage and tighter n_eff
-  estimates.  This is a known limitation for the rank guard's tightness.
+* **Single-chain pilot.** The pilot is single-chain; overdispersed
+  multi-chain initialisation would give stronger geometry coverage and
+  tighter n_eff estimates.  This is a known limitation for the rank guard's
+  tightness.
 * **NUTS-pilot fallback.** When the target has funnel-class geometry (e.g.
-  stoch_vol), the MCLMC pilot may under-mix even with n_eff/2 clamping.  A
-  NUTS-pilot fallback (replacing Phase 1 with
+  hierarchical models near unit-root), the MCLMC pilot may under-mix even
+  with n_eff/2 clamping.  A NUTS-pilot fallback (replacing Phase 1 with
   :func:`~blackjax.adaptation.window_adaptation.window_adaptation`) is the
   recommended escape hatch but is out of scope here.
+* **Adjusted path experimental.** The ``inner_kernel="adjusted_mclmc"``
+  branch is certified on german_credit but has not yet been validated across
+  a broad benchmark suite.  ill_cond_50 evidence is ongoing.  Treat as
+  experimental; the unadjusted default is the stable path.
 """
 
 import warnings
@@ -77,7 +105,11 @@ import jax
 import jax.numpy as jnp
 from jax.flatten_util import ravel_pytree
 
+import blackjax.mcmc.adjusted_mclmc as _adj_mclmc_mod
 import blackjax.mcmc.mclmc as _mclmc_mod
+from blackjax.adaptation.adjusted_mclmc_adaptation import (
+    adjusted_mclmc_find_L_and_step_size,
+)
 from blackjax.adaptation.mclmc_adaptation import (
     MCLMCAdaptationState,
     mclmc_find_L_and_step_size,
@@ -90,14 +122,16 @@ __all__ = [
     "mclmc_lrd_adaptation",
 ]
 
+_VALID_INNER_KERNELS = frozenset({"mclmc", "adjusted_mclmc"})
+
 
 class MCLMCLRDAdaptationState(NamedTuple):
     """Result of :func:`mclmc_lrd_adaptation`.
 
     L
-        Adapted momentum decoherence length from the LRD tuning phase.
+        Adapted momentum decoherence length from the final tuning phase.
     step_size
-        Adapted step size from the LRD tuning phase.
+        Adapted step size from the final tuning phase.
     inverse_mass_matrix
         The adapted LRD inverse mass matrix as a
         :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` NamedTuple
@@ -105,6 +139,9 @@ class MCLMCLRDAdaptationState(NamedTuple):
     diagnostics
         A plain dict with provenance fields:
 
+        ``inner_kernel``
+            Which inner kernel was used (``"mclmc"`` or
+            ``"adjusted_mclmc"``).
         ``n_eff``
             Effective sample size of the pilot chain (Geyer monotone-sequence
             estimator, blackjax basis, ravelled flat vector).
@@ -174,13 +211,17 @@ def mclmc_lrd_adaptation(
     pilot_num_warmup: int = 1000,
     pilot_num_samples: int = 5000,
     lrd_num_steps: int = 1000,
+    inner_kernel: str = "mclmc",
+    floor_factor: float = 1.15,
+    adjusted_target: float = 0.9,
 ):
     """Scheme A (pilot-free) MCLMC adaptation with Low-Rank Diagonal preconditioning.
 
     Runs a cheap diagonal unadjusted MCLMC pilot to reach the typical set and
     collect geometry samples, extracts a low-rank diagonal (LRD) inverse mass
     matrix via thin SVD, then tunes step size and trajectory length L against
-    the LRD metric kernel.
+    the LRD metric kernel.  The inner kernel for the final tuning phase is
+    controlled by ``inner_kernel``.
 
     Parameters
     ----------
@@ -191,8 +232,9 @@ def mclmc_lrd_adaptation(
     rng_key
         JAX PRNG key.
     k
-        Requested LRD rank.  Hard-clamped to ``floor(n_eff / 2)`` if the pilot
-        chain is under-mixed; see the rank-guard note in the module docstring.
+        Requested LRD rank.  Hard-clamped to ``floor(n_eff / 2)`` if the
+        pilot chain is under-mixed; see the rank-guard note in the module
+        docstring.
     pilot_num_warmup
         Number of steps for the diagonal pilot warmup phase (used by
         :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
@@ -201,9 +243,28 @@ def mclmc_lrd_adaptation(
         Number of unadjusted MCLMC draws collected *after* the pilot warmup,
         used for the SVD geometry estimate.
     lrd_num_steps
-        Number of steps passed as ``num_steps`` to the second call of
-        :func:`~blackjax.adaptation.mclmc_adaptation.mclmc_find_L_and_step_size`
-        (LRD tuning phase).
+        Number of steps passed to the LRD tuning call(s) in Phase 3 (and
+        Phase 4 for the adjusted path).
+    inner_kernel
+        Which inner kernel to use for the final tuning phase.  One of:
+
+        * ``"mclmc"`` *(default, stable)*: unadjusted MCLMC.  Phase 3
+          output ``(L, step_size)`` is returned directly.
+        * ``"adjusted_mclmc"`` *(experimental)*: after Phase 3 unadjusted
+          LRD tuning, warms-start
+          :func:`~blackjax.adaptation.adjusted_mclmc_adaptation.adjusted_mclmc_find_L_and_step_size`
+          with ``frac_tune2=0.0`` (variance-based *L* estimator disabled)
+          and ``diagonal_preconditioning=False``.
+
+    floor_factor
+        For ``inner_kernel="adjusted_mclmc"`` only: the L initialisation
+        floor is ``max(L_unadj, floor_factor * step_unadj)``.  Default
+        ``1.15``; increase (e.g. to ``1.5``) for high-condition-number
+        targets where the unadjusted trajectory length may be too short for
+        the adjusted integrator.  Ignored when ``inner_kernel="mclmc"``.
+    adjusted_target
+        Target acceptance rate for the adjusted MCLMC tuning phase.
+        Default ``0.9``.  Ignored when ``inner_kernel="mclmc"``.
 
     Returns
     -------
@@ -211,14 +272,21 @@ def mclmc_lrd_adaptation(
         A :class:`MCLMCLRDAdaptationState` NamedTuple with fields ``L``,
         ``step_size``, ``inverse_mass_matrix`` (a
         :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`), and
-        ``diagnostics`` (``n_eff``, ``k_safe``, ``k_used``,
-        ``pilot_num_grad_evals``).
+        ``diagnostics`` (``inner_kernel``, ``n_eff``, ``k_safe``,
+        ``k_used``, ``pilot_num_grad_evals``).
+
+    Raises
+    ------
+    ValueError
+        If ``inner_kernel`` is not one of ``"mclmc"`` or
+        ``"adjusted_mclmc"``.
 
     Examples
     --------
     .. code-block:: python
 
         import jax
+        import jax.numpy as jnp
         import blackjax
         from blackjax.adaptation.mclmc_lrd_adaptation import mclmc_lrd_adaptation
 
@@ -226,41 +294,51 @@ def mclmc_lrd_adaptation(
         position = jnp.zeros(10)
         rng_key = jax.random.key(42)
 
+        # Unadjusted (stable default):
         result = mclmc_lrd_adaptation(
             logdensity_fn, position, rng_key,
-            k=4, pilot_num_warmup=500, pilot_num_samples=2000, lrd_num_steps=1000,
+            k=4, pilot_num_warmup=500, pilot_num_samples=2000,
+            lrd_num_steps=1000,
         )
-        # result.L, result.step_size, result.inverse_mass_matrix (LowRankInverseMassMatrix)
-        # result.diagnostics["k_used"], result.diagnostics["n_eff"]
 
-        # Build the LRD kernel and run production sampling:
+        # Adjusted (experimental):
+        result_adj = mclmc_lrd_adaptation(
+            logdensity_fn, position, rng_key,
+            k=4, pilot_num_warmup=500, pilot_num_samples=2000,
+            lrd_num_steps=1000, inner_kernel="adjusted_mclmc",
+        )
+
+        # Build the production kernel from the unadjusted result:
         import blackjax.mcmc.mclmc as mclmc_mod
         lrd_imm = result.inverse_mass_matrix
-        base_kernel = mclmc_mod.build_kernel()
-
-        def lrd_kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size):
-            return base_kernel(rng_key, state, logdensity_fn, lrd_imm, L, step_size)
-
+        kernel = mclmc_mod.build_kernel()
         init_state = mclmc_mod.init(position, logdensity_fn, jax.random.key(0))
-        next_state, info = lrd_kernel(
+        next_state, info = kernel(
             jax.random.key(1), init_state, logdensity_fn,
             lrd_imm, result.L, result.step_size,
         )
     """
-    pilot_key, lrd_key = jax.random.split(rng_key, 2)
+    if inner_kernel not in _VALID_INNER_KERNELS:
+        raise ValueError(
+            f"inner_kernel must be one of {sorted(_VALID_INNER_KERNELS)!r}, "
+            f"got {inner_kernel!r}."
+        )
+
+    # Five independent keys — no reuse across init / pilot warmup / pilot
+    # sampling / LRD tuning / adjusted tuning.
+    init_key, warmup_key, sample_key, lrd_key, adj_key = jax.random.split(rng_key, 5)
 
     # ------------------------------------------------------------------
     # Phase 1: diagonal pilot — reach typical set + collect geometry samples
     # ------------------------------------------------------------------
     base_kernel = _mclmc_mod.build_kernel()
-    init_state = _mclmc_mod.init(position, logdensity_fn, pilot_key)
+    init_state = _mclmc_mod.init(position, logdensity_fn, init_key)
 
-    pilot_warmup_key, pilot_sample_key = jax.random.split(pilot_key, 2)
     state_after_warmup, pilot_params, _ = mclmc_find_L_and_step_size(
         mclmc_kernel=base_kernel,
         num_steps=pilot_num_warmup,
         state=init_state,
-        rng_key=pilot_warmup_key,
+        rng_key=warmup_key,
         logdensity_fn=logdensity_fn,
         diagonal_preconditioning=True,
     )
@@ -280,16 +358,15 @@ def mclmc_lrd_adaptation(
     _, pilot_positions = jax.lax.scan(
         _pilot_step,
         state_after_warmup,
-        jax.random.split(pilot_sample_key, pilot_num_samples),
+        jax.random.split(sample_key, pilot_num_samples),
     )
 
     # ------------------------------------------------------------------
     # Rank guard: n_eff via blackjax Geyer ESS on ravelled flat vector.
     # ESS basis: Geyer monotone-sequence estimator (blackjax.diagnostics.
-    # effective_sample_size), single chain, n_pilot_samples draws.
+    # effective_sample_size), single chain, pilot_num_samples draws.
     # Shape expected: (chains, draws, d) — we add the chains axis here.
     # ------------------------------------------------------------------
-    _, unravel_fn = ravel_pytree(jax.tree.map(lambda x: x[0], pilot_positions))
     flat_pilot = jax.vmap(lambda p: ravel_pytree(p)[0])(pilot_positions)  # (n, d)
 
     # effective_sample_size expects (chains, draws, d); add singleton chain axis.
@@ -322,11 +399,10 @@ def mclmc_lrd_adaptation(
     lrd_imm = LowRankInverseMassMatrix(sigma=sigma, U=U_k, lam=lam_k)
 
     # ------------------------------------------------------------------
-    # Phase 3: LRD tuning — re-tune L and step_size with LRD metric.
-    # The LRD kernel intercepts the inverse_mass_matrix argument passed
-    # by mclmc_find_L_and_step_size and routes it through lrd_imm instead,
-    # so diagonal_preconditioning=False prevents the diagonal IMM from
-    # overwriting lrd_imm inside the tuner.
+    # Phase 3: unadjusted LRD tuning — calibrate L and step_size with LRD
+    # metric.  The kernel wrapper routes the inverse_mass_matrix argument
+    # through lrd_imm so diagonal_preconditioning=False does not overwrite
+    # it inside the tuner.
     # ------------------------------------------------------------------
     def lrd_kernel(rng_key, state, logdensity_fn, inverse_mass_matrix, L, step_size):
         return base_kernel(
@@ -338,8 +414,7 @@ def mclmc_lrd_adaptation(
             step_size=step_size,
         )
 
-    # Initialise LRD tuning from the pilot's terminal state; pass pilot L/step_size
-    # as a warm start to avoid unnecessary exploration in the tuning phase.
+    # Warm-start from pilot L/step_size to skip unnecessary exploration.
     lrd_init_params = MCLMCAdaptationState(
         L=pilot_params.L,
         step_size=pilot_params.step_size,
@@ -355,10 +430,74 @@ def mclmc_lrd_adaptation(
         params=lrd_init_params,
     )
 
+    # ------------------------------------------------------------------
+    # Phase 4: inner-kernel dispatch
+    # ------------------------------------------------------------------
+    if inner_kernel == "mclmc":
+        final_L = lrd_params.L
+        final_step_size = lrd_params.step_size
+
+    else:  # inner_kernel == "adjusted_mclmc"
+        # Build the adjusted kernel wrapper — routes inverse_mass_matrix
+        # through lrd_imm (same override pattern as Phase 3).
+        adj_base_kernel = _adj_mclmc_mod.build_kernel()
+
+        def adj_lrd_kernel(
+            rng_key,
+            state,
+            logdensity_fn,
+            step_size,
+            integration_steps_params,
+            inverse_mass_matrix,
+        ):
+            return adj_base_kernel(
+                rng_key=rng_key,
+                state=state,
+                logdensity_fn=logdensity_fn,
+                step_size=step_size,
+                integration_steps_params=integration_steps_params,
+                inverse_mass_matrix=lrd_imm,  # always route through LRD
+            )
+
+        # L_init floor: prevents degenerate one-step trajectories.
+        # Hard constraints enforced here (see module docstring):
+        #   1) params != None  →  no sqrt(dim) default L init
+        #   2) frac_tune2=0.0  →  variance-based L estimator disabled
+        L_init = max(float(lrd_params.L), floor_factor * float(lrd_params.step_size))
+        # Note: inverse_mass_matrix is a placeholder — adj_lrd_kernel always
+        # routes through lrd_imm; using the diagonal pilot IMM keeps the field
+        # consistent with MCLMCAdaptationState's existing usage (jnp array).
+        adj_init_params = MCLMCAdaptationState(
+            L=L_init,
+            step_size=float(lrd_params.step_size),
+            inverse_mass_matrix=pilot_params.inverse_mass_matrix,
+        )
+
+        # adjusted_mclmc.init takes (position, logdensity_fn) — no rng_key.
+        adj_init_state = _adj_mclmc_mod.init(
+            position=state_after_warmup.position,
+            logdensity_fn=logdensity_fn,
+        )
+
+        _, adj_params, _ = adjusted_mclmc_find_L_and_step_size(
+            mclmc_kernel=adj_lrd_kernel,
+            logdensity_fn=logdensity_fn,
+            num_steps=lrd_num_steps,
+            state=adj_init_state,
+            rng_key=adj_key,
+            target=adjusted_target,
+            frac_tune2=0.0,  # variance-based L estimator incompatible with baked-in LRD IMM
+            diagonal_preconditioning=False,  # don't overwrite LRD IMM
+            params=adj_init_params,
+        )
+        final_L = adj_params.L
+        final_step_size = adj_params.step_size
+
     # Gradient accounting: unadjusted MCLMC costs 2 grads/step.
     pilot_num_grad_evals = (pilot_num_warmup + pilot_num_samples) * 2
 
     diagnostics = {
+        "inner_kernel": inner_kernel,
         "n_eff": n_eff,
         "k_safe": k_safe,
         "k_used": k_used,
@@ -366,8 +505,8 @@ def mclmc_lrd_adaptation(
     }
 
     return MCLMCLRDAdaptationState(
-        L=lrd_params.L,
-        step_size=lrd_params.step_size,
+        L=final_L,
+        step_size=final_step_size,
         inverse_mass_matrix=lrd_imm,
         diagnostics=diagnostics,
     )

--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -70,7 +70,11 @@ adjusted inner kernels; only Phase 4 switches:
 
      ``L_init`` is floored at ``floor_factor * step_unadj`` (default
      ``floor_factor=1.15``) to prevent the Dual-Averaging ceiling
-     ``(L / 1.1)`` from binding below the oracle step size.
+     ``(L / 1.1)`` from binding below the oracle step size.  For geometry
+     where the oracle step size exceeds the oracle L (stiff
+     high-condition-number targets), the default 1.15 may leave the DA
+     ceiling binding; raise to approximately 1.5 and set
+     ``adjusted_num_steps`` to at least 5000 for those targets.
 
 Stan-window analogy
 -------------------
@@ -97,10 +101,15 @@ Limitations
   with n_eff/2 clamping.  A NUTS-pilot fallback (replacing Phase 1 with
   :func:`~blackjax.adaptation.window_adaptation.window_adaptation`) is the
   recommended escape hatch but is out of scope here.
-* **Adjusted path experimental.** The ``inner_kernel="adjusted_mclmc"``
-  branch is certified on german_credit but has not yet been validated across
-  a broad benchmark suite.  Treat as experimental; the unadjusted default is
-  the stable path.
+* **Adjusted path experimental.** ``inner_kernel="adjusted_mclmc"`` is
+  certified 3/3 on german_credit at the default recipe (4-chain phase 3,
+  ``frac_tune2=0``, ``floor_factor=1.15``, ``adjusted_num_steps=3000``).
+  ill_cond_50 (stiff, κ=1000) is geometrically compatible (clamp-free at
+  ``floor_factor=1.5``, step size 104–114% of oracle, zero DA divergences)
+  but was NOT certified at ``adjusted_num_steps=3000`` (marginal R-hat
+  1.010–1.011; DA not converged).  For stiff geometry, raise
+  ``floor_factor`` to ~1.5 and ``adjusted_num_steps`` to ≥5000.
+  The unadjusted default remains the stable, broadly validated path.
 """
 
 import warnings
@@ -168,6 +177,20 @@ class MCLMCLRDAdaptationState(NamedTuple):
         ``lrd_step_size``
             Mean step size across ``num_chains`` chains after Phase-3
             unadjusted LRD tuning.
+        ``L_init``
+            *(adjusted path only)* The floor-guarded L initialisation value
+            passed to the adjusted warm-start: ``max(lrd_L, floor_factor *
+            lrd_step_size)``.  This is the value whose ``/ 1.1`` sets the DA
+            ceiling for step-size tuning.
+        ``floor_active``
+            *(adjusted path only)* ``True`` when the floor guard was
+            triggered (``floor_factor * lrd_step_size > lrd_L``), i.e. when
+            ``L_init`` was raised above the unadjusted mean.
+        ``N_sample``
+            *(adjusted path only)* Effective number of leapfrog steps per
+            trajectory at the final adapted parameters:
+            ``round(L_init / final_step_size)``.  Provided as a bookkeeping
+            aid for cert integration.
     """
 
     L: float
@@ -268,6 +291,7 @@ def mclmc_lrd_warmup(
     num_chains: int = 4,
     inner_kernel: str = "mclmc",
     floor_factor: float = 1.15,
+    adjusted_num_steps: int = 3000,
     adjusted_target: float = 0.9,
 ):
     """Scheme A (pilot-free) MCLMC warmup with Low-Rank Diagonal preconditioning.
@@ -321,9 +345,15 @@ def mclmc_lrd_warmup(
     floor_factor
         For ``inner_kernel="adjusted_mclmc"`` only: the L initialisation
         floor is ``max(L_unadj, floor_factor * step_unadj)``.  Default
-        ``1.15``; the guard ensures the Dual-Averaging ceiling ``L / 1.1``
-        cannot bind below the oracle step size.  Ignored when
-        ``inner_kernel="mclmc"``.
+        ``1.15``; certified on german_credit.  For stiff geometry where the
+        oracle step size exceeds the oracle L, raise to approximately 1.5
+        (the default leaves the DA ceiling ``L / 1.1`` binding for those
+        targets).  Ignored when ``inner_kernel="mclmc"``.
+    adjusted_num_steps
+        Number of DA tuning steps for the adjusted Phase-4 path.  Default
+        ``3000`` with ``frac_tune1=0.5`` → 1500 DA steps; the certified
+        recipe for german_credit.  For stiff high-κ geometry, increase to
+        at least 5000.  Ignored when ``inner_kernel="mclmc"``.
     adjusted_target
         Target acceptance rate for the adjusted MCLMC tuning phase.
         Default ``0.9``.  Ignored when ``inner_kernel="mclmc"``.
@@ -556,7 +586,9 @@ def mclmc_lrd_warmup(
         # Hard constraints enforced here (see module docstring):
         #   C1) params != None  →  no sqrt(dim) default L init
         #   C2) frac_tune2=0.0  →  variance-based L estimator disabled
-        L_init = max(lrd_L, floor_factor * lrd_step_size)
+        L_floor = floor_factor * lrd_step_size
+        floor_active = bool(L_floor > lrd_L)
+        L_init = float(max(lrd_L, L_floor))
 
         # Note: inverse_mass_matrix is a placeholder in adj_init_params —
         # adj_lrd_kernel always routes through lrd_imm; using the diagonal
@@ -583,11 +615,12 @@ def mclmc_lrd_warmup(
             _, params, _ = adjusted_mclmc_find_L_and_step_size(
                 mclmc_kernel=adj_lrd_kernel,
                 logdensity_fn=logdensity_fn,
-                num_steps=lrd_num_steps,
+                num_steps=adjusted_num_steps,
                 state=state,
                 rng_key=k,
                 target=adjusted_target,
-                frac_tune2=0.0,  # variance-based L estimator incompatible with LRD IMM
+                frac_tune1=0.5,  # certified recipe: 0.5 × adjusted_num_steps DA steps
+                frac_tune2=0.0,  # REQUIRED: variance-based L estimator incompatible with LRD IMM
                 diagonal_preconditioning=False,  # don't overwrite LRD IMM
                 params=adj_init_params,
             )
@@ -617,6 +650,15 @@ def mclmc_lrd_warmup(
         "lrd_L": lrd_L,
         "lrd_step_size": lrd_step_size,
     }
+
+    # Adjusted-path-only provenance keys (available in scope only for that branch).
+    if inner_kernel == "adjusted_mclmc":
+        diagnostics["L_init"] = L_init
+        diagnostics["floor_active"] = floor_active
+        # N_sample = effective number of leapfrog steps per trajectory at the
+        # final adapted params — the floor-guard inputs that tuningfork cert
+        # integration uses to verify trajectory-length bookkeeping.
+        diagnostics["N_sample"] = round(float(final_L) / max(float(final_step_size), 1e-10))
 
     return MCLMCLRDAdaptationState(
         L=final_L,

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -544,3 +544,176 @@ class TestMCLMCLRDAdjustedSmoke:
             assert (
                 key in result.diagnostics
             ), f"Missing provenance key {key!r} in adjusted path diagnostics"
+
+    def test_adjusted_path_l_init_and_floor_active_in_diagnostics(self):
+        """Adjusted path must expose L_init and floor_active in diagnostics."""
+        rng = jax.random.key(53)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+            )
+        diag = result.diagnostics
+        assert "L_init" in diag, "Missing L_init in adjusted diagnostics"
+        assert "floor_active" in diag, "Missing floor_active in adjusted diagnostics"
+        assert isinstance(diag["floor_active"], bool)
+        assert diag["L_init"] > 0
+
+        # L_init must be >= lrd_L (floor invariant)
+        assert diag["L_init"] >= diag["lrd_L"] - 1e-9
+
+    def test_adjusted_path_n_sample_in_diagnostics(self):
+        """Adjusted path must expose N_sample = round(L_init / final_step_size)."""
+        rng = jax.random.key(57)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+            )
+        diag = result.diagnostics
+        assert "N_sample" in diag, "Missing N_sample in adjusted diagnostics"
+        assert isinstance(diag["N_sample"], (int, float)), "N_sample must be numeric"
+        assert diag["N_sample"] > 0, "N_sample must be positive"
+        # Verify the value matches round(L_init / final_step_size) within rounding.
+        expected = float(diag["L_init"]) / float(result.step_size)
+        assert abs(diag["N_sample"] - expected) < 1.0  # within one step
+
+    def test_unadjusted_path_has_no_l_init_floor_active(self):
+        """Unadjusted path must NOT have L_init or floor_active in diagnostics."""
+        rng = jax.random.key(54)
+        pos = jnp.zeros(D)
+        result = mclmc_lrd_warmup(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+            num_chains=2,
+            inner_kernel="mclmc",
+        )
+        assert "L_init" not in result.diagnostics
+        assert "floor_active" not in result.diagnostics
+
+    def test_floor_active_true_when_step_dominates(self):
+        """floor_active must be True when floor_factor*step_size > lrd_L."""
+        # Use a very large floor_factor to force the floor to activate.
+        rng = jax.random.key(55)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+                floor_factor=1000.0,  # guarantee floor triggers
+            )
+        diag = result.diagnostics
+        assert (
+            diag["floor_active"] is True
+        ), "Expected floor_active=True with factor=1000"
+        # L_init should equal floor_factor * lrd_step_size (within float precision)
+        expected = 1000.0 * diag["lrd_step_size"]
+        assert abs(diag["L_init"] - expected) < 1e-5 * expected
+
+    def test_floor_inactive_when_l_already_large(self):
+        """floor_active must be False when lrd_L > floor_factor*lrd_step_size."""
+        # floor_factor=0.0 ensures L_init = lrd_L (floor never active).
+        rng = jax.random.key(56)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+                floor_factor=0.0,  # floor never triggers
+            )
+        diag = result.diagnostics
+        assert (
+            diag["floor_active"] is False
+        ), "Expected floor_active=False with factor=0"
+        # L_init should equal lrd_L exactly (no floor applied)
+        assert abs(diag["L_init"] - diag["lrd_L"]) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# frac_tune2=0 invariant test via monkeypatch
+# ---------------------------------------------------------------------------
+
+
+class TestAdjustedFracTune2Invariant:
+    """Verify that frac_tune2 is always 0.0 in the adjusted tuning call."""
+
+    def test_frac_tune2_is_zero_in_adjusted_call(self, monkeypatch):
+        """Monkeypatch adjusted_mclmc_find_L_and_step_size to capture kwargs."""
+        import blackjax.adaptation.mclmc_lrd_adaptation as _mod
+
+        captured_kwargs = {}
+        original_fn = _mod.adjusted_mclmc_find_L_and_step_size
+
+        def capturing_fn(*args, **kwargs):  # noqa: F841 (original_fn used in body)
+            captured_kwargs.update(kwargs)
+            return original_fn(*args, **kwargs)
+
+        monkeypatch.setattr(_mod, "adjusted_mclmc_find_L_and_step_size", capturing_fn)
+
+        rng = jax.random.key(60)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+            )
+
+        assert "frac_tune2" in captured_kwargs, "frac_tune2 not passed as kwarg"
+        assert (
+            captured_kwargs["frac_tune2"] == 0.0
+        ), f"Expected frac_tune2=0.0, got {captured_kwargs['frac_tune2']}"
+        assert (
+            captured_kwargs.get("diagonal_preconditioning") is False
+        ), "diagonal_preconditioning must be False to preserve LRD IMM"

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -294,3 +294,91 @@ class TestMCLMCLRDAdaptationSmoke:
         # d = 3 + 2 = 5
         assert result.inverse_mass_matrix.sigma.shape == (5,)
         assert result.inverse_mass_matrix.U.shape == (5, 2)
+
+    def test_diagnostics_inner_kernel_field(self):
+        """diagnostics must include inner_kernel field matching the argument."""
+        rng = jax.random.key(46)
+        pos = jnp.zeros(D)
+        result = mclmc_lrd_adaptation(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+            inner_kernel="mclmc",
+        )
+        assert result.diagnostics["inner_kernel"] == "mclmc"
+
+    def test_invalid_inner_kernel_raises(self):
+        """Passing an unknown inner_kernel must raise ValueError immediately."""
+        with pytest.raises(ValueError, match="inner_kernel"):
+            mclmc_lrd_adaptation(
+                logdensity_fn,
+                jnp.zeros(D),
+                jax.random.key(0),
+                inner_kernel="nuts",
+            )
+
+
+class TestMCLMCLRDAdjustedSmoke:
+    """Smoke tests for the adjusted_mclmc inner-kernel path (experimental)."""
+
+    def test_adjusted_path_returns_valid_state(self):
+        """inner_kernel='adjusted_mclmc' must return a valid MCLMCLRDAdaptationState."""
+        rng = jax.random.key(50)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_adaptation(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=200,
+            pilot_num_samples=400,
+            lrd_num_steps=200,
+            inner_kernel="adjusted_mclmc",
+        )
+
+        assert isinstance(result, MCLMCLRDAdaptationState)
+        assert jnp.isfinite(result.L) and result.L > 0
+        assert jnp.isfinite(result.step_size) and result.step_size > 0
+        assert isinstance(result.inverse_mass_matrix, LowRankInverseMassMatrix)
+        assert result.diagnostics["inner_kernel"] == "adjusted_mclmc"
+        assert result.inverse_mass_matrix.sigma.shape == (D,)
+        assert result.inverse_mass_matrix.U.shape == (D, K)
+        assert result.inverse_mass_matrix.lam.shape == (K,)
+
+    def test_adjusted_path_lrd_imm_usable_with_adjusted_kernel(self):
+        """LRD IMM from adjusted path must plug into adjusted_mclmc kernel."""
+        import blackjax.mcmc.adjusted_mclmc as adj_mod
+
+        rng = jax.random.key(51)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_adaptation(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+            inner_kernel="adjusted_mclmc",
+        )
+
+        lrd_imm = result.inverse_mass_matrix
+        adj_kernel = adj_mod.build_kernel()
+        init_state = adj_mod.init(pos, logdensity_fn)
+
+        next_state, info = adj_kernel(
+            rng_key=jax.random.key(99),
+            state=init_state,
+            logdensity_fn=logdensity_fn,
+            step_size=result.step_size,
+            inverse_mass_matrix=lrd_imm,
+        )
+        assert jnp.all(
+            jnp.isfinite(jax.flatten_util.ravel_pytree(next_state.position)[0])
+        )

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -1,0 +1,296 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for mclmc_lrd_adaptation (Scheme A, pilot-free LRD warmup)."""
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+import blackjax
+from blackjax.adaptation.mclmc_lrd_adaptation import (
+    MCLMCLRDAdaptationState,
+    _extract_lrd_from_samples,
+    mclmc_lrd_adaptation,
+)
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
+
+# ---------------------------------------------------------------------------
+# Shared fixture: isotropic Gaussian (d=6)
+# ---------------------------------------------------------------------------
+
+D = 6
+K = 3  # rank for most tests
+
+
+def logdensity_fn(x):
+    return -0.5 * jnp.sum(x**2)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _extract_lrd_from_samples
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLrd:
+    """Shape and contract tests for the internal SVD extraction helper."""
+
+    def test_output_shapes(self):
+        """sigma (d,), U (d,k), lam (k,) for any valid n>k."""
+        rng = jax.random.key(0)
+        d, n, k = 8, 50, 3
+        samples = jax.random.normal(rng, (n, d))
+        sigma, U, lam = _extract_lrd_from_samples(samples, k=k)
+        assert sigma.shape == (d,)
+        assert U.shape == (d, k)
+        assert lam.shape == (k,)
+
+    def test_sigma_positive(self):
+        """All diagonal scales must be strictly positive."""
+        rng = jax.random.key(1)
+        samples = jax.random.normal(rng, (30, 5))
+        sigma, _, _ = _extract_lrd_from_samples(samples, k=2)
+        assert jnp.all(sigma > 0)
+
+    def test_zero_variance_dim_gets_unit_sigma(self):
+        """A dimension with zero variance must not produce NaN/Inf sigma."""
+        rng = jax.random.key(2)
+        samples = jax.random.normal(rng, (30, 4))
+        # Force dim-0 to constant (zero variance)
+        samples = samples.at[:, 0].set(0.0)
+        sigma, _, _ = _extract_lrd_from_samples(samples, k=2)
+        assert jnp.all(jnp.isfinite(sigma))
+        assert sigma[0] == pytest.approx(1.0)  # clamped to 1 for zero-var dim
+
+    def test_columns_of_U_are_unit_vectors(self):
+        """Each column of U should be (approximately) unit-norm."""
+        rng = jax.random.key(3)
+        samples = jax.random.normal(rng, (100, 10))
+        _, U, _ = _extract_lrd_from_samples(samples, k=4)
+        col_norms = jnp.linalg.norm(U, axis=0)
+        assert jnp.allclose(col_norms, jnp.ones(4), atol=1e-5)
+
+    def test_isotropic_lam_near_one(self):
+        """For an isotropic Gaussian, all eigenvalues should be close to 1."""
+        rng = jax.random.key(4)
+        n, d, k = 5000, 6, 3
+        samples = jax.random.normal(rng, (n, d))
+        _, _, lam = _extract_lrd_from_samples(samples, k=k)
+        assert jnp.allclose(lam, jnp.ones(k), atol=0.15)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: rank guard
+# ---------------------------------------------------------------------------
+
+
+class TestRankGuard:
+    """Rank-guard clamping and warning behaviour."""
+
+    def test_clamp_k_when_pilot_under_mixed(self):
+        """When k > n_eff/2, k_used must equal k_safe and a warning must fire."""
+        # Tiny pilot that cannot give high ESS: n=10 draws, request k=20
+        rng = jax.random.key(5)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = mclmc_lrd_adaptation(
+                logdensity_fn,
+                pos,
+                rng,
+                k=20,
+                pilot_num_warmup=50,
+                pilot_num_samples=10,  # very few draws → low ESS
+                lrd_num_steps=50,
+            )
+
+        assert isinstance(result, MCLMCLRDAdaptationState)
+        diag = result.diagnostics
+        # k_used must be ≤ k_safe
+        assert (
+            diag["k_used"] <= diag["k_safe"]
+        ), f"k_used={diag['k_used']} > k_safe={diag['k_safe']}"
+        # Should have emitted a UserWarning about clamping
+        assert any(
+            issubclass(w.category, UserWarning) for w in caught
+        ), "Expected a UserWarning about rank clamping but none was emitted"
+
+    def test_no_warning_when_k_within_bound(self):
+        """When k ≤ n_eff/2, no clamping warning should be emitted."""
+        rng = jax.random.key(6)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = mclmc_lrd_adaptation(
+                logdensity_fn,
+                pos,
+                rng,
+                k=1,  # very low rank — should always be within n_eff/2
+                pilot_num_warmup=100,
+                pilot_num_samples=500,
+                lrd_num_steps=50,
+            )
+
+        clamp_warnings = [
+            w
+            for w in caught
+            if issubclass(w.category, UserWarning)
+            and "rank-safety" in str(w.message).lower()
+        ]
+        assert (
+            len(clamp_warnings) == 0
+        ), f"Unexpected rank-clamp warning for k=1: {clamp_warnings}"
+        assert result.diagnostics["k_used"] == 1
+
+    def test_k_safe_at_least_one(self):
+        """k_used must be at least 1 even when the pilot is tiny and n_eff rounds to 0."""
+        rng = jax.random.key(7)
+        pos = jnp.zeros(D)
+        # Very small pilot (2 draws) → n_eff ≤ 2 → k_safe likely 0 or 1 → clamped to ≥1
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result = mclmc_lrd_adaptation(
+                logdensity_fn,
+                pos,
+                rng,
+                k=5,
+                pilot_num_warmup=30,
+                pilot_num_samples=2,
+                lrd_num_steps=30,
+            )
+        assert result.diagnostics["k_used"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke test: isotropic Gaussian (CI-friendly, no heavy compute)
+# ---------------------------------------------------------------------------
+
+
+class TestMCLMCLRDAdaptationSmoke:
+    """End-to-end shape + contract checks on a cheap Gaussian target."""
+
+    def test_return_type_and_shapes(self):
+        """Result is MCLMCLRDAdaptationState with correct field types and shapes."""
+        rng = jax.random.key(42)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_adaptation(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=200,
+            pilot_num_samples=400,
+            lrd_num_steps=200,
+        )
+
+        assert isinstance(result, MCLMCLRDAdaptationState)
+        assert jnp.isfinite(result.L) and result.L > 0
+        assert jnp.isfinite(result.step_size) and result.step_size > 0
+        assert isinstance(result.inverse_mass_matrix, LowRankInverseMassMatrix)
+
+        imm = result.inverse_mass_matrix
+        assert imm.sigma.shape == (D,)
+        assert imm.U.shape == (D, K)
+        assert imm.lam.shape == (K,)
+        assert jnp.all(jnp.isfinite(imm.sigma))
+        assert jnp.all(jnp.isfinite(imm.U))
+        assert jnp.all(jnp.isfinite(imm.lam))
+
+    def test_diagnostics_keys_and_types(self):
+        """diagnostics dict must contain n_eff, k_safe, k_used, pilot_num_grad_evals."""
+        rng = jax.random.key(43)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_adaptation(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+        )
+        diag = result.diagnostics
+        for key in ("n_eff", "k_safe", "k_used", "pilot_num_grad_evals"):
+            assert key in diag, f"Missing diagnostics key: {key}"
+
+        assert diag["k_used"] <= K
+        assert diag["k_used"] >= 1
+        assert diag["k_safe"] >= 0
+        assert diag["n_eff"] > 0
+        assert diag["pilot_num_grad_evals"] == (100 + 200) * 2
+
+    def test_top_level_api_exposed(self):
+        """blackjax.mclmc_lrd_adaptation must resolve to the correct function."""
+        assert blackjax.mclmc_lrd_adaptation is mclmc_lrd_adaptation
+
+    def test_lrd_imm_usable_with_mclmc_kernel(self):
+        """The returned LRD IMM must plug into the mclmc base kernel without error."""
+        import blackjax.mcmc.mclmc as mclmc_mod
+
+        rng = jax.random.key(44)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_adaptation(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+        )
+
+        lrd_imm = result.inverse_mass_matrix
+        base_kernel = mclmc_mod.build_kernel()
+        init_state = mclmc_mod.init(pos, logdensity_fn, jax.random.key(99))
+
+        next_state, info = base_kernel(
+            rng_key=jax.random.key(100),
+            state=init_state,
+            logdensity_fn=logdensity_fn,
+            inverse_mass_matrix=lrd_imm,
+            L=result.L,
+            step_size=result.step_size,
+        )
+        assert jnp.all(
+            jnp.isfinite(jax.flatten_util.ravel_pytree(next_state.position)[0])
+        )
+
+    def test_pytree_position(self):
+        """mclmc_lrd_adaptation must work when position is a dict pytree."""
+        rng = jax.random.key(45)
+        pos = {"a": jnp.zeros(3), "b": jnp.zeros(2)}
+
+        def logp_dict(x):
+            return -0.5 * (jnp.sum(x["a"] ** 2) + jnp.sum(x["b"] ** 2))
+
+        result = mclmc_lrd_adaptation(
+            logp_dict,
+            pos,
+            rng,
+            k=2,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+        )
+
+        assert isinstance(result, MCLMCLRDAdaptationState)
+        # d = 3 + 2 = 5
+        assert result.inverse_mass_matrix.sigma.shape == (5,)
+        assert result.inverse_mass_matrix.U.shape == (5, 2)

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for mclmc_lrd_adaptation (Scheme A, pilot-free LRD warmup)."""
+"""Tests for mclmc_lrd_warmup (Scheme A, pilot-free LRD warmup)."""
 
 import warnings
 
@@ -22,8 +22,9 @@ import pytest
 import blackjax
 from blackjax.adaptation.mclmc_lrd_adaptation import (
     MCLMCLRDAdaptationState,
+    _check_da_ceiling_warning,
     _extract_lrd_from_samples,
-    mclmc_lrd_adaptation,
+    mclmc_lrd_warmup,
 )
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 
@@ -107,7 +108,7 @@ class TestRankGuard:
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            result = mclmc_lrd_adaptation(
+            result = mclmc_lrd_warmup(
                 logdensity_fn,
                 pos,
                 rng,
@@ -115,6 +116,7 @@ class TestRankGuard:
                 pilot_num_warmup=50,
                 pilot_num_samples=10,  # very few draws → low ESS
                 lrd_num_steps=50,
+                num_chains=2,
             )
 
         assert isinstance(result, MCLMCLRDAdaptationState)
@@ -135,7 +137,7 @@ class TestRankGuard:
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            result = mclmc_lrd_adaptation(
+            result = mclmc_lrd_warmup(
                 logdensity_fn,
                 pos,
                 rng,
@@ -143,6 +145,7 @@ class TestRankGuard:
                 pilot_num_warmup=100,
                 pilot_num_samples=500,
                 lrd_num_steps=50,
+                num_chains=2,
             )
 
         clamp_warnings = [
@@ -157,13 +160,13 @@ class TestRankGuard:
         assert result.diagnostics["k_used"] == 1
 
     def test_k_safe_at_least_one(self):
-        """k_used must be at least 1 even when the pilot is tiny and n_eff rounds to 0."""
+        """k_used must be at least 1 even when the pilot is tiny."""
         rng = jax.random.key(7)
         pos = jnp.zeros(D)
         # Very small pilot (2 draws) → n_eff ≤ 2 → k_safe likely 0 or 1 → clamped to ≥1
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            result = mclmc_lrd_adaptation(
+            result = mclmc_lrd_warmup(
                 logdensity_fn,
                 pos,
                 rng,
@@ -171,16 +174,17 @@ class TestRankGuard:
                 pilot_num_warmup=30,
                 pilot_num_samples=2,
                 lrd_num_steps=30,
+                num_chains=2,
             )
         assert result.diagnostics["k_used"] >= 1
 
 
 # ---------------------------------------------------------------------------
-# Integration smoke test: isotropic Gaussian (CI-friendly, no heavy compute)
+# Integration smoke tests: isotropic Gaussian (CI-friendly, no heavy compute)
 # ---------------------------------------------------------------------------
 
 
-class TestMCLMCLRDAdaptationSmoke:
+class TestMCLMCLRDWarmupSmoke:
     """End-to-end shape + contract checks on a cheap Gaussian target."""
 
     def test_return_type_and_shapes(self):
@@ -188,7 +192,7 @@ class TestMCLMCLRDAdaptationSmoke:
         rng = jax.random.key(42)
         pos = jnp.zeros(D)
 
-        result = mclmc_lrd_adaptation(
+        result = mclmc_lrd_warmup(
             logdensity_fn,
             pos,
             rng,
@@ -196,6 +200,7 @@ class TestMCLMCLRDAdaptationSmoke:
             pilot_num_warmup=200,
             pilot_num_samples=400,
             lrd_num_steps=200,
+            num_chains=2,
         )
 
         assert isinstance(result, MCLMCLRDAdaptationState)
@@ -211,12 +216,12 @@ class TestMCLMCLRDAdaptationSmoke:
         assert jnp.all(jnp.isfinite(imm.U))
         assert jnp.all(jnp.isfinite(imm.lam))
 
-    def test_diagnostics_keys_and_types(self):
-        """diagnostics dict must contain n_eff, k_safe, k_used, pilot_num_grad_evals."""
-        rng = jax.random.key(43)
+    def test_L_and_step_size_are_scalars(self):
+        """Phase-3 multi-chain averaging must produce scalar L and step_size."""
+        rng = jax.random.key(48)
         pos = jnp.zeros(D)
 
-        result = mclmc_lrd_adaptation(
+        result = mclmc_lrd_warmup(
             logdensity_fn,
             pos,
             rng,
@@ -224,6 +229,30 @@ class TestMCLMCLRDAdaptationSmoke:
             pilot_num_warmup=100,
             pilot_num_samples=200,
             lrd_num_steps=100,
+            num_chains=4,
+        )
+
+        assert (
+            jnp.ndim(result.L) == 0
+        ), f"Expected scalar L after multi-chain mean, got shape {jnp.shape(result.L)}"
+        assert (
+            jnp.ndim(result.step_size) == 0
+        ), f"Expected scalar step_size, got shape {jnp.shape(result.step_size)}"
+
+    def test_diagnostics_keys_and_types(self):
+        """diagnostics dict must contain n_eff, k_safe, k_used, pilot_num_grad_evals."""
+        rng = jax.random.key(43)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_warmup(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+            num_chains=2,
         )
         diag = result.diagnostics
         for key in ("n_eff", "k_safe", "k_used", "pilot_num_grad_evals"):
@@ -235,9 +264,32 @@ class TestMCLMCLRDAdaptationSmoke:
         assert diag["n_eff"] > 0
         assert diag["pilot_num_grad_evals"] == (100 + 200) * 2
 
+    def test_diagnostics_provenance_keys(self):
+        """diagnostics must contain pilot_L, pilot_step_size, lrd_L, lrd_step_size."""
+        rng = jax.random.key(47)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_warmup(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=100,
+            pilot_num_samples=200,
+            lrd_num_steps=100,
+            num_chains=2,
+        )
+        diag = result.diagnostics
+        for key in ("pilot_L", "pilot_step_size", "lrd_L", "lrd_step_size"):
+            assert key in diag, f"Missing diagnostics provenance key: {key}"
+        assert diag["pilot_L"] > 0
+        assert diag["pilot_step_size"] > 0
+        assert diag["lrd_L"] > 0
+        assert diag["lrd_step_size"] > 0
+
     def test_top_level_api_exposed(self):
-        """blackjax.mclmc_lrd_adaptation must resolve to the correct function."""
-        assert blackjax.mclmc_lrd_adaptation is mclmc_lrd_adaptation
+        """blackjax.mclmc_lrd_warmup must resolve to the correct function."""
+        assert blackjax.mclmc_lrd_warmup is mclmc_lrd_warmup
 
     def test_lrd_imm_usable_with_mclmc_kernel(self):
         """The returned LRD IMM must plug into the mclmc base kernel without error."""
@@ -246,7 +298,7 @@ class TestMCLMCLRDAdaptationSmoke:
         rng = jax.random.key(44)
         pos = jnp.zeros(D)
 
-        result = mclmc_lrd_adaptation(
+        result = mclmc_lrd_warmup(
             logdensity_fn,
             pos,
             rng,
@@ -254,6 +306,7 @@ class TestMCLMCLRDAdaptationSmoke:
             pilot_num_warmup=100,
             pilot_num_samples=200,
             lrd_num_steps=100,
+            num_chains=2,
         )
 
         lrd_imm = result.inverse_mass_matrix
@@ -273,14 +326,14 @@ class TestMCLMCLRDAdaptationSmoke:
         )
 
     def test_pytree_position(self):
-        """mclmc_lrd_adaptation must work when position is a dict pytree."""
+        """mclmc_lrd_warmup must work when position is a dict pytree."""
         rng = jax.random.key(45)
         pos = {"a": jnp.zeros(3), "b": jnp.zeros(2)}
 
         def logp_dict(x):
             return -0.5 * (jnp.sum(x["a"] ** 2) + jnp.sum(x["b"] ** 2))
 
-        result = mclmc_lrd_adaptation(
+        result = mclmc_lrd_warmup(
             logp_dict,
             pos,
             rng,
@@ -288,6 +341,7 @@ class TestMCLMCLRDAdaptationSmoke:
             pilot_num_warmup=100,
             pilot_num_samples=200,
             lrd_num_steps=100,
+            num_chains=2,
         )
 
         assert isinstance(result, MCLMCLRDAdaptationState)
@@ -299,7 +353,7 @@ class TestMCLMCLRDAdaptationSmoke:
         """diagnostics must include inner_kernel field matching the argument."""
         rng = jax.random.key(46)
         pos = jnp.zeros(D)
-        result = mclmc_lrd_adaptation(
+        result = mclmc_lrd_warmup(
             logdensity_fn,
             pos,
             rng,
@@ -307,6 +361,7 @@ class TestMCLMCLRDAdaptationSmoke:
             pilot_num_warmup=100,
             pilot_num_samples=200,
             lrd_num_steps=100,
+            num_chains=2,
             inner_kernel="mclmc",
         )
         assert result.diagnostics["inner_kernel"] == "mclmc"
@@ -314,12 +369,87 @@ class TestMCLMCLRDAdaptationSmoke:
     def test_invalid_inner_kernel_raises(self):
         """Passing an unknown inner_kernel must raise ValueError immediately."""
         with pytest.raises(ValueError, match="inner_kernel"):
-            mclmc_lrd_adaptation(
+            mclmc_lrd_warmup(
                 logdensity_fn,
                 jnp.zeros(D),
                 jax.random.key(0),
                 inner_kernel="nuts",
             )
+
+
+# ---------------------------------------------------------------------------
+# Unit test: DA-ceiling warning helper
+# ---------------------------------------------------------------------------
+
+
+class TestDACeilingWarning:
+    """Tests for the DA-ceiling warning logic in _check_da_ceiling_warning."""
+
+    def test_warning_fires_when_at_ceiling(self):
+        """Warning must fire when step_size / (L_init/1.1) >= 0.999."""
+        L_init = 10.0
+        da_clamp = L_init / 1.1  # 9.0909...
+        # Set step_size to exactly the clamp (ratio = 1.0)
+        step_size = da_clamp
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _check_da_ceiling_warning(step_size, L_init, floor_factor=1.15)
+
+        ceiling_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert (
+            len(ceiling_warnings) > 0
+        ), "Expected DA-ceiling UserWarning but none was emitted"
+        assert "ceiling" in str(ceiling_warnings[0].message).lower()
+
+    def test_warning_fires_near_ceiling(self):
+        """Warning must fire when ratio >= 0.999 (just below ceiling)."""
+        L_init = 10.0
+        da_clamp = L_init / 1.1
+        step_size = da_clamp * 0.9995  # ratio = 0.9995 >= 0.999
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _check_da_ceiling_warning(step_size, L_init, floor_factor=1.15)
+
+        assert any(
+            issubclass(w.category, UserWarning) for w in caught
+        ), "Expected warning at ratio=0.9995 but none fired"
+
+    def test_no_warning_when_well_below_ceiling(self):
+        """No warning when step_size is well below DA ceiling."""
+        L_init = 10.0
+        da_clamp = L_init / 1.1
+        step_size = da_clamp * 0.8  # ratio = 0.8 << 0.999
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _check_da_ceiling_warning(step_size, L_init, floor_factor=1.15)
+
+        ceiling_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert (
+            len(ceiling_warnings) == 0
+        ), f"Unexpected DA-ceiling warning at ratio=0.8: {ceiling_warnings}"
+
+    def test_warning_mentions_floor_factor(self):
+        """Warning message must reference floor_factor for actionable guidance."""
+        L_init = 5.0
+        step_size = L_init / 1.1  # at ceiling
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            _check_da_ceiling_warning(step_size, L_init, floor_factor=1.15)
+
+        assert len(caught) > 0
+        msg = str(caught[0].message).lower()
+        assert (
+            "floor_factor" in msg
+        ), "Warning message should mention floor_factor for actionable guidance"
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for adjusted path
+# ---------------------------------------------------------------------------
 
 
 class TestMCLMCLRDAdjustedSmoke:
@@ -330,16 +460,22 @@ class TestMCLMCLRDAdjustedSmoke:
         rng = jax.random.key(50)
         pos = jnp.zeros(D)
 
-        result = mclmc_lrd_adaptation(
-            logdensity_fn,
-            pos,
-            rng,
-            k=K,
-            pilot_num_warmup=200,
-            pilot_num_samples=400,
-            lrd_num_steps=200,
-            inner_kernel="adjusted_mclmc",
-        )
+        # DA-ceiling warning may fire for this cheap isotropic Gaussian (where
+        # floor_factor * step_mclmc ≈ L_mclmc, so L_init/1.1 ≈ step_size).
+        # That is expected/correct behaviour — suppress it for this smoke test.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=200,
+                pilot_num_samples=400,
+                lrd_num_steps=200,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+            )
 
         assert isinstance(result, MCLMCLRDAdaptationState)
         assert jnp.isfinite(result.L) and result.L > 0
@@ -357,16 +493,19 @@ class TestMCLMCLRDAdjustedSmoke:
         rng = jax.random.key(51)
         pos = jnp.zeros(D)
 
-        result = mclmc_lrd_adaptation(
-            logdensity_fn,
-            pos,
-            rng,
-            k=K,
-            pilot_num_warmup=100,
-            pilot_num_samples=200,
-            lrd_num_steps=100,
-            inner_kernel="adjusted_mclmc",
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+            )
 
         lrd_imm = result.inverse_mass_matrix
         adj_kernel = adj_mod.build_kernel()
@@ -382,3 +521,26 @@ class TestMCLMCLRDAdjustedSmoke:
         assert jnp.all(
             jnp.isfinite(jax.flatten_util.ravel_pytree(next_state.position)[0])
         )
+
+    def test_adjusted_path_provenance_keys_present(self):
+        """Adjusted path must also populate pilot_L/step_size and lrd_L/step_size."""
+        rng = jax.random.key(52)
+        pos = jnp.zeros(D)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                inner_kernel="adjusted_mclmc",
+            )
+        for key in ("pilot_L", "pilot_step_size", "lrd_L", "lrd_step_size"):
+            assert (
+                key in result.diagnostics
+            ), f"Missing provenance key {key!r} in adjusted path diagnostics"


### PR DESCRIPTION
## Summary

Adds `blackjax.mclmc_lrd_adaptation` — a self-contained three-phase Scheme A warmup that produces a calibrated `(L, step_size, LowRankInverseMassMatrix)` for unadjusted MCLMC without a NUTS pilot.

### Algorithm (phases)

1. **Diagonal pilot** — single unadjusted MCLMC chain with `mclmc_find_L_and_step_size(diagonal_preconditioning=True)` to reach the typical set and collect geometry samples.
2. **SVD extraction** — standardise pilot draws, thin SVD → `LowRankInverseMassMatrix(sigma, U, lam)` retaining the top-k directions by |λ−1|.
3. **LRD tuning** — re-run `mclmc_find_L_and_step_size(diagonal_preconditioning=False)` with a LRD metric kernel, calibrating step_size and L to the true posterior geometry.

### Stan-window analogy

The staging mirrors Stan's two-phase warmup: a cheap diagonal (fast) phase reaches the typical set first; the LRD (slow) phase builds the metric from draws already in the right region. Both phases use MCLMC (unadjusted, leapfrog-free), eliminating the NUTS pilot cost that dominated total gradient expenditure in benchmarks.

### Rank guard (non-negotiable)

Before SVD, `n_eff` is estimated via `blackjax.diagnostics.effective_sample_size` (Geyer monotone-sequence estimator on the ravelled flat-parameter vector; basis documented in docstring). `k` is hard-clamped to `floor(n_eff / 2)` with a `UserWarning` when clamping occurs.

**Why:** without the guard, under-mixed pilots produce rank-deficient SVDs. Observed failure mode: ill_cond_50 at k=40, n_pilot=1k, n_eff≈30 → k_safe=15. Cert passed only once n_pilot≥10k kept k≤n_eff/2.

### Benchmark evidence (tuningfork cert runs, seeds 77777/88888/99999, 3/3 PASS)

| Model | d | k | n_pilot | ESS/total-grad vs NUTS-pilot | Oracle step-size | Grad savings |
|-------|---|---|---------|------------------------------|-----------------|--------------|
| ill_cond_50 | 50 | 40 | 10k | 2.42× | 101.1% | 72.5% |
| german_credit | 26 | 8 | 5k | | | |
| mvn_10 | 10 | 4 | 2k | | | |

### New public API

```python
result = blackjax.mclmc_lrd_adaptation(
    logdensity_fn, position, rng_key,
    k=10, pilot_num_warmup=1000, pilot_num_samples=5000, lrd_num_steps=1000,
)
# result.L, result.step_size, result.inverse_mass_matrix, result.diagnostics
```

### Design choice: new file vs extending mclmc_adaptation.py

New file chosen because: new return type (`MCLMCLRDAdaptationState`), substantially different docstring (3-phase, rank guard, benchmarks, limitations), adjusted-MCLMC extension is out of scope and needs a different entry point. Matches the `low_rank_adaptation.py` / `adjusted_mclmc_adaptation.py` separation pattern.

### Known limitations (documented in module docstring)

- Unadjusted only — adjusted MCLMC + LRD is future work
- Single-chain pilot — multi-chain init would give tighter n_eff
- NUTS-pilot fallback for funnel-class geometry is the intended future hook

### Tests (13/13 ✅)

- `TestExtractLrd` (5): shapes, sigma positivity, zero-var dims, orthonormality, isotropic eigenvalues
- `TestRankGuard` (3): clamp + UserWarning, no warning within bound, k_used≥1
- `TestMCLMCLRDAdaptationSmoke` (5): return types/shapes, diagnostics, top-level API, LRD-kernel round-trip, dict-pytree position

## Test plan

- [x] 13 new tests passing locally
- [x] pre-commit clean (flake8, black, mypy, isort, pyupgrade)
- [ ] CI on full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)