### PR TITLE
feat(adaptation): gated √d warm-start for mclmc_lrd_warmup

### DIFF
--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -140,6 +140,22 @@ __all__ = [
 ]
 
 _VALID_INNER_KERNELS = frozenset({"mclmc", "adjusted_mclmc"})
+_VALID_WARMUP_STEP_INITS = frozenset({"law", "default"})
+
+# √d scaling-law constants from the MCLMC scaling-laws study (S3).
+# At good preconditioning (κ_eff ≲ 5), the optimal step and trajectory length
+# scale as constant × √d with dimension-independent constants:
+#   step ≈ 1.22 × √d,  L ≈ 0.85 × √d.
+# Source: tuningfork/experiments/mclmc_scaling/ Q0 sweep (2026-06).
+_SQRT_D_STEP_CONST = 1.22
+_SQRT_D_L_CONST = 0.85
+
+# κ_eff gate for the √d warm-start (E1).  When the pilot-derived LRD IMM
+# achieves κ_eff ≤ this threshold, the geometry is sufficiently whitened for
+# the scaling-law warm-start to be accurate.  κ_eff > 5 indicates the IMM is
+# not yet whitening the target; falling back to the pilot's own (step, L)
+# avoids overshooting the tuning region.
+_KAPPA_EFF_GATE = 5.0
 
 
 class MCLMCLRDAdaptationState(NamedTuple):
@@ -194,6 +210,17 @@ class MCLMCLRDAdaptationState(NamedTuple):
             trajectory at the final adapted parameters:
             ``round(L_init / final_step_size)``.  Provided as a bookkeeping
             aid for cert integration.
+        ``e1_fired``
+            ``True`` when the √d warm-start (E1) was applied to Phase-3 DA
+            initialisation; ``False`` when the fallback (pilot step/L) was
+            used instead.  Always ``False`` when ``warmup_step_init="default"``.
+        ``kappa_eff_pilot``
+            Effective condition number κ(M⁻¹ Σ⁻¹) of the pilot-derived LRD
+            IMM against the pilot sample covariance.  Computed from the Phase-2
+            SVD eigenspectrum.  Values near 1 indicate good whitening; values
+            above 5 indicate the IMM is under-preconditioned (E1 falls back to
+            pilot step/L).  Present whenever ``warmup_step_init`` is set (both
+            ``"law"`` and ``"default"`` paths compute it for observability).
     """
 
     L: float
@@ -220,6 +247,12 @@ def _extract_lrd_from_samples(
     sigma : shape ``(d,)``
     U     : shape ``(d, k)``
     lam   : shape ``(k,)``
+    lam_all : shape ``(min(n, d),)``
+        **Full** eigenspectrum of the sample correlation matrix (all singular
+        values, not just the top-k).  Returned for :func:`_kappa_eff_pilot`
+        so it can compute the residual contribution to κ_eff without a second
+        SVD.  The ordering here is by descending ``|λ - 1|``, matching the
+        selection order used for ``lam`` (i.e. ``lam == lam_all[:k]``).
     """
     mean = jnp.mean(flat_positions, axis=0)  # (d,)
     sigma = jnp.std(flat_positions, axis=0)  # (d,)
@@ -240,7 +273,91 @@ def _extract_lrd_from_samples(
 
     lam_k = lam[top_idx]  # (k,)
     U_k = V[:, top_idx]  # (d, k)
-    return sigma, U_k, lam_k
+    lam_all_sorted = lam[sort_idx]  # full spectrum, ordered by |λ-1| desc
+    return sigma, U_k, lam_k, lam_all_sorted
+
+
+def _kappa_eff_pilot(
+    lam_all_sorted: Any,
+    k: int,
+) -> float:
+    """Effective condition number of the pilot LRD IMM against the pilot Sigma.
+
+    Computes κ_eff = κ(M⁻¹ Σ⁻¹) from the full SVD eigenspectrum produced
+    in Phase 2, using the correct accounting of whitened vs. residual directions.
+
+    **Correct formula** (the LRD preconditioning theory):
+
+    The LRD IMM M⁻¹ captures the top-k principal directions of the sample
+    correlation matrix (those with ``|λ - 1|`` largest).  In the M⁻¹Σ⁻¹
+    product:
+
+    * The **k captured** directions are whitened to eigenvalue **1** — M⁻¹
+      exactly inverts Σ along those directions.
+    * The **residual** (d − k) directions, with correlation eigenvalues
+      ``μ_i`` (the *k+1*, *k+2*, … entries of ``lam_all_sorted``), are left
+      as *diagonal*-only (M⁻¹ = D² along those directions).  In the
+      correlation-normalised space, the diagonal correction gives eigenvalue
+      ``1/μ_i`` for each residual direction.
+
+    Hence the spectrum of M⁻¹Σ⁻¹ is:
+
+        {1} × k  ∪  {1/μ_i : i ∈ residual}
+
+    and κ_eff = max / min of this combined set.
+
+    **Why the na‌ive {lam_k ∪ {1}} formula is wrong:** it uses the captured
+    eigenvalues (those with ``|λ - 1|`` largest) in the numerator/denominator,
+    which are exactly the directions that *are* whitened.  The actual spread
+    comes from the *residual* directions, whose ``μ_i`` are closest to 1 and
+    therefore ``1/μ_i`` can still be far from 1 when some residuals are very
+    small (under-corrected).
+
+    Parameters
+    ----------
+    lam_all_sorted : array, shape ``(min(n, d),)``
+        Full eigenspectrum of the sample correlation matrix, ordered by
+        descending ``|λ - 1|`` (as returned by
+        :func:`_extract_lrd_from_samples`).  The first ``k`` entries are
+        the selected top-k; the remaining entries are the residuals.
+    k : int
+        Rank of the LRD approximation (same ``k_used`` passed to
+        :func:`_extract_lrd_from_samples`).
+
+    Returns
+    -------
+    float
+        κ_eff = max / min of {1} × k ∪ {1/μ_i : i ≥ k}.
+        Returns the correlation κ (all residual, no whitening) when k = 0.
+        Returns 1.0 when k ≥ len(lam_all_sorted) (all directions whitened).
+    """
+    lam_np = jnp.array(lam_all_sorted)
+    n_svd = lam_np.size  # min(n_pilot, d)
+
+    if n_svd == 0:
+        return 1.0
+
+    # Residual eigenvalues: entries at positions k, k+1, … in lam_all_sorted.
+    # These are the (d-k) directions NOT captured by the top-k selection.
+    if k >= n_svd:
+        # All SVD-supported directions are whitened → κ_eff = 1.
+        return 1.0
+
+    residual_mu = lam_np[k:]  # shape (n_svd - k,)
+
+    # Guard against near-zero residuals (degenerate pilots with very few draws)
+    residual_mu = jnp.where(
+        residual_mu < 1e-12, jnp.ones_like(residual_mu), residual_mu
+    )
+    residual_eigs = 1.0 / residual_mu  # (n_svd - k,)
+
+    # The k whitened directions each contribute eigenvalue 1.
+    # Combine: max and min over {1} ∪ {1/μ_i}.
+    max_eig = float(jnp.maximum(jnp.max(residual_eigs), 1.0))
+    min_eig = float(jnp.minimum(jnp.min(residual_eigs), 1.0))
+    if min_eig <= 0.0:
+        return float("inf")
+    return max_eig / min_eig
 
 
 def _check_da_ceiling_warning(
@@ -296,6 +413,7 @@ def mclmc_lrd_warmup(
     floor_factor: float = 1.15,
     adjusted_num_steps: int = 3000,
     adjusted_target: float = 0.9,
+    warmup_step_init: str = "law",
 ):
     """Scheme A (pilot-free) MCLMC warmup with Low-Rank Diagonal preconditioning.
 
@@ -360,6 +478,39 @@ def mclmc_lrd_warmup(
     adjusted_target
         Target acceptance rate for the adjusted MCLMC tuning phase.
         Default ``0.9``.  Ignored when ``inner_kernel="mclmc"``.
+    warmup_step_init : str
+        Initialisation strategy for the Phase-3 Dual-Averaging (DA) step-size
+        tuner.  One of:
+
+        * ``"law"`` *(default)*: **√d warm-start (E1)**, gated on κ_eff.
+
+          When the pilot-derived LRD IMM achieves κ_eff ≤ 5 (the geometry is
+          sufficiently whitened), Phase-3 DA is initialised at the scaling-law
+          values ``step_size = 1.22 × √d``, ``L = 0.85 × √d``.  These
+          constants were derived from the MCLMC scaling-laws study (S3, 2026):
+          at good preconditioning, MCLMC's optimal step and trajectory length
+          are dimension-independent multiples of √d.
+
+          When κ_eff > 5 (under-preconditioned, e.g. rank-1 LRD on a κ=1000
+          target), E1 is **not applied** and Phase-3 DA falls back to the
+          pilot's own ``(step_size, L)`` — the same behaviour as
+          ``"default"``.  This gate prevents overshoot: at low rank the
+          geometry is not yet whitened and the scaling-law values would place
+          the DA starting point far from the actual optimum.
+
+          The warm-start only affects DA *convergence speed*, not the final
+          converged value.  At sufficient ``lrd_num_steps`` budget,
+          ``"law"`` and ``"default"`` produce statistically identical
+          ``(step_size, L)`` outputs.  The gain is in sample quality at
+          *low-budget* warmup (measured via ESS/grad):
+          ~20–30% improvement through n_warmup ≈ 1000 at d = 500 in the
+          Q0 sweep (2026-06), scaling with dimension because the default
+          DA init at 0.25 √d falls further below the optimum at larger d.
+
+        * ``"default"``: Phase-3 DA is initialised by warm-starting from the
+          pilot's own ``(step_size, L)`` (the pre-existing behaviour prior to
+          this parameter).  Use this to reproduce results from the previous
+          code path or to suppress E1 entirely.
 
     Returns
     -------
@@ -416,6 +567,11 @@ def mclmc_lrd_warmup(
         raise ValueError(
             f"inner_kernel must be one of {sorted(_VALID_INNER_KERNELS)!r}, "
             f"got {inner_kernel!r}."
+        )
+    if warmup_step_init not in _VALID_WARMUP_STEP_INITS:
+        raise ValueError(
+            f"warmup_step_init must be one of {sorted(_VALID_WARMUP_STEP_INITS)!r}, "
+            f"got {warmup_step_init!r}."
         )
 
     # Five independent keys — no reuse across init / pilot warmup / pilot
@@ -494,7 +650,7 @@ def mclmc_lrd_warmup(
     # ------------------------------------------------------------------
     # Phase 2: SVD extraction → LowRankInverseMassMatrix
     # ------------------------------------------------------------------
-    sigma, U_k, lam_k = _extract_lrd_from_samples(flat_pilot, k=k_used)
+    sigma, U_k, lam_k, lam_all_sorted = _extract_lrd_from_samples(flat_pilot, k=k_used)
     lrd_imm = LowRankInverseMassMatrix(sigma=sigma, U=U_k, lam=lam_k)
 
     # ------------------------------------------------------------------
@@ -513,12 +669,41 @@ def mclmc_lrd_warmup(
             step_size=step_size,
         )
 
-    # Warm-start from pilot L/step_size to skip unnecessary exploration.
-    lrd_init_params = MCLMCAdaptationState(
-        L=pilot_params.L,
-        step_size=pilot_params.step_size,
-        inverse_mass_matrix=pilot_params.inverse_mass_matrix,  # placeholder; overridden
-    )
+    # Compute κ_eff of the pilot-derived LRD IMM.  Uses the full Phase-2 SVD
+    # eigenspectrum (lam_all_sorted) and the selected rank k_used to correctly
+    # account for whitened vs. residual directions in the M⁻¹Σ⁻¹ product.
+    kappa_eff_pilot_val = _kappa_eff_pilot(lam_all_sorted=lam_all_sorted, k=k_used)
+
+    # Phase-3 DA initialisation (warmup_step_init controls E1).
+    if warmup_step_init == "law":
+        # E1: √d warm-start, gated on κ_eff ≤ 5.
+        # Gate condition: the pilot LRD IMM must sufficiently whiten the
+        # geometry (κ_eff ≤ 5) before the scaling-law init is accurate.
+        e1_fired = kappa_eff_pilot_val <= _KAPPA_EFF_GATE
+        if e1_fired:
+            # Scaling-law warm-start: step ≈ 1.22√d, L ≈ 0.85√d.
+            d = flat_pilot.shape[1]
+            sqrt_d = jnp.sqrt(float(d))
+            lrd_init_params = MCLMCAdaptationState(
+                L=jnp.array(_SQRT_D_L_CONST * sqrt_d),
+                step_size=jnp.array(_SQRT_D_STEP_CONST * sqrt_d),
+                inverse_mass_matrix=pilot_params.inverse_mass_matrix,  # placeholder; overridden
+            )
+        else:
+            # Fallback: pilot's own (step, L) — same as "default".
+            lrd_init_params = MCLMCAdaptationState(
+                L=pilot_params.L,
+                step_size=pilot_params.step_size,
+                inverse_mass_matrix=pilot_params.inverse_mass_matrix,  # placeholder; overridden
+            )
+    else:
+        # "default": warm-start from pilot L/step_size to skip unnecessary exploration.
+        e1_fired = False
+        lrd_init_params = MCLMCAdaptationState(
+            L=pilot_params.L,
+            step_size=pilot_params.step_size,
+            inverse_mass_matrix=pilot_params.inverse_mass_matrix,  # placeholder; overridden
+        )
 
     # Split into 2*num_chains keys: first half for chain init, second for tuning.
     lrd_all_keys = jax.random.split(lrd_subkey, 2 * num_chains)
@@ -652,6 +837,8 @@ def mclmc_lrd_warmup(
         "pilot_step_size": pilot_step_size_val,
         "lrd_L": lrd_L,
         "lrd_step_size": lrd_step_size,
+        "e1_fired": e1_fired,
+        "kappa_eff_pilot": kappa_eff_pilot_val,
     }
 
     # Adjusted-path-only provenance keys (available in scope only for that branch).

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -24,6 +24,7 @@ from blackjax.adaptation.mclmc_lrd_adaptation import (
     MCLMCLRDAdaptationState,
     _check_da_ceiling_warning,
     _extract_lrd_from_samples,
+    _kappa_eff_pilot,
     mclmc_lrd_warmup,
 )
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
@@ -49,20 +50,24 @@ class TestExtractLrd:
     """Shape and contract tests for the internal SVD extraction helper."""
 
     def test_output_shapes(self):
-        """sigma (d,), U (d,k), lam (k,) for any valid n>k."""
+        """sigma (d,), U (d,k), lam (k,), lam_all (min(n,d),) for any valid n>k."""
         rng = jax.random.key(0)
         d, n, k = 8, 50, 3
         samples = jax.random.normal(rng, (n, d))
-        sigma, U, lam = _extract_lrd_from_samples(samples, k=k)
+        sigma, U, lam, lam_all = _extract_lrd_from_samples(samples, k=k)
         assert sigma.shape == (d,)
         assert U.shape == (d, k)
         assert lam.shape == (k,)
+        # lam_all has shape (min(n,d),) = (d,) since n > d here
+        assert lam_all.shape == (d,)
+        # lam_all[:k] must equal lam (top-k are first in sorted order)
+        assert jnp.allclose(lam_all[:k], lam)
 
     def test_sigma_positive(self):
         """All diagonal scales must be strictly positive."""
         rng = jax.random.key(1)
         samples = jax.random.normal(rng, (30, 5))
-        sigma, _, _ = _extract_lrd_from_samples(samples, k=2)
+        sigma, _, _, _ = _extract_lrd_from_samples(samples, k=2)
         assert jnp.all(sigma > 0)
 
     def test_zero_variance_dim_gets_unit_sigma(self):
@@ -71,7 +76,7 @@ class TestExtractLrd:
         samples = jax.random.normal(rng, (30, 4))
         # Force dim-0 to constant (zero variance)
         samples = samples.at[:, 0].set(0.0)
-        sigma, _, _ = _extract_lrd_from_samples(samples, k=2)
+        sigma, _, _, _ = _extract_lrd_from_samples(samples, k=2)
         assert jnp.all(jnp.isfinite(sigma))
         assert sigma[0] == pytest.approx(1.0)  # clamped to 1 for zero-var dim
 
@@ -79,7 +84,7 @@ class TestExtractLrd:
         """Each column of U should be (approximately) unit-norm."""
         rng = jax.random.key(3)
         samples = jax.random.normal(rng, (100, 10))
-        _, U, _ = _extract_lrd_from_samples(samples, k=4)
+        _, U, _, _ = _extract_lrd_from_samples(samples, k=4)
         col_norms = jnp.linalg.norm(U, axis=0)
         assert jnp.allclose(col_norms, jnp.ones(4), atol=1e-5)
 
@@ -88,7 +93,7 @@ class TestExtractLrd:
         rng = jax.random.key(4)
         n, d, k = 5000, 6, 3
         samples = jax.random.normal(rng, (n, d))
-        _, _, lam = _extract_lrd_from_samples(samples, k=k)
+        _, _, lam, _ = _extract_lrd_from_samples(samples, k=k)
         assert jnp.allclose(lam, jnp.ones(k), atol=0.15)
 
 
@@ -717,3 +722,335 @@ class TestAdjustedFracTune2Invariant:
         assert (
             captured_kwargs.get("diagonal_preconditioning") is False
         ), "diagonal_preconditioning must be False to preserve LRD IMM"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _kappa_eff_pilot helper
+# ---------------------------------------------------------------------------
+
+
+class TestKappaEffPilot:
+    """Unit tests for the corrected κ_eff computation.
+
+    _kappa_eff_pilot(lam_all_sorted, k) takes the FULL eigenspectrum ordered
+    by |λ-1| descending, and the rank k.  The top-k directions are whitened
+    (eigenvalue 1 in M⁻¹Σ⁻¹); residuals contribute 1/μ_i.
+    """
+
+    def test_full_rank_gives_kappa_one(self):
+        """k == len(lam_all_sorted) → all directions whitened → κ_eff = 1."""
+        # All 4 directions captured at k=4
+        lam_all = jnp.array([5.0, 0.2, 1.5, 0.8])  # some spread
+        kappa = _kappa_eff_pilot(lam_all_sorted=lam_all, k=4)
+        assert abs(kappa - 1.0) < 1e-6
+
+    def test_zero_rank_gives_full_correlation_kappa(self):
+        """k=0 → no whitening → κ_eff = max(1/μ) / min(1/μ) = max(μ)/min(μ)."""
+        # lam_all_sorted = [5.0, 0.2] → residuals = both → 1/5, 1/0.2=5 → κ=25
+        lam_all = jnp.array([5.0, 0.2])
+        kappa = _kappa_eff_pilot(lam_all_sorted=lam_all, k=0)
+        assert abs(kappa - 25.0) < 1e-6
+
+    def test_residual_spread_drives_kappa(self):
+        """κ_eff decreases as k increases (more directions whitened)."""
+        # lam_all_sorted (by |λ-1| desc): [10., 0.1, 0.9]
+        # k=0: residuals=[10,0.1,0.9] → 1/eigs=[0.1,10,1.11] → κ=100
+        # k=1: residuals=[0.1,0.9]   → 1/eigs=[10, 1.11]     → κ=10
+        # k=2: residuals=[0.9]       → 1/eigs=[1.11]          → κ=max(1.11,1)/min(1.11,1)=1.11
+        # k=3: all whitened          → κ=1
+        lam_all = jnp.array([10.0, 0.1, 0.9])
+        kappa_0 = _kappa_eff_pilot(lam_all_sorted=lam_all, k=0)
+        kappa_1 = _kappa_eff_pilot(lam_all_sorted=lam_all, k=1)
+        kappa_2 = _kappa_eff_pilot(lam_all_sorted=lam_all, k=2)
+        kappa_3 = _kappa_eff_pilot(lam_all_sorted=lam_all, k=3)
+        assert kappa_0 > kappa_1 > kappa_2 > kappa_3
+        assert abs(kappa_3 - 1.0) < 1e-6
+
+    def test_kappa_is_positive_finite_float(self):
+        """κ_eff must always be a positive finite float."""
+        lam_all = jnp.array([2.0, 0.8, 1.1, 0.5])
+        kappa = _kappa_eff_pilot(lam_all_sorted=lam_all, k=2)
+        assert isinstance(kappa, float)
+        assert kappa > 0
+        assert jnp.isfinite(kappa)
+
+    def test_ill_conditioned_full_rank_imm_gives_kappa_near_one(self):
+        """On an ill-cond target, k=d IMM (full-rank SVD) → κ_eff ≈ 1.
+
+        This is the key regression test: the wrong formula gave κ≈863 at k=d;
+        the correct formula must give 1.0 (all directions whitened).
+        """
+        # Build a d=8 correlated Gaussian with kappa=100
+        import numpy as np
+
+        d_test = 8
+        rng_np = np.random.default_rng(7)
+        eigs_test = np.array([1.0, 2.0, 5.0, 10.0, 20.0, 50.0, 100.0, 0.5])
+        Q_test, _ = np.linalg.qr(rng_np.standard_normal((d_test, d_test)))
+        Sigma_test = Q_test @ np.diag(eigs_test) @ Q_test.T
+        L_test = np.linalg.cholesky(Sigma_test)
+        draws_test = (L_test @ rng_np.standard_normal((d_test, 5000))).T
+        flat_test = jnp.asarray(draws_test)
+
+        # k = d (full rank): all directions captured → κ_eff should be ≈ 1
+        _, _, _, lam_all_full = _extract_lrd_from_samples(flat_test, k=d_test)
+        kappa_full = _kappa_eff_pilot(lam_all_sorted=lam_all_full, k=d_test)
+        assert (
+            kappa_full < 2.0
+        ), "Full-rank IMM on ill-cond target should give kappa_eff < 2, got " + str(
+            round(kappa_full, 3)
+        )
+
+        # k = 1 (rank-1): only one direction captured → κ_eff should be large
+        _, _, _, lam_all_k1 = _extract_lrd_from_samples(flat_test, k=1)
+        kappa_k1 = _kappa_eff_pilot(lam_all_sorted=lam_all_k1, k=1)
+        assert (
+            kappa_k1 > 5.0
+        ), "Rank-1 IMM on ill-cond target should give kappa_eff > 5, got " + str(
+            round(kappa_k1, 3)
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: E1 (√d warm-start) gate behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestE1WarmStart:
+    """Tests for warmup_step_init="law" / "default" and the κ_eff gate."""
+
+    def test_well_conditioned_target_e1_fires(self):
+        """isotropic N(0,I): k_eff ≈ 1 → e1_fired=True, step ≈ 1.22√d (within 15%)."""
+        # d=6, sqrt(6) ≈ 2.449, target step ≈ 1.22*2.449 ≈ 2.99
+        rng = jax.random.key(200)
+        pos = jnp.zeros(D)
+
+        result = mclmc_lrd_warmup(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=300,
+            pilot_num_samples=1000,
+            lrd_num_steps=500,
+            num_chains=2,
+            warmup_step_init="law",
+        )
+        diag = result.diagnostics
+        kappa_str = str(round(diag["kappa_eff_pilot"], 3))
+        assert diag["e1_fired"] is True, (
+            "Expected e1_fired=True on isotropic target, got "
+            + repr(diag["e1_fired"])
+            + "; kappa_eff_pilot="
+            + kappa_str
+        )
+        # Adapted step should be within 15% of 1.22*sqrt(d)
+        import math
+
+        target_step = 1.22 * math.sqrt(D)
+        lrd_step = result.diagnostics["lrd_step_size"]
+        step_ratio = lrd_step / target_step
+        lrd_step_s = str(round(lrd_step, 3))
+        target_step_s = str(round(target_step, 3))
+        step_ratio_s = str(round(step_ratio, 3))
+        assert 0.85 <= step_ratio <= 1.15, (
+            "Adapted step "
+            + lrd_step_s
+            + " deviates >15% from target 1.22*sqrt(d)="
+            + target_step_s
+            + " (ratio="
+            + step_ratio_s
+            + ")"
+        )
+
+    def test_under_preconditioned_e1_does_not_fire(self):
+        """Off-diagonal-correlated target at low rank → κ_eff >> 5 → e1_fired=False.
+
+        The LRD IMM's DIAGONAL part (sigma) fully whitens any axis-aligned
+        per-coordinate scaling, so an *axis-aligned* ill-conditioned Σ gives
+        κ_eff ≈ 1 and WOULD fire E1.  κ_eff measures residual *off-diagonal
+        correlation* conditioning, which only the low-rank part can remove.  We
+        therefore use an equicorrelation target R = (1-ρ)I + ρ·11ᵀ (ρ=0.97, unit
+        diagonal → nothing for the diagonal sigma to absorb): κ(R) ≈ 195.  With
+        k=1 the LRD captures only the single large 1+(d-1)ρ eigendirection,
+        leaving (d-1) residual eigenvalues of (1-ρ), so κ_eff ≈ 1/(1-ρ) ≈ 33 in
+        the noiseless limit — well above the gate of 5 → e1_fired=False.
+
+        The high-ρ target mixes slowly under the diagonal pilot, so a larger
+        pilot (800) is used to keep the κ_eff estimate clean (300 draws straddle
+        the gate). When e1_fired=False, "law" and "default" produce bit-identical
+        output (same rng_key → same PRNG trajectory → same adapted (L, step)).
+        """
+        import numpy as np
+
+        d_ill = 6
+        rho = 0.97
+        R = (1.0 - rho) * np.eye(d_ill) + rho * np.ones((d_ill, d_ill))
+        Sigma_inv_ill = jnp.asarray(np.linalg.inv(R))
+
+        def logdensity_ill(x):
+            return -0.5 * jnp.dot(x, Sigma_inv_ill @ x)
+
+        rng = jax.random.key(201)
+        pos_ill = jnp.zeros(d_ill)
+
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            result_law = mclmc_lrd_warmup(
+                logdensity_ill,
+                pos_ill,
+                rng,
+                k=1,
+                pilot_num_warmup=100,
+                pilot_num_samples=800,
+                lrd_num_steps=100,
+                num_chains=2,
+                warmup_step_init="law",
+            )
+            result_def = mclmc_lrd_warmup(
+                logdensity_ill,
+                pos_ill,
+                rng,
+                k=1,
+                pilot_num_warmup=100,
+                pilot_num_samples=800,
+                lrd_num_steps=100,
+                num_chains=2,
+                warmup_step_init="default",
+            )
+
+        # κ_eff should be well above 5 (the top singular value >> 1).
+        kappa_pilot = result_law.diagnostics["kappa_eff_pilot"]
+        kappa_str = str(round(kappa_pilot, 3))
+        assert result_law.diagnostics["e1_fired"] is False, (
+            "Expected e1_fired=False on ill-conditioned target (kappa_eff_pilot="
+            + kappa_str
+            + " should be >5)"
+        )
+        # kappa_eff should be well above the gate threshold of 5.
+        assert kappa_pilot > 5.0, (
+            "Expected kappa_eff_pilot > 5 for ill-conditioned target with k=1, got "
+            + kappa_str
+        )
+        # When e1_fired=False, "law" and "default" use the same DA init
+        # → same rng_key → bit-identical adapted (L, step_size).
+        law_L = float(result_law.L)
+        def_L = float(result_def.L)
+        assert abs(law_L - def_L) < 1e-6, (
+            "law L=" + str(round(law_L, 6)) + " != default L=" + str(round(def_L, 6))
+        )
+        law_step = float(result_law.step_size)
+        def_step = float(result_def.step_size)
+        assert abs(law_step - def_step) < 1e-6, (
+            "law step="
+            + str(round(law_step, 6))
+            + " != default step="
+            + str(round(def_step, 6))
+        )
+
+    def test_large_budget_law_and_default_converge(self):
+        """At large lrd_num_steps, "law" and "default" produce same (step,L) within tol."""
+        rng = jax.random.key(202)
+        pos = jnp.zeros(D)
+
+        result_law = mclmc_lrd_warmup(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=300,
+            pilot_num_samples=1000,
+            lrd_num_steps=2000,
+            num_chains=2,
+            warmup_step_init="law",
+        )
+        result_def = mclmc_lrd_warmup(
+            logdensity_fn,
+            pos,
+            rng,
+            k=K,
+            pilot_num_warmup=300,
+            pilot_num_samples=1000,
+            lrd_num_steps=2000,
+            num_chains=2,
+            warmup_step_init="default",
+        )
+
+        # At large budget, both should converge to approximately the same answer.
+        # Tolerance is generous (10%) because they start from different inits and
+        # use independent PRNG trajectories; we're testing convergence not identity.
+        law_step = float(result_law.step_size)
+        def_step = float(result_def.step_size)
+        step_ratio = law_step / def_step
+        law_L = float(result_law.L)
+        def_L = float(result_def.L)
+        L_ratio = law_L / def_L
+        step_msg = (
+            "law step="
+            + str(round(law_step, 4))
+            + " vs default step="
+            + str(round(def_step, 4))
+            + ": ratio="
+            + str(round(step_ratio, 3))
+            + " outside [0.90, 1.10] at large budget"
+        )
+        assert 0.90 <= step_ratio <= 1.10, step_msg
+        L_msg = (
+            "law L="
+            + str(round(law_L, 4))
+            + " vs default L="
+            + str(round(def_L, 4))
+            + ": ratio="
+            + str(round(L_ratio, 3))
+            + " outside [0.90, 1.10] at large budget"
+        )
+        assert 0.90 <= L_ratio <= 1.10, L_msg
+
+    def test_e1_fired_and_kappa_eff_pilot_in_diagnostics(self):
+        """e1_fired and kappa_eff_pilot must be present in diagnostics for both modes."""
+        rng = jax.random.key(203)
+        pos = jnp.zeros(D)
+
+        for mode in ("law", "default"):
+            result = mclmc_lrd_warmup(
+                logdensity_fn,
+                pos,
+                rng,
+                k=K,
+                pilot_num_warmup=100,
+                pilot_num_samples=200,
+                lrd_num_steps=100,
+                num_chains=2,
+                warmup_step_init=mode,
+            )
+            diag = result.diagnostics
+            assert (
+                "e1_fired" in diag
+            ), f"Missing 'e1_fired' key in diagnostics for warmup_step_init={mode!r}"
+            assert (
+                "kappa_eff_pilot" in diag
+            ), f"Missing 'kappa_eff_pilot' key in diagnostics for warmup_step_init={mode!r}"
+            assert isinstance(
+                diag["e1_fired"], bool
+            ), f"e1_fired must be bool, got {type(diag['e1_fired'])}"
+            assert isinstance(
+                diag["kappa_eff_pilot"], float
+            ), f"kappa_eff_pilot must be float, got {type(diag['kappa_eff_pilot'])}"
+            assert (
+                diag["kappa_eff_pilot"] >= 1.0
+            ), f"kappa_eff_pilot={diag['kappa_eff_pilot']} must be >= 1.0 (condition number)"
+            # "default" mode must never fire E1
+            if mode == "default":
+                assert (
+                    diag["e1_fired"] is False
+                ), "warmup_step_init='default' must have e1_fired=False, got True"
+
+    def test_invalid_warmup_step_init_raises(self):
+        """Passing an unknown warmup_step_init must raise ValueError immediately."""
+        with pytest.raises(ValueError, match="warmup_step_init"):
+            mclmc_lrd_warmup(
+                logdensity_fn,
+                jnp.zeros(D),
+                jax.random.key(0),
+                warmup_step_init="scaling",
+            )


### PR DESCRIPTION
## Summary

Adds a **gated √d warm-start** to `mclmc_lrd_warmup`'s Phase-3 dual-averaging
initialisation. When the pilot-derived LRD inverse-mass-matrix already whitens
the target (effective condition number `κ_eff ≤ 5`), the step-size/trajectory-
length tuner is warm-started at the dimension-scaling law

```
step ≈ 1.22 · √d        L ≈ 0.85 · √d
```

instead of the pilot's own (typically much smaller) step. On poorly-whitened
geometry the gate does **not** fire and the routine falls back to the existing
pilot-initialised behaviour — so this is a strict no-regression change.

New kwarg `warmup_step_init: {"law", "default"}` (default `"law"`); two new
diagnostics, `e1_fired` and `kappa_eff_pilot`.

## Motivation — the √d scaling law

A groundtruth-scaffolded characterisation of MCLMC tuning (step-size/trajectory
sweeps at fixed GT inverse-mass-matrix, across `mvn_10 → ill_cond_50 → german_credit
→ irt_1pl(500-D) → lgcp(1600-D)`) found the optimal unadjusted-MCLMC step and
decoherence length both scale as a **dimension-independent constant × √d** once
the geometry is whitened:

| quantity | fitted scaling | constant |
|---|---|---|
| optimal step | d^0.49 ≈ √d | **1.22** |
| optimal L | d^0.50 = √d | **0.85** |

This is mechanistically the √d typical-set radius of a whitened Gaussian. The
default dual-averaging tuner starts far below this (≈0.25√d) and spends the
whole Phase-3 budget climbing toward it — most expensively at high `d`, exactly
where MCLMC's O(d^¼) gradient-scaling advantage lives.

## Evidence (Q0): warm-start → better samples at lower tuning budget

Fixed GT-dense IMM, default-init vs √d warm-start, sampling n=3000×4 chains.
Table is ess/grad ratio **(warm-start / default)** — >1 means warm-start wins:

| model | d | n_w=50 | 100 | 200 | 500 | 1000 | 2000 |
|---|---|---|---|---|---|---|---|
| mvn_10 | 10 | 1.21 | 1.16 | 1.06 | 1.00 | 1.00 | 1.00 |
| german_credit | 26 | 1.22 | 1.37 | 1.08 | 1.03 | 1.00 | 1.00 |
| ill_cond_50 | 50 | 1.77 | 1.33 | 1.14 | 1.03 | 1.01 | 1.00 |
| **irt_1pl** | **500** | **1.58** | **1.32** | **1.29** | **1.22** | **1.21** | 1.02 |

- **Benefit persists with dimension.** At d=500 the warm-start is ~20–30%
  better through `n_warmup=1000` (the default tuner is still climbing toward the
  d=500 optimum step ≈27: it reaches 19.7 vs warm-start's 22.7 at n=1000),
  converging to parity only at n=2000. → a ~2× shorter tuning phase at high d,
  ~30–40% faster wall.
- **No downside.** Bias unchanged; full-budget result identical (parity at
  n=2000, every model).

## The κ_eff gate

The warm-start is only valid once the geometry is whitened, so it is gated on
the effective condition number of the pilot LRD IMM,
`κ_eff = κ(M⁻¹ Σ⁻¹) ≤ 5`. This is computed from the Phase-2 SVD eigenspectrum
with the correct whitened/residual accounting:

- the `k` captured directions whiten to eigenvalue **1**;
- each residual direction `μ_i` (the k+1, k+2, … entries of the spectrum,
  ordered by `|λ−1|`) contributes `1/μ_i`;
- `κ_eff = max / min` over `{1}×k ∪ {1/μ_i}`.

On a well-conditioned target `κ_eff ≈ 1` → gate fires. On an ill-conditioned
target that the pilot IMM fails to whiten (e.g. under-ranked), `κ_eff ≫ 5` →
gate does not fire → fall back to pilot init. When the gate does not fire,
`"law"` and `"default"` produce bit-identical output.

## Scope

- **E1 only** (the √d warm-start). The companion rank-selection idea (κ_eff-based
  rank cutoff, "E2") is **explicitly excluded**: in disentangled testing it
  under-ranks relative to the existing `k_safe = floor(n_eff/2)` guard and
  *lowers* sample quality whenever it fires on a model that benefits from more
  rank. Only the warm-start survived as a clean win.
- No change to the IMM extraction, the rank guard, or the public algorithm set.

## Test coverage

- `TestKappaEffPilot` — unit tests of the corrected κ_eff: full-rank → 1,
  zero-rank → correlation κ, monotone decrease in k, and a **regression test**
  (`test_ill_conditioned_full_rank_imm_gives_kappa_near_one`) that pins the bug
  the correct formula fixes (full-rank IMM on an ill-conditioned target must give
  κ_eff ≈ 1, not the naïve κ(R) ≈ 863).
- `TestE1WarmStart` — integration: isotropic target → `e1_fired=True` and adapted
  step within 15% of 1.22√d; ill-conditioned + k=1 → `e1_fired=False` and
  `"law"`==`"default"` bit-identical; large-budget convergence; diagnostics
  presence/typing; invalid-kwarg `ValueError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
