### PR TITLE
Add slice sampling kernel

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -30,6 +30,7 @@ from .mcmc import mclmc as _mclmc
 from .mcmc import nuts as _nuts
 from .mcmc import periodic_orbital, random_walk
 from .mcmc import rmhmc as _rmhmc
+from .mcmc import slice as _slice
 from .mcmc.random_walk import additive_step_random_walk as _additive_step_random_walk
 from .mcmc.random_walk import (
     irmh_as_top_level_api,
@@ -126,6 +127,7 @@ mclmc = generate_top_level_api_from(_mclmc)
 adjusted_mclmc_dynamic = generate_top_level_api_from(_adjusted_mclmc_dynamic)
 adjusted_mclmc = generate_top_level_api_from(_adjusted_mclmc)
 elliptical_slice = generate_top_level_api_from(_elliptical_slice)
+slice_sampling = generate_top_level_api_from(_slice)
 ghmc = generate_top_level_api_from(_ghmc)
 barker = generate_top_level_api_from(_barker)
 barker_proposal = barker  # backwards-compatible alias
@@ -242,6 +244,7 @@ __all__ = [
     "ghmc",
     "barker",
     "elliptical_slice",
+    "slice_sampling",
     "mclmc",
     "adjusted_mclmc",
     "adjusted_mclmc_dynamic",

--- a/blackjax/mcmc/slice.py
+++ b/blackjax/mcmc/slice.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Public API for the Slice sampling kernel."""
+
 from typing import Callable, NamedTuple
 
 import jax

--- a/blackjax/mcmc/slice.py
+++ b/blackjax/mcmc/slice.py
@@ -32,30 +32,25 @@ class SliceState(NamedTuple):
         Current position of the chain.
     logdensity
         Current value of the log-density.
-    widths
-        Per-dimension step widths, adapted online via Welford averaging.
-    n
-        Number of completed transitions (used to compute the running average
-        of step widths).
 
     """
 
     position: ArrayTree
     logdensity: float
-    widths: ArrayTree
-    n: Array
 
 
 class SliceInfo(NamedTuple):
     """Additional information on the Slice sampling transition.
 
-    widths
-        Per-dimension step widths after this transition (matches the position
-        PyTree structure). Useful for monitoring adaptation.
+    bracket_widths
+        Per-dimension realized bracket widths produced by the doubling
+        procedure on this step.  Useful for diagnosing proposal efficiency
+        (very wide brackets relative to the posterior suggest the initial
+        width is too small; very narrow ones suggest it may be too large).
 
     """
 
-    widths: ArrayTree
+    bracket_widths: ArrayTree
 
 
 def init(position: ArrayLikeTree, logdensity_fn: Callable) -> SliceState:
@@ -73,11 +68,10 @@ def init(position: ArrayLikeTree, logdensity_fn: Callable) -> SliceState:
     The initial state of the Slice sampling chain.
     """
     logdensity = logdensity_fn(position)
-    widths = jax.tree.map(lambda x: jnp.full(x.shape, 0.01), position)
-    return SliceState(position, jnp.atleast_1d(logdensity), widths, jnp.atleast_1d(0.0))
+    return SliceState(position, jnp.atleast_1d(logdensity))
 
 
-def build_kernel(n_doublings: int = 10) -> Callable:
+def build_kernel(n_doublings: int = 10, initial_widths: float = 1.0) -> Callable:
     """Build a Slice sampling kernel.
 
     Implementation according to [1]. Doubling implementation inspired
@@ -87,6 +81,14 @@ def build_kernel(n_doublings: int = 10) -> Callable:
     ----------
     n_doublings
         Maximum number of slice interval doublings.
+    initial_widths
+        Fixed per-dimension bracket width used as the starting interval for
+        the doubling procedure (default: 1.0).  The value 1.0 is a
+        reasonable default for posterior scales in the range 0.1–10: the
+        doubling procedure rapidly expands the bracket when the width is
+        too small, so correctness is insensitive to the exact value.  Pass
+        a smaller value for very narrow posteriors, or a larger one for very
+        diffuse ones, to improve efficiency.
 
     Returns
     -------
@@ -103,9 +105,9 @@ def build_kernel(n_doublings: int = 10) -> Callable:
     def kernel(
         rng_key: PRNGKey, state: SliceState, logdensity_fn: Callable
     ) -> tuple[SliceState, SliceInfo]:
-        proposal_generator = _slice_proposal(logdensity_fn, n_doublings)
-        new_state = proposal_generator(rng_key, state)
-        return new_state, SliceInfo(new_state.widths)
+        proposal_generator = _slice_proposal(logdensity_fn, n_doublings, initial_widths)
+        new_state, bracket_widths = proposal_generator(rng_key, state)
+        return new_state, SliceInfo(bracket_widths)
 
     return kernel
 
@@ -114,6 +116,7 @@ def as_top_level_api(
     logdensity_fn: Callable,
     *,
     n_doublings: int = 10,
+    initial_widths: float = 1.0,
 ) -> SamplingAlgorithm:
     """Implements the user interface for the Slice sampling kernel.
 
@@ -142,32 +145,37 @@ def as_top_level_api(
         The log-density function of the distribution we wish to sample from.
     n_doublings
         Maximum number of slice interval doublings (default: 10).
+    initial_widths
+        Fixed per-dimension bracket width used as the starting interval for
+        the doubling procedure (default: 1.0).
 
     Returns
     -------
     A ``SamplingAlgorithm``.
     """
-    kernel = build_kernel(n_doublings)
+    kernel = build_kernel(n_doublings, initial_widths)
     return build_sampling_algorithm(kernel, init, logdensity_fn)
 
 
-def _slice_proposal(logdensity_fn: Callable, n_doublings: int) -> Callable:
-    def generate(rng_key: PRNGKey, state: SliceState) -> SliceState:
+def _slice_proposal(
+    logdensity_fn: Callable, n_doublings: int, initial_widths: float
+) -> Callable:
+    def generate(rng_key: PRNGKey, state: SliceState) -> tuple[SliceState, ArrayTree]:
         order_key, rng_key = random.split(rng_key)
-        n = state.n[0]
         positions, unravel_fn = jax.flatten_util.ravel_pytree(state.position)
-        widths, _ = jax.flatten_util.ravel_pytree(state.widths)
+        widths = jnp.full(positions.shape, initial_widths)
 
-        def body_fn(carry, rn):
+        def body_fn(
+            carry: tuple[Array, Array], rn: tuple[PRNGKey, Array]
+        ) -> tuple[tuple[Array, Array], tuple[Array, Array]]:
             seed, idx = rn
-            positions, widths = carry
-            xi, wi = _sample_conditionally(
+            positions, bracket_widths = carry
+            xi, bi = _sample_conditionally(
                 seed, logdensity_fn, unravel_fn, idx, positions, widths, n_doublings
             )
             positions = positions.at[idx].set(xi)
-            nw = widths[idx] + (wi - widths[idx]) / (n + 1)
-            widths = widths.at[idx].set(nw)
-            return (positions, widths), (positions, widths)
+            bracket_widths = bracket_widths.at[idx].set(bi)
+            return (positions, bracket_widths), (positions, bracket_widths)
 
         order = random.choice(
             order_key,
@@ -177,37 +185,57 @@ def _slice_proposal(logdensity_fn: Callable, n_doublings: int) -> Callable:
         )
 
         keys = random.split(rng_key, len(positions))
-        (new_positions, new_widths), _ = jax.lax.scan(
-            body_fn, (positions, widths), (keys, order)
+        bracket_widths_init = jnp.zeros_like(positions)
+        (new_positions, new_bracket_widths), _ = jax.lax.scan(
+            body_fn, (positions, bracket_widths_init), (keys, order)
         )
 
         new_positions = unravel_fn(new_positions)
-        new_widths = unravel_fn(new_widths)
-        return SliceState(
+        new_bracket_widths = unravel_fn(new_bracket_widths)
+        new_state = SliceState(
             new_positions,
             jnp.atleast_1d(logdensity_fn(new_positions)),
-            new_widths,
-            jnp.atleast_1d(n + 1.0),
         )
+        return new_state, new_bracket_widths
 
     return generate
 
 
 def _sample_conditionally(
-    seed, logdensity_fn, unravel_fn, idx, positions, widths, n_doublings
-):
-    def cond_lp_fn(xi_to_set):
+    seed: PRNGKey,
+    logdensity_fn: Callable,
+    unravel_fn: Callable,
+    idx: Array,
+    positions: Array,
+    widths: Array,
+    n_doublings: int,
+) -> tuple[Array, Array]:
+    def conditional_logdensity_fn(xi_to_set: Array) -> Array:
         return logdensity_fn(unravel_fn(positions.at[idx].set(xi_to_set)))
 
     key, seed1, seed2 = random.split(seed, 3)
     x0, w0 = positions[idx], widths[idx]
-    y = cond_lp_fn(x0) - random.exponential(key)
-    left, right, _ = _doubling_fn(seed1, y, x0, cond_lp_fn, w0, n_doublings)
-    x1 = _shrinkage_fn(seed2, y, x0, cond_lp_fn, left, right, w0)
+    logdensity = conditional_logdensity_fn(x0) - random.exponential(key)
+    left, right, _ = _doubling_fn(
+        seed1, logdensity, x0, conditional_logdensity_fn, w0, n_doublings
+    )
+    x1 = _shrinkage_fn(
+        seed2, logdensity, x0, conditional_logdensity_fn, left, right, w0
+    )
     return x1, right - left
 
 
-def _doubling_fn(rng, y, x0, cond_lp_fn, w, n_doublings):
+# --- Doubling ---
+
+
+def _doubling_fn(
+    rng: PRNGKey,
+    logdensity: Array,
+    x0: Array,
+    conditional_logdensity_fn: Callable,
+    w: Array,
+    n_doublings: int,
+) -> tuple[Array, Array, Array]:
     key1, key2 = random.split(rng, 2)
     initial_left = x0 - w * random.uniform(key1)
     initial_right = initial_left + w
@@ -228,10 +256,10 @@ def _doubling_fn(rng, y, x0, cond_lp_fn, w, n_doublings):
 
     lefts = initial_left - left_increments
     rights = initial_right + right_increments
-    left_lps = jax.vmap(cond_lp_fn)(lefts)
-    right_lps = jax.vmap(cond_lp_fn)(rights)
+    left_lps = jax.vmap(conditional_logdensity_fn)(lefts)
+    right_lps = jax.vmap(conditional_logdensity_fn)(rights)
 
-    both_ok = jnp.logical_and(left_lps < y, right_lps < y)
+    both_ok = jnp.logical_and(left_lps < logdensity, right_lps < logdensity)
     best_interval_idx = _best_interval(both_ok.astype(jnp.int32))
 
     return (
@@ -241,7 +269,7 @@ def _doubling_fn(rng, y, x0, cond_lp_fn, w, n_doublings):
     )
 
 
-def _best_interval(x):
+def _best_interval(x: Array) -> Array:
     k = x.shape[0]
     mults = jnp.arange(2 * k, k, -1, dtype=x.dtype)
     shifts = jnp.arange(k, dtype=x.dtype)
@@ -249,19 +277,31 @@ def _best_interval(x):
     return indices
 
 
-def _shrinkage_fn(seed, y, x0, cond_lp_fn, left, right, w):
-    def cond_fn(state):
+# --- Shrinkage ---
+
+
+def _shrinkage_fn(
+    seed: PRNGKey,
+    logdensity: Array,
+    x0: Array,
+    conditional_logdensity_fn: Callable,
+    left: Array,
+    right: Array,
+    w: Array,
+) -> Array:
+    def cond_fn(state: tuple) -> Array:
         *_, found = state
         return jnp.logical_not(found)
 
-    def body_fn(state):
+    def body_fn(state: tuple) -> tuple:
         x1, left, right, seed, _ = state
         key, seed = random.split(seed)
         v = random.uniform(key)
         x1 = left + v * (right - left)
 
         found = jnp.logical_and(
-            y < cond_lp_fn(x1), _accept_fn(y, x1, x0, cond_lp_fn, left, right, w)
+            logdensity < conditional_logdensity_fn(x1),
+            _accept_fn(logdensity, x1, x0, conditional_logdensity_fn, left, right, w),
         )
 
         left = jnp.where(x1 < x0, x1, left)
@@ -269,21 +309,32 @@ def _shrinkage_fn(seed, y, x0, cond_lp_fn, left, right, w):
 
         return x1, left, right, seed, found
 
-    key, seed = random.split(seed)
-    v = random.uniform(key)
-    x1 = left + v * (right - left)
     x1, left, right, seed, _ = jax.lax.while_loop(
-        cond_fn, body_fn, (x1, left, right, seed, False)
+        cond_fn, body_fn, (x0, left, right, seed, False)
     )
     return x1
 
 
-def _accept_fn(y, x1, x0, cond_lp_fn, left, right, w):
-    def cond_fn(state):
+# --- Acceptance test ---
+
+
+def _accept_fn(
+    logdensity: Array,
+    x1: Array,
+    x0: Array,
+    conditional_logdensity_fn: Callable,
+    left: Array,
+    right: Array,
+    w: Array,
+) -> Array:
+    # The 1.1 * w termination threshold is from Neal 2003 Fig. 6: the
+    # acceptance test bisects the interval until it is within 10% of the
+    # original width w, at which point no further refinement is needed.
+    def cond_fn(state: tuple) -> Array:
         _, _, left, right, w, _, is_acceptable = state
         return jnp.logical_and(right - left > 1.1 * w, is_acceptable)
 
-    def body_fn(state):
+    def body_fn(state: tuple) -> tuple:
         x1, x0, left, right, w, D, _ = state
         mid = (left + right) / 2
         D = jnp.logical_or(
@@ -296,8 +347,8 @@ def _accept_fn(y, x1, x0, cond_lp_fn, left, right, w):
         right = jnp.where(x1 < mid, mid, right)
         left = jnp.where(x1 >= mid, mid, left)
 
-        left_is_not_acceptable = y >= cond_lp_fn(left)
-        right_is_not_acceptable = y >= cond_lp_fn(right)
+        left_is_not_acceptable = logdensity >= conditional_logdensity_fn(left)
+        right_is_not_acceptable = logdensity >= conditional_logdensity_fn(right)
         interval_is_not_acceptable = jnp.logical_and(
             left_is_not_acceptable, right_is_not_acceptable
         )

--- a/blackjax/mcmc/slice.py
+++ b/blackjax/mcmc/slice.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Public API for the Slice sampling kernel."""
 
-from typing import Callable, NamedTuple, Union
+from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -72,7 +72,7 @@ def init(position: ArrayLikeTree, logdensity_fn: Callable) -> SliceState:
 
 
 def build_kernel(
-    n_doublings: int = 10, initial_widths: Union[float, Array] = 1.0
+    n_doublings: int = 10, initial_widths: float | Array = 1.0
 ) -> Callable:
     """Build a Slice sampling kernel.
 
@@ -121,7 +121,7 @@ def as_top_level_api(
     logdensity_fn: Callable,
     *,
     n_doublings: int = 10,
-    initial_widths: Union[float, Array] = 1.0,
+    initial_widths: float | Array = 1.0,
 ) -> SamplingAlgorithm:
     """Implements the user interface for the Slice sampling kernel.
 
@@ -165,7 +165,7 @@ def as_top_level_api(
 
 
 def _slice_proposal(
-    logdensity_fn: Callable, n_doublings: int, initial_widths: Union[float, Array]
+    logdensity_fn: Callable, n_doublings: int, initial_widths: float | Array
 ) -> Callable:
     def generate(rng_key: PRNGKey, state: SliceState) -> tuple[SliceState, ArrayTree]:
         order_key, rng_key = random.split(rng_key)

--- a/blackjax/mcmc/slice.py
+++ b/blackjax/mcmc/slice.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Public API for the Slice sampling kernel."""
 
-from typing import Callable, NamedTuple
+from typing import Callable, NamedTuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -71,7 +71,9 @@ def init(position: ArrayLikeTree, logdensity_fn: Callable) -> SliceState:
     return SliceState(position, jnp.atleast_1d(logdensity))
 
 
-def build_kernel(n_doublings: int = 10, initial_widths: float = 1.0) -> Callable:
+def build_kernel(
+    n_doublings: int = 10, initial_widths: Union[float, Array] = 1.0
+) -> Callable:
     """Build a Slice sampling kernel.
 
     Implementation according to [1]. Doubling implementation inspired
@@ -82,13 +84,16 @@ def build_kernel(n_doublings: int = 10, initial_widths: float = 1.0) -> Callable
     n_doublings
         Maximum number of slice interval doublings.
     initial_widths
-        Fixed per-dimension bracket width used as the starting interval for
-        the doubling procedure (default: 1.0).  The value 1.0 is a
-        reasonable default for posterior scales in the range 0.1–10: the
-        doubling procedure rapidly expands the bracket when the width is
+        Fixed bracket width(s) used as the starting interval for the doubling
+        procedure.  Accepts either a scalar (applied uniformly to every
+        coordinate, default: 1.0) or a 1-D array of length equal to the
+        total flattened position dimension ``D``, giving a per-coordinate
+        width — mirroring TFP's per-dimension ``step_size``.  The value 1.0
+        is a reasonable default for posterior scales in the range 0.1–10:
+        the doubling procedure rapidly expands the bracket when the width is
         too small, so correctness is insensitive to the exact value.  Pass
-        a smaller value for very narrow posteriors, or a larger one for very
-        diffuse ones, to improve efficiency.
+        a smaller value (or per-dimension array) for very narrow posteriors,
+        or a larger one for very diffuse ones, to improve efficiency.
 
     Returns
     -------
@@ -116,7 +121,7 @@ def as_top_level_api(
     logdensity_fn: Callable,
     *,
     n_doublings: int = 10,
-    initial_widths: float = 1.0,
+    initial_widths: Union[float, Array] = 1.0,
 ) -> SamplingAlgorithm:
     """Implements the user interface for the Slice sampling kernel.
 
@@ -146,8 +151,10 @@ def as_top_level_api(
     n_doublings
         Maximum number of slice interval doublings (default: 10).
     initial_widths
-        Fixed per-dimension bracket width used as the starting interval for
-        the doubling procedure (default: 1.0).
+        Fixed bracket width(s) used as the starting interval for the doubling
+        procedure.  A scalar applies to all coordinates; a 1-D array of
+        length ``D`` (total flattened position dimension) gives per-coordinate
+        widths, mirroring TFP's per-dimension ``step_size`` (default: 1.0).
 
     Returns
     -------
@@ -158,12 +165,16 @@ def as_top_level_api(
 
 
 def _slice_proposal(
-    logdensity_fn: Callable, n_doublings: int, initial_widths: float
+    logdensity_fn: Callable, n_doublings: int, initial_widths: Union[float, Array]
 ) -> Callable:
     def generate(rng_key: PRNGKey, state: SliceState) -> tuple[SliceState, ArrayTree]:
         order_key, rng_key = random.split(rng_key)
         positions, unravel_fn = jax.flatten_util.ravel_pytree(state.position)
-        widths = jnp.full(positions.shape, initial_widths)
+        # Scalar → uniform width; array → per-coordinate widths (length D).
+        # jnp.broadcast_to handles both: a scalar broadcasts to (D,) cleanly,
+        # and an array of shape (D,) is validated by broadcast semantics
+        # (a length mismatch raises an error at build time, before any JIT).
+        widths = jnp.broadcast_to(jnp.asarray(initial_widths).ravel(), positions.shape)
 
         def body_fn(
             carry: tuple[Array, Array], rn: tuple[PRNGKey, Array]

--- a/blackjax/mcmc/slice.py
+++ b/blackjax/mcmc/slice.py
@@ -157,15 +157,12 @@ def _slice_proposal(logdensity_fn: Callable, n_doublings: int) -> Callable:
         positions, unravel_fn = jax.flatten_util.ravel_pytree(state.position)
         widths, _ = jax.flatten_util.ravel_pytree(state.widths)
 
-        def conditional_proposal(rng_key, idx):
-            return _sample_conditionally(
-                rng_key, logdensity_fn, unravel_fn, idx, positions, widths, n_doublings
-            )
-
         def body_fn(carry, rn):
             seed, idx = rn
             positions, widths = carry
-            xi, wi = conditional_proposal(seed, idx)
+            xi, wi = _sample_conditionally(
+                seed, logdensity_fn, unravel_fn, idx, positions, widths, n_doublings
+            )
             positions = positions.at[idx].set(xi)
             nw = widths[idx] + (wi - widths[idx]) / (n + 1)
             widths = widths.at[idx].set(nw)
@@ -210,17 +207,26 @@ def _sample_conditionally(
 
 
 def _doubling_fn(rng, y, x0, cond_lp_fn, w, n_doublings):
-    key1, key2, key3, key4 = random.split(rng, 4)
-    left = x0 - w * random.uniform(key1)
+    key1, key2 = random.split(rng, 2)
+    initial_left = x0 - w * random.uniform(key1)
+    initial_right = initial_left + w
 
     K = n_doublings + 1
     left_expands = random.bernoulli(key2, 0.5, (K,))
-    width_multipliers = 2 ** jnp.arange(0, K, dtype=jnp.int32)
-    widths = width_multipliers * w
-    left_increments = jnp.cumsum(widths * left_expands)
+    right_expands = 1 - left_expands.astype(jnp.int32)
+    step_widths = w * (2 ** jnp.arange(0, K, dtype=jnp.float32))
 
-    lefts = left - left_increments
-    rights = left + widths
+    # Exclusive cumsum: increment at level k = sum of expansions at steps 0..k-1.
+    # rights[0] and lefts[0] are the initial interval (0 doublings).
+    left_increments = jnp.concatenate(
+        [jnp.zeros(1), jnp.cumsum(step_widths * left_expands)[:-1]]
+    )
+    right_increments = jnp.concatenate(
+        [jnp.zeros(1), jnp.cumsum(step_widths * right_expands)[:-1]]
+    )
+
+    lefts = initial_left - left_increments
+    rights = initial_right + right_increments
     left_lps = jax.vmap(cond_lp_fn)(lefts)
     right_lps = jax.vmap(cond_lp_fn)(rights)
 

--- a/blackjax/mcmc/slice.py
+++ b/blackjax/mcmc/slice.py
@@ -1,0 +1,305 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Public API for the Slice sampling kernel."""
+from typing import Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax import random
+
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
+
+__all__ = ["SliceState", "SliceInfo", "init", "build_kernel", "as_top_level_api"]
+
+
+class SliceState(NamedTuple):
+    """State of the Slice sampling chain.
+
+    position
+        Current position of the chain.
+    logdensity
+        Current value of the log-density.
+    widths
+        Per-dimension step widths, adapted online via Welford averaging.
+    n
+        Number of completed transitions (used to compute the running average
+        of step widths).
+
+    """
+
+    position: ArrayTree
+    logdensity: float
+    widths: ArrayTree
+    n: Array
+
+
+class SliceInfo(NamedTuple):
+    """Additional information on the Slice sampling transition.
+
+    widths
+        Per-dimension step widths after this transition (matches the position
+        PyTree structure). Useful for monitoring adaptation.
+
+    """
+
+    widths: ArrayTree
+
+
+def init(position: ArrayLikeTree, logdensity_fn: Callable) -> SliceState:
+    """Create an initial state from a position and log-density function.
+
+    Parameters
+    ----------
+    position
+        Initial position of the chain.
+    logdensity_fn
+        Log-probability density function of the target distribution.
+
+    Returns
+    -------
+    The initial state of the Slice sampling chain.
+    """
+    logdensity = logdensity_fn(position)
+    widths = jax.tree.map(lambda x: jnp.full(x.shape, 0.01), position)
+    return SliceState(position, jnp.atleast_1d(logdensity), widths, jnp.atleast_1d(0.0))
+
+
+def build_kernel(n_doublings: int = 10) -> Callable:
+    """Build a Slice sampling kernel.
+
+    Implementation according to [1]. Doubling implementation inspired
+    by TensorFlow Probability's implementation.
+
+    Parameters
+    ----------
+    n_doublings
+        Maximum number of slice interval doublings.
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current state
+    of the chain and returns a new state of the chain along with information
+    about the transition.
+
+    References
+    ----------
+    .. [1] Radford M. Neal, "Slice sampling", The Annals of Statistics,
+       Ann. Statist. 31(3), 705-767, (June 2003).
+    """
+
+    def kernel(
+        rng_key: PRNGKey, state: SliceState, logdensity_fn: Callable
+    ) -> tuple[SliceState, SliceInfo]:
+        proposal_generator = _slice_proposal(logdensity_fn, n_doublings)
+        new_state = proposal_generator(rng_key, state)
+        return new_state, SliceInfo(new_state.widths)
+
+    return kernel
+
+
+def as_top_level_api(
+    logdensity_fn: Callable,
+    *,
+    n_doublings: int = 10,
+) -> SamplingAlgorithm:
+    """Implements the user interface for the Slice sampling kernel.
+
+    Examples
+    --------
+
+    A new Slice sampling kernel can be initialized and used with the following
+    code:
+
+    .. code::
+
+        slice_sampling = blackjax.slice_sampling(logdensity_fn, n_doublings=10)
+        state = slice_sampling.init(position)
+        new_state, info = slice_sampling.step(rng_key, state)
+
+    We can JIT-compile the step function for better performance:
+
+    .. code::
+
+        step = jax.jit(slice_sampling.step)
+        new_state, info = step(rng_key, state)
+
+    Parameters
+    ----------
+    logdensity_fn
+        The log-density function of the distribution we wish to sample from.
+    n_doublings
+        Maximum number of slice interval doublings (default: 10).
+
+    Returns
+    -------
+    A ``SamplingAlgorithm``.
+    """
+    kernel = build_kernel(n_doublings)
+    return build_sampling_algorithm(kernel, init, logdensity_fn)
+
+
+def _slice_proposal(logdensity_fn: Callable, n_doublings: int) -> Callable:
+    def generate(rng_key: PRNGKey, state: SliceState) -> SliceState:
+        order_key, rng_key = random.split(rng_key)
+        n = state.n[0]
+        positions, unravel_fn = jax.flatten_util.ravel_pytree(state.position)
+        widths, _ = jax.flatten_util.ravel_pytree(state.widths)
+
+        def conditional_proposal(rng_key, idx):
+            return _sample_conditionally(
+                rng_key, logdensity_fn, unravel_fn, idx, positions, widths, n_doublings
+            )
+
+        def body_fn(carry, rn):
+            seed, idx = rn
+            positions, widths = carry
+            xi, wi = conditional_proposal(seed, idx)
+            positions = positions.at[idx].set(xi)
+            nw = widths[idx] + (wi - widths[idx]) / (n + 1)
+            widths = widths.at[idx].set(nw)
+            return (positions, widths), (positions, widths)
+
+        order = random.choice(
+            order_key,
+            jnp.arange(len(positions)),
+            shape=(len(positions),),
+            replace=False,
+        )
+
+        keys = random.split(rng_key, len(positions))
+        (new_positions, new_widths), _ = jax.lax.scan(
+            body_fn, (positions, widths), (keys, order)
+        )
+
+        new_positions = unravel_fn(new_positions)
+        new_widths = unravel_fn(new_widths)
+        return SliceState(
+            new_positions,
+            jnp.atleast_1d(logdensity_fn(new_positions)),
+            new_widths,
+            jnp.atleast_1d(n + 1.0),
+        )
+
+    return generate
+
+
+def _sample_conditionally(
+    seed, logdensity_fn, unravel_fn, idx, positions, widths, n_doublings
+):
+    def cond_lp_fn(xi_to_set):
+        return logdensity_fn(unravel_fn(positions.at[idx].set(xi_to_set)))
+
+    key, seed1, seed2 = random.split(seed, 3)
+    x0, w0 = positions[idx], widths[idx]
+    y = cond_lp_fn(x0) - random.exponential(key)
+    left, right, _ = _doubling_fn(seed1, y, x0, cond_lp_fn, w0, n_doublings)
+    x1 = _shrinkage_fn(seed2, y, x0, cond_lp_fn, left, right, w0)
+    return x1, right - left
+
+
+def _doubling_fn(rng, y, x0, cond_lp_fn, w, n_doublings):
+    key1, key2, key3, key4 = random.split(rng, 4)
+    left = x0 - w * random.uniform(key1)
+
+    K = n_doublings + 1
+    left_expands = random.bernoulli(key2, 0.5, (K,))
+    width_multipliers = 2 ** jnp.arange(0, K, dtype=jnp.int32)
+    widths = width_multipliers * w
+    left_increments = jnp.cumsum(widths * left_expands)
+
+    lefts = left - left_increments
+    rights = left + widths
+    left_lps = jax.vmap(cond_lp_fn)(lefts)
+    right_lps = jax.vmap(cond_lp_fn)(rights)
+
+    both_ok = jnp.logical_and(left_lps < y, right_lps < y)
+    best_interval_idx = _best_interval(both_ok.astype(jnp.int32))
+
+    return (
+        lefts[best_interval_idx],
+        rights[best_interval_idx],
+        both_ok[best_interval_idx],
+    )
+
+
+def _best_interval(x):
+    k = x.shape[0]
+    mults = jnp.arange(2 * k, k, -1, dtype=x.dtype)
+    shifts = jnp.arange(k, dtype=x.dtype)
+    indices = jnp.argmax(mults * x + shifts).astype(x.dtype)
+    return indices
+
+
+def _shrinkage_fn(seed, y, x0, cond_lp_fn, left, right, w):
+    def cond_fn(state):
+        *_, found = state
+        return jnp.logical_not(found)
+
+    def body_fn(state):
+        x1, left, right, seed, _ = state
+        key, seed = random.split(seed)
+        v = random.uniform(key)
+        x1 = left + v * (right - left)
+
+        found = jnp.logical_and(
+            y < cond_lp_fn(x1), _accept_fn(y, x1, x0, cond_lp_fn, left, right, w)
+        )
+
+        left = jnp.where(x1 < x0, x1, left)
+        right = jnp.where(x1 >= x0, x1, right)
+
+        return x1, left, right, seed, found
+
+    key, seed = random.split(seed)
+    v = random.uniform(key)
+    x1 = left + v * (right - left)
+    x1, left, right, seed, _ = jax.lax.while_loop(
+        cond_fn, body_fn, (x1, left, right, seed, False)
+    )
+    return x1
+
+
+def _accept_fn(y, x1, x0, cond_lp_fn, left, right, w):
+    def cond_fn(state):
+        _, _, left, right, w, _, is_acceptable = state
+        return jnp.logical_and(right - left > 1.1 * w, is_acceptable)
+
+    def body_fn(state):
+        x1, x0, left, right, w, D, _ = state
+        mid = (left + right) / 2
+        D = jnp.logical_or(
+            jnp.logical_or(
+                jnp.logical_and(x0 < mid, x1 >= mid),
+                jnp.logical_and(x0 >= mid, x1 < mid),
+            ),
+            D,
+        )
+        right = jnp.where(x1 < mid, mid, right)
+        left = jnp.where(x1 >= mid, mid, left)
+
+        left_is_not_acceptable = y >= cond_lp_fn(left)
+        right_is_not_acceptable = y >= cond_lp_fn(right)
+        interval_is_not_acceptable = jnp.logical_and(
+            left_is_not_acceptable, right_is_not_acceptable
+        )
+        is_still_acceptable = jnp.logical_not(
+            jnp.logical_and(D, interval_is_not_acceptable)
+        )
+        return x1, x0, left, right, w, D, is_still_acceptable
+
+    *_, is_acceptable = jax.lax.while_loop(
+        cond_fn, body_fn, (x1, x0, left, right, w, False, True)
+    )
+    return is_acceptable

--- a/tests/mcmc/test_slice.py
+++ b/tests/mcmc/test_slice.py
@@ -19,12 +19,7 @@ import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest
 
-from blackjax.mcmc.slice import (
-    SliceInfo,
-    SliceState,
-    build_kernel,
-    init,
-)
+from blackjax.mcmc.slice import SliceInfo, SliceState, build_kernel, init
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
 
@@ -62,7 +57,6 @@ class SliceInitTest(BlackJAXTest):
         self.assertIsInstance(state, SliceState)
         assert jnp.isfinite(state.logdensity[0])
         chex.assert_trees_all_equal_shapes(state.widths, position)
-
 
 
 class SliceKernelTest(BlackJAXTest):
@@ -163,7 +157,6 @@ class SliceKernelTest(BlackJAXTest):
         for _ in range(5):
             state, _ = kernel(self.next_key(), state, std_normal_logdensity)
             assert jnp.isfinite(state.logdensity[0])
-
 
 
 class SliceTopLevelAPITest(BlackJAXTest):

--- a/tests/mcmc/test_slice.py
+++ b/tests/mcmc/test_slice.py
@@ -138,7 +138,7 @@ class SliceKernelTest(BlackJAXTest):
             assert jnp.isfinite(state.logdensity[0])
 
     def test_initial_widths_parameter(self):
-        """build_kernel accepts initial_widths and runs without error."""
+        """build_kernel accepts a scalar initial_widths and runs without error."""
         position = jnp.zeros(3)
         state = init(position, std_normal_logdensity)
         kernel = build_kernel(n_doublings=5, initial_widths=2.0)
@@ -146,6 +146,26 @@ class SliceKernelTest(BlackJAXTest):
         self.assertIsInstance(new_state, SliceState)
         flat_bw, _ = jax.flatten_util.ravel_pytree(info.bracket_widths)
         assert jnp.all(flat_bw > 0)
+
+    def test_per_dim_initial_widths(self):
+        """build_kernel accepts a per-coordinate initial_widths array (D,).
+
+        Verifies that distinct per-dimension widths are accepted and that the
+        kernel still runs, produces valid states, and returns finite positive
+        bracket widths.  Uses a 3D target with widths [0.5, 1.0, 2.0] to
+        exercise the non-uniform path end-to-end.
+        """
+        ndim = 3
+        per_dim_widths = jnp.array([0.5, 1.0, 2.0])
+        position = jnp.zeros(ndim)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5, initial_widths=per_dim_widths)
+        new_state, info = kernel(self.next_key(), state, std_normal_logdensity)
+        self.assertIsInstance(new_state, SliceState)
+        self.assertEqual(new_state.position.shape, (ndim,))
+        flat_bw, _ = jax.flatten_util.ravel_pytree(info.bracket_widths)
+        assert jnp.all(jnp.isfinite(flat_bw)), "bracket_widths must be finite"
+        assert jnp.all(flat_bw > 0), "bracket_widths must be positive"
 
 
 class SliceTopLevelAPITest(BlackJAXTest):
@@ -226,6 +246,37 @@ class SliceMomentsRecoveryTest(BlackJAXTest):
             self.assertAlmostEqual(float(means[i]), 0.0, delta=0.15)
             self.assertGreater(float(stds[i]), 0.8)
             self.assertLess(float(stds[i]), 1.2)
+
+    def test_recovers_moments_with_per_dim_widths(self):
+        """Per-dimension initial_widths array produces correct samples.
+
+        Uses distinct widths [0.5, 1.5, 3.0] on a 3D standard normal.
+        Verifies that per-coordinate widths do not break correctness.
+        """
+        per_dim_widths = jnp.array([0.5, 1.5, 3.0])
+        positions = self._run_chain(
+            std_normal_logdensity,
+            jnp.zeros(3),
+            n_steps=2000,
+            n_doublings=10,
+        )
+        # Re-run with per-dim widths (override kernel inside _run_chain is not
+        # straightforward, so build and run inline here).
+        state = init(jnp.zeros(3), std_normal_logdensity)
+        kernel = build_kernel(n_doublings=10, initial_widths=per_dim_widths)
+
+        def step_fn(s, key):
+            new_s, _ = kernel(key, s, std_normal_logdensity)
+            return new_s, new_s.position
+
+        keys = jax.random.split(self.next_key(), 2000)
+        _, positions = jax.lax.scan(step_fn, state, keys)
+        means = jnp.mean(positions, axis=0)
+        stds = jnp.std(positions, axis=0)
+        for i in range(3):
+            self.assertAlmostEqual(float(means[i]), 0.0, delta=0.2)
+            self.assertGreater(float(stds[i]), 0.7)
+            self.assertLess(float(stds[i]), 1.3)
 
     def test_recovers_correlated_gaussian_2d(self):
         """Slice sampler recovers the correlation of a 2D Gaussian with rho=0.9.

--- a/tests/mcmc/test_slice.py
+++ b/tests/mcmc/test_slice.py
@@ -1,0 +1,211 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the Slice sampling kernel."""
+
+import chex
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest
+
+from blackjax.mcmc.slice import (
+    SliceInfo,
+    SliceState,
+    build_kernel,
+    init,
+)
+from tests.fixtures import BlackJAXTest, std_normal_logdensity
+
+
+class SliceInitTest(BlackJAXTest):
+    """Tests for slice.init."""
+
+    def test_init_stores_position_and_logdensity(self):
+        """init stores the initial position and the log-density at that position."""
+        position = jnp.array([1.0, 2.0, 3.0])
+        state = init(position, std_normal_logdensity)
+        np.testing.assert_allclose(state.position, position)
+        expected_ld = std_normal_logdensity(position)
+        np.testing.assert_allclose(float(state.logdensity[0]), float(expected_ld))
+
+    def test_init_widths_are_positive(self):
+        """Initial step widths are all positive."""
+        position = jnp.ones(4)
+        state = init(position, std_normal_logdensity)
+        flat_widths, _ = jax.flatten_util.ravel_pytree(state.widths)
+        assert jnp.all(flat_widths > 0)
+
+    def test_init_n_is_zero(self):
+        """Iteration counter starts at zero."""
+        state = init(jnp.zeros(2), std_normal_logdensity)
+        np.testing.assert_equal(float(state.n[0]), 0.0)
+
+    def test_init_pytree_position(self):
+        """init works with PyTree (dict) positions."""
+
+        def logdensity_fn(pos):
+            return -0.5 * (jnp.sum(pos["a"] ** 2) + jnp.sum(pos["b"] ** 2))
+
+        position = {"a": jnp.ones(2), "b": jnp.zeros(3)}
+        state = init(position, logdensity_fn)
+        self.assertIsInstance(state, SliceState)
+        assert jnp.isfinite(state.logdensity[0])
+        chex.assert_trees_all_equal_shapes(state.widths, position)
+
+
+
+class SliceKernelTest(BlackJAXTest):
+    """Tests for the slice sampling kernel."""
+
+    def test_returns_state_and_info(self):
+        """Kernel returns a (SliceState, SliceInfo) pair."""
+        position = jnp.zeros(3)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        new_state, info = kernel(self.next_key(), state, std_normal_logdensity)
+        self.assertIsInstance(new_state, SliceState)
+        self.assertIsInstance(info, SliceInfo)
+
+    def test_position_shape_preserved(self):
+        """Output position has the same shape as input position."""
+        ndim = 4
+        position = jnp.zeros(ndim)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        new_state, _ = kernel(self.next_key(), state, std_normal_logdensity)
+        self.assertEqual(new_state.position.shape, (ndim,))
+
+    def test_logdensity_consistent(self):
+        """Stored logdensity matches the density evaluated at the new position."""
+        position = jnp.zeros(3)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        new_state, _ = kernel(self.next_key(), state, std_normal_logdensity)
+        expected = std_normal_logdensity(new_state.position)
+        np.testing.assert_allclose(
+            float(new_state.logdensity[0]), float(expected), atol=1e-5
+        )
+
+    def test_n_increments(self):
+        """Iteration counter increments by 1 per step."""
+        state = init(jnp.zeros(2), std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        new_state, _ = kernel(self.next_key(), state, std_normal_logdensity)
+        np.testing.assert_equal(float(new_state.n[0]), 1.0)
+
+    def test_info_widths_match_state(self):
+        """SliceInfo.widths equals the widths stored in the new state."""
+        position = jnp.zeros(3)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        new_state, info = kernel(self.next_key(), state, std_normal_logdensity)
+        flat_state_widths, _ = jax.flatten_util.ravel_pytree(new_state.widths)
+        flat_info_widths, _ = jax.flatten_util.ravel_pytree(info.widths)
+        np.testing.assert_allclose(flat_state_widths, flat_info_widths)
+
+    def test_widths_adapt(self):
+        """Step widths change from their initial values after several steps."""
+        position = jnp.zeros(3)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        initial_widths, _ = jax.flatten_util.ravel_pytree(state.widths)
+
+        for _ in range(10):
+            state, _ = kernel(self.next_key(), state, std_normal_logdensity)
+
+        final_widths, _ = jax.flatten_util.ravel_pytree(state.widths)
+        assert not jnp.allclose(initial_widths, final_widths)
+
+    def test_pytree_position(self):
+        """Kernel works with PyTree (dict) positions."""
+
+        def logdensity_fn(pos):
+            return -0.5 * (jnp.sum(pos["x"] ** 2) + jnp.sum(pos["y"] ** 2))
+
+        position = {"x": jnp.zeros(2), "y": jnp.zeros(2)}
+        state = init(position, logdensity_fn)
+        kernel = build_kernel(n_doublings=5)
+        new_state, info = kernel(self.next_key(), state, logdensity_fn)
+        chex.assert_trees_all_equal_shapes(new_state.position, position)
+        chex.assert_trees_all_equal_shapes(info.widths, position)
+
+    def test_jit_compatible(self):
+        """Kernel is JIT-compilable."""
+        position = jnp.zeros(3)
+        state = init(position, std_normal_logdensity)
+        kernel = jax.jit(build_kernel(n_doublings=5), static_argnums=(2,))
+        new_state, _ = kernel(self.next_key(), state, std_normal_logdensity)
+        self.assertEqual(new_state.position.shape, (3,))
+
+    def test_different_keys_give_different_samples(self):
+        """Two independent runs from the same state produce different positions."""
+        state = init(jnp.zeros(3), std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        new_state_1, _ = kernel(self.next_key(), state, std_normal_logdensity)
+        new_state_2, _ = kernel(self.next_key(), state, std_normal_logdensity)
+        assert not jnp.allclose(new_state_1.position, new_state_2.position)
+
+    def test_logdensity_finite(self):
+        """Log-density in the new state is always finite."""
+        state = init(jnp.ones(3), std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5)
+        for _ in range(5):
+            state, _ = kernel(self.next_key(), state, std_normal_logdensity)
+            assert jnp.isfinite(state.logdensity[0])
+
+
+
+class SliceTopLevelAPITest(BlackJAXTest):
+    """Tests for the top-level blackjax.slice_sampling API."""
+
+    def test_init_and_step(self):
+        """Top-level API: init + step runs and returns SliceState."""
+        import blackjax
+
+        algo = blackjax.slice_sampling(std_normal_logdensity, n_doublings=5)
+        state = algo.init(jnp.zeros(3))
+        new_state, info = algo.step(self.next_key(), state)
+        self.assertIsInstance(new_state, SliceState)
+        self.assertIsInstance(info, SliceInfo)
+
+    def test_top_level_jit(self):
+        """Top-level step is JIT-compilable."""
+        import blackjax
+
+        algo = blackjax.slice_sampling(std_normal_logdensity, n_doublings=5)
+        state = algo.init(jnp.zeros(3))
+        new_state, _ = jax.jit(algo.step)(self.next_key(), state)
+        self.assertEqual(new_state.position.shape, (3,))
+
+    def test_default_n_doublings(self):
+        """as_top_level_api default n_doublings=10 works without explicit arg."""
+        import blackjax
+
+        algo = blackjax.slice_sampling(std_normal_logdensity)
+        state = algo.init(jnp.zeros(2))
+        new_state, _ = algo.step(self.next_key(), state)
+        self.assertEqual(new_state.position.shape, (2,))
+
+    def test_build_kernel_accessible(self):
+        """build_kernel is accessible via blackjax.slice_sampling.build_kernel."""
+        import blackjax
+
+        kernel = blackjax.slice_sampling.build_kernel(n_doublings=3)
+        state = blackjax.slice_sampling.init(jnp.zeros(2), std_normal_logdensity)
+        new_state, info = kernel(self.next_key(), state, std_normal_logdensity)
+        self.assertIsInstance(new_state, SliceState)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/mcmc/test_slice.py
+++ b/tests/mcmc/test_slice.py
@@ -200,5 +200,76 @@ class SliceTopLevelAPITest(BlackJAXTest):
         self.assertIsInstance(new_state, SliceState)
 
 
+class SliceMomentsRecoveryTest(BlackJAXTest):
+    """Statistical moments-recovery tests: verify the sampler actually samples correctly.
+
+    These tests run the kernel for enough steps to measure empirical mean and
+    standard deviation and assert they match the target. Tolerances are
+    deliberately generous to avoid seed-specific flakiness — the point is to
+    catch gross sampling failures, not to test convergence speed.
+    """
+
+    def _run_chain(self, logdensity_fn, initial_position, n_steps, n_doublings=10):
+        """Run a slice-sampling chain and return an array of positions."""
+        state = init(initial_position, logdensity_fn)
+        kernel = build_kernel(n_doublings=n_doublings)
+
+        def step_fn(state, key):
+            new_state, _ = kernel(key, state, logdensity_fn)
+            return new_state, new_state.position
+
+        keys = jax.random.split(self.next_key(), n_steps)
+        _, positions = jax.lax.scan(step_fn, state, keys)
+        return positions
+
+    def test_recovers_mean_std_normal_1d(self):
+        """Slice sampler recovers the mean of a 1D standard normal.
+
+        Uses 2000 post-warmup steps and checks mean within 0.15 of 0.0
+        and std within [0.8, 1.2].  Tolerance is ~3 SE for ESS≈100, leaving
+        substantial room for the actual ESS, which is typically >> 100 here.
+        """
+        positions = self._run_chain(std_normal_logdensity, jnp.zeros(1), n_steps=2000)
+        mean = float(jnp.mean(positions))
+        std = float(jnp.std(positions))
+        self.assertAlmostEqual(mean, 0.0, delta=0.15)
+        self.assertGreater(std, 0.8)
+        self.assertLess(std, 1.2)
+
+    def test_recovers_std_normal_2d(self):
+        """Slice sampler recovers marginal means and stds of a 2D standard normal."""
+        positions = self._run_chain(std_normal_logdensity, jnp.zeros(2), n_steps=2000)
+        means = jnp.mean(positions, axis=0)
+        stds = jnp.std(positions, axis=0)
+        for i in range(2):
+            self.assertAlmostEqual(float(means[i]), 0.0, delta=0.15)
+            self.assertGreater(float(stds[i]), 0.8)
+            self.assertLess(float(stds[i]), 1.2)
+
+    def test_recovers_correlated_gaussian_2d(self):
+        """Slice sampler recovers the correlation of a 2D Gaussian with rho=0.9.
+
+        Coordinate-wise updates can mix slowly under high correlation, so this
+        test uses 3000 steps and only checks that the empirical correlation is
+        positive and at least 0.7 (true value is 0.9).
+        """
+        rho = jnp.asarray(0.9)
+        sigma2 = 1.0 - rho**2
+
+        def corr_gaussian_logdensity(x):
+            x0, x1 = x[0], x[1]
+            return -0.5 / sigma2 * (x0**2 - 2.0 * rho * x0 * x1 + x1**2)
+
+        positions = self._run_chain(
+            corr_gaussian_logdensity, jnp.zeros(2), n_steps=3000
+        )
+        x0 = np.array(positions[:, 0])
+        x1 = np.array(positions[:, 1])
+        corr = float(np.corrcoef(x0, x1)[0, 1])
+        self.assertGreater(corr, 0.7)
+        for i in range(2):
+            self.assertAlmostEqual(float(jnp.mean(positions[:, i])), 0.0, delta=0.2)
+
+
 if __name__ == "__main__":
     absltest.main()

--- a/tests/mcmc/test_slice.py
+++ b/tests/mcmc/test_slice.py
@@ -147,6 +147,7 @@ class SliceKernelTest(BlackJAXTest):
         flat_bw, _ = jax.flatten_util.ravel_pytree(info.bracket_widths)
         assert jnp.all(flat_bw > 0)
 
+    @chex.assert_max_traces(n=2)
     def test_per_dim_initial_widths(self):
         """build_kernel accepts a per-coordinate initial_widths array (D,).
 

--- a/tests/mcmc/test_slice.py
+++ b/tests/mcmc/test_slice.py
@@ -19,6 +19,7 @@ import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest
 
+import blackjax
 from blackjax.mcmc.slice import SliceInfo, SliceState, build_kernel, init
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
@@ -34,18 +35,6 @@ class SliceInitTest(BlackJAXTest):
         expected_ld = std_normal_logdensity(position)
         np.testing.assert_allclose(float(state.logdensity[0]), float(expected_ld))
 
-    def test_init_widths_are_positive(self):
-        """Initial step widths are all positive."""
-        position = jnp.ones(4)
-        state = init(position, std_normal_logdensity)
-        flat_widths, _ = jax.flatten_util.ravel_pytree(state.widths)
-        assert jnp.all(flat_widths > 0)
-
-    def test_init_n_is_zero(self):
-        """Iteration counter starts at zero."""
-        state = init(jnp.zeros(2), std_normal_logdensity)
-        np.testing.assert_equal(float(state.n[0]), 0.0)
-
     def test_init_pytree_position(self):
         """init works with PyTree (dict) positions."""
 
@@ -56,12 +45,18 @@ class SliceInitTest(BlackJAXTest):
         state = init(position, logdensity_fn)
         self.assertIsInstance(state, SliceState)
         assert jnp.isfinite(state.logdensity[0])
-        chex.assert_trees_all_equal_shapes(state.widths, position)
+
+    def test_init_state_has_two_fields(self):
+        """SliceState has exactly position and logdensity (pure Markov state)."""
+        state = init(jnp.zeros(2), std_normal_logdensity)
+        self.assertIsInstance(state, SliceState)
+        self.assertEqual(len(state), 2)
 
 
 class SliceKernelTest(BlackJAXTest):
     """Tests for the slice sampling kernel."""
 
+    @chex.assert_max_traces(n=2)
     def test_returns_state_and_info(self):
         """Kernel returns a (SliceState, SliceInfo) pair."""
         position = jnp.zeros(3)
@@ -71,6 +66,7 @@ class SliceKernelTest(BlackJAXTest):
         self.assertIsInstance(new_state, SliceState)
         self.assertIsInstance(info, SliceInfo)
 
+    @chex.assert_max_traces(n=2)
     def test_position_shape_preserved(self):
         """Output position has the same shape as input position."""
         ndim = 4
@@ -80,6 +76,7 @@ class SliceKernelTest(BlackJAXTest):
         new_state, _ = kernel(self.next_key(), state, std_normal_logdensity)
         self.assertEqual(new_state.position.shape, (ndim,))
 
+    @chex.assert_max_traces(n=2)
     def test_logdensity_consistent(self):
         """Stored logdensity matches the density evaluated at the new position."""
         position = jnp.zeros(3)
@@ -91,36 +88,18 @@ class SliceKernelTest(BlackJAXTest):
             float(new_state.logdensity[0]), float(expected), atol=1e-5
         )
 
-    def test_n_increments(self):
-        """Iteration counter increments by 1 per step."""
-        state = init(jnp.zeros(2), std_normal_logdensity)
-        kernel = build_kernel(n_doublings=5)
-        new_state, _ = kernel(self.next_key(), state, std_normal_logdensity)
-        np.testing.assert_equal(float(new_state.n[0]), 1.0)
-
-    def test_info_widths_match_state(self):
-        """SliceInfo.widths equals the widths stored in the new state."""
+    @chex.assert_max_traces(n=2)
+    def test_info_reports_bracket_widths(self):
+        """SliceInfo.bracket_widths is a finite positive diagnostic output."""
         position = jnp.zeros(3)
         state = init(position, std_normal_logdensity)
         kernel = build_kernel(n_doublings=5)
-        new_state, info = kernel(self.next_key(), state, std_normal_logdensity)
-        flat_state_widths, _ = jax.flatten_util.ravel_pytree(new_state.widths)
-        flat_info_widths, _ = jax.flatten_util.ravel_pytree(info.widths)
-        np.testing.assert_allclose(flat_state_widths, flat_info_widths)
+        _, info = kernel(self.next_key(), state, std_normal_logdensity)
+        flat_bw, _ = jax.flatten_util.ravel_pytree(info.bracket_widths)
+        assert jnp.all(jnp.isfinite(flat_bw)), "bracket_widths must be finite"
+        assert jnp.all(flat_bw > 0), "bracket_widths must be positive"
 
-    def test_widths_adapt(self):
-        """Step widths change from their initial values after several steps."""
-        position = jnp.zeros(3)
-        state = init(position, std_normal_logdensity)
-        kernel = build_kernel(n_doublings=5)
-        initial_widths, _ = jax.flatten_util.ravel_pytree(state.widths)
-
-        for _ in range(10):
-            state, _ = kernel(self.next_key(), state, std_normal_logdensity)
-
-        final_widths, _ = jax.flatten_util.ravel_pytree(state.widths)
-        assert not jnp.allclose(initial_widths, final_widths)
-
+    @chex.assert_max_traces(n=2)
     def test_pytree_position(self):
         """Kernel works with PyTree (dict) positions."""
 
@@ -132,7 +111,7 @@ class SliceKernelTest(BlackJAXTest):
         kernel = build_kernel(n_doublings=5)
         new_state, info = kernel(self.next_key(), state, logdensity_fn)
         chex.assert_trees_all_equal_shapes(new_state.position, position)
-        chex.assert_trees_all_equal_shapes(info.widths, position)
+        chex.assert_trees_all_equal_shapes(info.bracket_widths, position)
 
     def test_jit_compatible(self):
         """Kernel is JIT-compilable."""
@@ -158,14 +137,22 @@ class SliceKernelTest(BlackJAXTest):
             state, _ = kernel(self.next_key(), state, std_normal_logdensity)
             assert jnp.isfinite(state.logdensity[0])
 
+    def test_initial_widths_parameter(self):
+        """build_kernel accepts initial_widths and runs without error."""
+        position = jnp.zeros(3)
+        state = init(position, std_normal_logdensity)
+        kernel = build_kernel(n_doublings=5, initial_widths=2.0)
+        new_state, info = kernel(self.next_key(), state, std_normal_logdensity)
+        self.assertIsInstance(new_state, SliceState)
+        flat_bw, _ = jax.flatten_util.ravel_pytree(info.bracket_widths)
+        assert jnp.all(flat_bw > 0)
+
 
 class SliceTopLevelAPITest(BlackJAXTest):
     """Tests for the top-level blackjax.slice_sampling API."""
 
     def test_init_and_step(self):
         """Top-level API: init + step runs and returns SliceState."""
-        import blackjax
-
         algo = blackjax.slice_sampling(std_normal_logdensity, n_doublings=5)
         state = algo.init(jnp.zeros(3))
         new_state, info = algo.step(self.next_key(), state)
@@ -174,8 +161,6 @@ class SliceTopLevelAPITest(BlackJAXTest):
 
     def test_top_level_jit(self):
         """Top-level step is JIT-compilable."""
-        import blackjax
-
         algo = blackjax.slice_sampling(std_normal_logdensity, n_doublings=5)
         state = algo.init(jnp.zeros(3))
         new_state, _ = jax.jit(algo.step)(self.next_key(), state)
@@ -183,8 +168,6 @@ class SliceTopLevelAPITest(BlackJAXTest):
 
     def test_default_n_doublings(self):
         """as_top_level_api default n_doublings=10 works without explicit arg."""
-        import blackjax
-
         algo = blackjax.slice_sampling(std_normal_logdensity)
         state = algo.init(jnp.zeros(2))
         new_state, _ = algo.step(self.next_key(), state)
@@ -192,8 +175,6 @@ class SliceTopLevelAPITest(BlackJAXTest):
 
     def test_build_kernel_accessible(self):
         """build_kernel is accessible via blackjax.slice_sampling.build_kernel."""
-        import blackjax
-
         kernel = blackjax.slice_sampling.build_kernel(n_doublings=3)
         state = blackjax.slice_sampling.init(jnp.zeros(2), std_normal_logdensity)
         new_state, info = kernel(self.next_key(), state, std_normal_logdensity)

--- a/tests/test_api_protocols.py
+++ b/tests/test_api_protocols.py
@@ -120,6 +120,10 @@ def _make_algorithm(name):
             std_normal_logdensity,
             proposal_distribution=lambda key: jax.random.normal(key, (_DIM,)),
         ),
+        "slice_sampling": lambda: blackjax.slice_sampling(
+            std_normal_logdensity,
+            n_doublings=5,
+        ),
     }
 
     if name not in factories:
@@ -148,6 +152,7 @@ _MCMC_ALGORITHMS = [
     "additive_step_random_walk",
     "rmh",
     "irmh",
+    "slice_sampling",
 ]
 
 


### PR DESCRIPTION
## Description

Adds the Slice Sampler following the API from TFP. Discussed previously [here](https://github.com/blackjax-devs/blackjax/pull/514). 

## Checklist

**General**
- [x] The branch is rebased on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes (`mamba run -n blackjax python -m pytest tests/`)

**Code quality**
- [x] Public functions have docstrings following the [NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Naming follows existing conventions (`logdensity`, `jax.tree.map`, `jax.random.key()`, `jnp.clip(min=, max=)`)
- [x] All new code is JIT-compatible

**New sampler / algorithm** *(skip if not applicable)*
- [ ] There is an open issue discussing this algorithm (use the [sampler proposal template](https://github.com/blackjax-devs/blackjax/issues/new?template=sampler_proposal.yml))
- [x] Follows the three-layer pattern: `init` / `build_kernel` / `as_top_level_api`
- [x] Registered in `blackjax/__init__.py`
- [ ] An example notebook has been added or updated

Consider opening a **Draft PR** first if you want early feedback on the design.
