### PR TITLE
fix(adaptation): mclmc_lrd adjusted-path step/L mismatch — drop L_init re-pin (option ii)

### DIFF
--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -816,13 +816,16 @@ def mclmc_lrd_warmup(
 
         adj_params_all = _adj_tune_one(adj_tune_keys, adj_init_states)
 
-        # frac_tune2=0.0 → L is fixed at L_init across all chains.
-        # Average step_size across chains for a stable multi-chain estimate.
+        # target_num_integration_steps=2.0 (default) → avg-preserving calibration:
+        # the tuner enforces L = 2·step per chain throughout DA.  Average both
+        # across chains for a stable multi-chain estimate; by the avg-preserving
+        # invariant final_L ≈ 2·final_step_size.
         final_step_size = jnp.mean(adj_params_all.step_size)
-        final_L = jnp.array(L_init)  # L is fixed by construction
+        final_L = jnp.mean(adj_params_all.L)  # L = 2·step by avg-preserving invariant
 
-        # DA-ceiling diagnostic: warn if step_size is at or near L_init/1.1.
-        _check_da_ceiling_warning(float(final_step_size), L_init, floor_factor)
+        # DA-ceiling diagnostic: non-binding at avg=2 (step ≈ L/2 ≪ L/1.1),
+        # but kept correct: use final_L (not L_init) as the calibration anchor.
+        _check_da_ceiling_warning(float(final_step_size), float(final_L), floor_factor)
 
     # Gradient accounting: unadjusted MCLMC costs 2 grads/step.
     pilot_num_grad_evals = (pilot_num_warmup + pilot_num_samples) * 2

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -578,7 +578,12 @@ class TestMCLMCLRDAdjustedSmoke:
         assert diag["L_init"] >= diag["lrd_L"] - 1e-9
 
     def test_adjusted_path_n_sample_in_diagnostics(self):
-        """Adjusted path must expose N_sample = round(L_init / final_step_size)."""
+        """Adjusted path must expose N_sample = round(final_L / final_step_size) ≈ 2.
+
+        After option-(ii): N_sample tracks final_L (the avg-preserving tuner's
+        calibrated L), NOT L_init.  By the avg=2 invariant, final_L ≈ 2·step
+        so N_sample ≈ 2.  Asserting against result.L / step_size (not L_init).
+        """
         rng = jax.random.key(57)
         pos = jnp.zeros(D)
 
@@ -599,8 +604,9 @@ class TestMCLMCLRDAdjustedSmoke:
         assert "N_sample" in diag, "Missing N_sample in adjusted diagnostics"
         assert isinstance(diag["N_sample"], (int, float)), "N_sample must be numeric"
         assert diag["N_sample"] > 0, "N_sample must be positive"
-        # Verify the value matches round(L_init / final_step_size) within rounding.
-        expected = float(diag["L_init"]) / float(result.step_size)
+        # N_sample = round(final_L / step_size); final_L ≈ 2·step → N_sample ≈ 2.
+        # Assert against result.L (not L_init) since we no longer pin L=L_init.
+        expected = float(result.L) / float(result.step_size)
         assert abs(diag["N_sample"] - expected) < 1.0  # within one step
 
     def test_unadjusted_path_has_no_l_init_floor_active(self):


### PR DESCRIPTION
## Fix

`mclmc_lrd_warmup` adjusted path (`inner_kernel="adjusted_mclmc"`): drop the `:822` `final_L = jnp.array(L_init)` re-pin so the avg-preserving tuner's `L = 2·step` invariant stands (option ii). The step-size DA (via `adjusted_mclmc_find_L_and_step_size` with `target_num_integration_steps=2.0` default) calibrates `step` at `avg = 2` throughout adaptation; discarding the tuner's `L` and re-pinning to `L_init` ran the sampled kernel at `avg = L_init/step ≈ 1.1` — a step/L mismatch causing ~0.1-posterior-SD systematic mean bias (confirmed on german_credit d=26, z_max 3.58–4.74, all failing the z<2.0 cert gate).

Changes (isolated to `blackjax/adaptation/mclmc_lrd_adaptation.py`, ~4 lines):
- `:824` `final_L = jnp.mean(adj_params_all.L)` — lets the avg-preserving tuner's L stand; by #940's per-chain `L/step=2` invariant, `mean(L) ≈ 2·mean(step)` and avg=2 is self-consistent at sampling time.
- Comment block updated to document avg-preserving semantics.
- `_check_da_ceiling_warning(...)` re-anchored to `float(final_L)` (non-binding at avg=2, kept correct).
- `adjusted_mclmc_adaptation.py` **bit-unchanged** — standalone `adjusted_mclmc_dynamic` path (#940) is untouched.

## Validation

Statistician re-cert on german_credit (d=26) adjusted path, 3 seeds × 2 arms, M1@359205da reference in isolated worktree:
- z_disc: **2.710 vs M1 2.597** (0.29σ — M1-parity, indistinguishable)
- minESS: **16.5k (post-fix) vs 6.0k (pre-fix)** — 2.7× improvement at equal acceptance
- avg realised: **2.000** by construction
- ill_cond_50: PASS; efficiency: PASS; mvn_10: clean

**Honest caveat:** cert basis is M1-parity + 2.7× ESS, not absolute z<2. Both arms carry a pre-existing german/LRD stiff-direction residual (z≈2.6–2.7) not introduced by this change — present in M1 baseline at 359205da and is a separate open issue.

## Tests

- `test_adjusted_mclmc_adaptation.py`: **11/11 PASSED, bit-unchanged** — key safety gate: standalone adjusted_mclmc_dynamic path (#940) confirmed untouched.
- `test_mclmc_lrd_adaptation.py`: **40/40 PASSED**.
  - One justified golden update: `test_adjusted_path_n_sample_in_diagnostics` — `N_sample` now asserts `≈ result.L/step ≈ 2` (avg=2 calibration); old assertion `≈ L_init/step ≈ 0.8` was itself evidence of the pre-fix breakage.
- pre-commit: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)