### PR TITLE
Add Lie-Trotter integrator for SGHMC

### DIFF
--- a/blackjax/sgmcmc/diffusions.py
+++ b/blackjax/sgmcmc/diffusions.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Solvers for Langevin diffusions."""
 import operator
+from typing import Callable
 
 import jax
 import jax.numpy as jnp
@@ -20,7 +21,7 @@ import jax.numpy as jnp
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
 from blackjax.util import generate_gaussian_noise, pytree_size
 
-__all__ = ["overdamped_langevin", "sghmc", "sgnht"]
+__all__ = ["overdamped_langevin", "sghmc", "sghmc_lie_trotter", "sgnht"]
 
 
 def overdamped_langevin():
@@ -79,6 +80,54 @@ def sghmc(alpha: float = 0.01, beta: float = 0):
             * n,
             momentum,
             logdensity_grad,
+            noise,
+        )
+
+        return position, momentum
+
+    return one_step
+
+
+def sghmc_lie_trotter(alpha: float = 0.01, beta: float = 0):
+    """Lie-Trotter solver for the diffusion equation of the SGHMC algorithm.
+
+    The Hamiltonian part is integrated with one deterministic leapfrog step,
+    followed by the exact Ornstein-Uhlenbeck update for the momentum. The
+    ``alpha`` parameter is the friction coefficient. The ``beta`` parameter is
+    accepted for API compatibility with :func:`sghmc` and is unused.
+
+    """
+    del beta
+
+    def one_step(
+        rng_key: PRNGKey,
+        position: ArrayLikeTree,
+        momentum: ArrayLikeTree,
+        grad_estimator: Callable,
+        minibatch: ArrayLikeTree,
+        step_size: float,
+        temperature: float = 1.0,
+    ):
+        logdensity_grad = grad_estimator(position, minibatch)
+        momentum = jax.tree.map(
+            lambda p, g: p + 0.5 * step_size * g,
+            momentum,
+            logdensity_grad,
+        )
+        position = jax.tree.map(lambda x, p: x + step_size * p, position, momentum)
+        logdensity_grad = grad_estimator(position, minibatch)
+        momentum = jax.tree.map(
+            lambda p, g: p + 0.5 * step_size * g,
+            momentum,
+            logdensity_grad,
+        )
+
+        noise = generate_gaussian_noise(rng_key, position)
+        friction = jnp.exp(-alpha * step_size)
+        noise_scale = jnp.sqrt(temperature * (1.0 - jnp.exp(-2.0 * alpha * step_size)))
+        momentum = jax.tree.map(
+            lambda p, n: friction * p + noise_scale * n,
+            momentum,
             noise,
         )
 

--- a/blackjax/sgmcmc/sghmc.py
+++ b/blackjax/sgmcmc/sghmc.py
@@ -28,11 +28,59 @@ def init(position: ArrayLikeTree) -> ArrayLikeTree:
     return position
 
 
-def build_kernel(alpha: float = 0.01, beta: float = 0) -> Callable:
-    """Stochastic gradient Hamiltonian Monte Carlo (SgHMC) algorithm."""
-    integrator = diffusions.sghmc(alpha, beta)
+def build_kernel(
+    alpha: float = 0.01,
+    beta: float = 0,
+    *,
+    integrator: Callable | None = None,
+) -> Callable:
+    """Stochastic gradient Hamiltonian Monte Carlo (SgHMC) algorithm.
 
-    def kernel(
+    Parameters
+    ----------
+    alpha
+        Friction parameter for the SGHMC diffusion.
+    beta
+        Gradient noise estimate parameter for the default Euler diffusion.
+    integrator
+        Optional diffusion integrator factory. When ``None``, the original
+        Euler SGHMC diffusion is used. Custom factories should accept
+        ``(alpha, beta)`` and return a one-step integrator with signature
+        ``(rng_key, position, momentum, grad_estimator, minibatch, step_size,
+        temperature)``.
+
+    """
+    if integrator is None:
+        integrator = diffusions.sghmc(alpha, beta)
+
+        def default_kernel(
+            rng_key: PRNGKey,
+            position: ArrayLikeTree,
+            grad_estimator: Callable,
+            minibatch: ArrayLikeTree,
+            step_size: float,
+            num_integration_steps: int,
+            temperature: float = 1.0,
+        ) -> ArrayTree:
+            def body_fn(state, rng_key):
+                position, momentum = state
+                logdensity_grad = grad_estimator(position, minibatch)
+                position, momentum = integrator(
+                    rng_key, position, momentum, logdensity_grad, step_size, temperature
+                )
+                return ((position, momentum), position)
+
+            momentum = generate_gaussian_noise(rng_key, position)
+            keys = jax.random.split(rng_key, num_integration_steps)
+            (position, momentum), _ = jax.lax.scan(body_fn, (position, momentum), keys)
+
+            return position
+
+        return default_kernel
+
+    integrator = integrator(alpha, beta)
+
+    def custom_integrator_kernel(
         rng_key: PRNGKey,
         position: ArrayLikeTree,
         grad_estimator: Callable,
@@ -43,9 +91,14 @@ def build_kernel(alpha: float = 0.01, beta: float = 0) -> Callable:
     ) -> ArrayTree:
         def body_fn(state, rng_key):
             position, momentum = state
-            logdensity_grad = grad_estimator(position, minibatch)
             position, momentum = integrator(
-                rng_key, position, momentum, logdensity_grad, step_size, temperature
+                rng_key,
+                position,
+                momentum,
+                grad_estimator,
+                minibatch,
+                step_size,
+                temperature,
             )
             return ((position, momentum), position)
 
@@ -55,7 +108,7 @@ def build_kernel(alpha: float = 0.01, beta: float = 0) -> Callable:
 
         return position
 
-    return kernel
+    return custom_integrator_kernel
 
 
 def as_top_level_api(
@@ -63,6 +116,8 @@ def as_top_level_api(
     num_integration_steps: int = 10,
     alpha: float = 0.01,
     beta: float = 0,
+    *,
+    integrator: Callable | None = None,
 ) -> SamplingAlgorithm:
     """Implements the (basic) user interface for the SGHMC kernel.
 
@@ -116,7 +171,7 @@ def as_top_level_api(
 
     """
 
-    kernel = build_kernel(alpha, beta)
+    kernel = build_kernel(alpha, beta, integrator=integrator)
 
     def init_fn(position: ArrayLikeTree, rng_key=None):
         del rng_key

--- a/tests/sgmcmc/test_diffusions.py
+++ b/tests/sgmcmc/test_diffusions.py
@@ -153,6 +153,104 @@ class SGHMCDiffusionTest(BlackJAXTest):
         chex.assert_trees_all_equal_shapes(momentum, new_momentum)
 
 
+class SGHMCLieTrotterDiffusionTest(BlackJAXTest):
+    """Tests for the SGHMC Lie-Trotter diffusion solver."""
+
+    def setUp(self):
+        super().setUp()
+        self.step_size = 1e-1
+        self.alpha = 0.7
+        self.step = diffusions.sghmc_lie_trotter(self.alpha)
+
+    def test_returns_position_and_momentum_for_pytree(self):
+        """Step returns a (position, momentum) pair with correct PyTree shapes."""
+        position = {"a": jnp.zeros(2), "b": jnp.zeros(3)}
+        momentum = {"a": jnp.ones(2), "b": jnp.ones(3)}
+
+        def grad_estimator(position, minibatch):
+            del minibatch
+            return jax.tree.map(jnp.ones_like, position)
+
+        new_position, new_momentum = self.step(
+            self.next_key(),
+            position,
+            momentum,
+            grad_estimator,
+            jnp.zeros(1),
+            self.step_size,
+        )
+        chex.assert_trees_all_equal_shapes(position, new_position)
+        chex.assert_trees_all_equal_shapes(momentum, new_momentum)
+
+    def test_temperature_zero_matches_deterministic_leapfrog_without_friction(self):
+        """With alpha=0 and temperature=0, the update is one leapfrog step."""
+        step = diffusions.sghmc_lie_trotter(alpha=0.0)
+        position = jnp.array([1.0])
+        momentum = jnp.array([0.5])
+
+        def grad_estimator(position, minibatch):
+            del minibatch
+            return -position
+
+        new_position, new_momentum = step(
+            self.next_key(),
+            position,
+            momentum,
+            grad_estimator,
+            jnp.zeros(1),
+            self.step_size,
+            temperature=0.0,
+        )
+
+        half_momentum = momentum + 0.5 * self.step_size * (-position)
+        expected_position = position + self.step_size * half_momentum
+        expected_momentum = half_momentum + 0.5 * self.step_size * (-expected_position)
+        np.testing.assert_allclose(new_position, expected_position, atol=1e-6)
+        np.testing.assert_allclose(new_momentum, expected_momentum, atol=1e-6)
+
+    def test_ou_friction_reduces_momentum_exactly(self):
+        """With zero temperature, the OU update applies exact friction."""
+        position = jnp.zeros(2)
+        momentum = jnp.ones(2)
+
+        def grad_estimator(position, minibatch):
+            del minibatch
+            return jax.tree.map(jnp.zeros_like, position)
+
+        _, new_momentum = self.step(
+            self.next_key(),
+            position,
+            momentum,
+            grad_estimator,
+            jnp.zeros(1),
+            self.step_size,
+            temperature=0.0,
+        )
+        expected_momentum = jnp.exp(-self.alpha * self.step_size) * momentum
+        np.testing.assert_allclose(new_momentum, expected_momentum, atol=1e-6)
+
+    def test_jit_compatible(self):
+        """Step function is JIT-compilable."""
+        position = jnp.ones(3)
+        momentum = jnp.ones(3)
+
+        def grad_estimator(position, minibatch):
+            del minibatch
+            return jax.tree.map(jnp.ones_like, position)
+
+        jit_step = jax.jit(self.step, static_argnums=(3,))
+        new_position, new_momentum = jit_step(
+            self.next_key(),
+            position,
+            momentum,
+            grad_estimator,
+            jnp.zeros(1),
+            self.step_size,
+        )
+        self.assertEqual(new_position.shape, (3,))
+        self.assertEqual(new_momentum.shape, (3,))
+
+
 class SGNHTDiffusionTest(BlackJAXTest):
     """Tests for the SGNHT diffusion solver."""
 

--- a/tests/sgmcmc/test_kernels.py
+++ b/tests/sgmcmc/test_kernels.py
@@ -20,9 +20,11 @@ import numpy as np
 from absl.testing import absltest
 
 import blackjax.sgmcmc.csgld as csgld
+import blackjax.sgmcmc.diffusions as diffusions
 import blackjax.sgmcmc.sghmc as sghmc
 import blackjax.sgmcmc.sgld as sgld
 import blackjax.sgmcmc.sgnht as sgnht
+from blackjax.util import generate_gaussian_noise
 from tests.fixtures import BlackJAXTest
 
 # ---------------------------------------------------------------------------
@@ -210,6 +212,47 @@ class SGHMCKernelTest(BlackJAXTest):
         )
         np.testing.assert_array_equal(p1, p2)
 
+    def test_default_kernel_matches_manual_euler_scan(self):
+        """Default build_kernel keeps the original Euler SGHMC update."""
+        position = jnp.zeros(3)
+        alpha = 0.03
+        beta = 0.01
+        temperature = 1.2
+        num_integration_steps = 4
+        grad_estimator = _make_grad_estimator(scale=0.5)
+        key = self.next_key()
+
+        kernel = sghmc.build_kernel(alpha, beta)
+        actual = kernel(
+            key,
+            position,
+            grad_estimator,
+            MINIBATCH,
+            self.step_size,
+            num_integration_steps,
+            temperature,
+        )
+
+        integrator = diffusions.sghmc(alpha, beta)
+        momentum = generate_gaussian_noise(key, position)
+        keys = jax.random.split(key, num_integration_steps)
+
+        def body_fn(state, rng_key):
+            position, momentum = state
+            logdensity_grad = grad_estimator(position, MINIBATCH)
+            position, momentum = integrator(
+                rng_key,
+                position,
+                momentum,
+                logdensity_grad,
+                self.step_size,
+                temperature,
+            )
+            return (position, momentum), position
+
+        (expected, _), _ = jax.lax.scan(body_fn, (position, momentum), keys)
+        np.testing.assert_allclose(actual, expected, atol=1e-6)
+
     def test_top_level_api_step(self):
         """as_top_level_api step runs and returns correct shape."""
         position = jnp.zeros(4)
@@ -217,6 +260,64 @@ class SGHMCKernelTest(BlackJAXTest):
         state = algo.init(position)
         new_state = algo.step(self.next_key(), state, MINIBATCH, self.step_size)
         self.assertEqual(new_state.shape, position.shape)
+
+    def test_lie_trotter_kernel_output_shape(self):
+        """Lie-Trotter kernel returns position with the same shape."""
+        position = jnp.zeros(4)
+        kernel = sghmc.build_kernel(integrator=diffusions.sghmc_lie_trotter)
+        new_position = kernel(
+            self.next_key(),
+            position,
+            _make_grad_estimator(),
+            MINIBATCH,
+            self.step_size,
+            num_integration_steps=5,
+        )
+        self.assertEqual(new_position.shape, (4,))
+
+    def test_lie_trotter_kernel_pytree_position(self):
+        """Lie-Trotter kernel works for PyTree positions."""
+        position = {"a": jnp.zeros(2), "b": jnp.zeros(3)}
+        kernel = sghmc.build_kernel(integrator=diffusions.sghmc_lie_trotter)
+        new_position = kernel(
+            self.next_key(),
+            position,
+            _make_grad_estimator(),
+            MINIBATCH,
+            self.step_size,
+            num_integration_steps=3,
+        )
+        chex.assert_trees_all_equal_shapes(position, new_position)
+
+    def test_lie_trotter_top_level_api_step(self):
+        """as_top_level_api runs with the Lie-Trotter integrator."""
+        position = jnp.zeros(4)
+        algo = sghmc.as_top_level_api(
+            _make_grad_estimator(),
+            num_integration_steps=5,
+            integrator=diffusions.sghmc_lie_trotter,
+        )
+        state = algo.init(position)
+        new_state = algo.step(self.next_key(), state, MINIBATCH, self.step_size)
+        self.assertEqual(new_state.shape, position.shape)
+
+    def test_lie_trotter_jit_compatible(self):
+        """Lie-Trotter kernel is JIT-compilable."""
+        position = jnp.ones(3)
+        grad_est = _make_grad_estimator()
+        kernel = jax.jit(
+            sghmc.build_kernel(integrator=diffusions.sghmc_lie_trotter),
+            static_argnums=(2, 5),
+        )
+        new_position = kernel(
+            self.next_key(),
+            position,
+            grad_est,
+            MINIBATCH,
+            self.step_size,
+            5,
+        )
+        self.assertEqual(new_position.shape, (3,))
 
     def test_jit_compatible(self):
         """Kernel is JIT-compilable."""


### PR DESCRIPTION
## Description

This PR adds an optional Lie-Trotter integrator for SGHMC.

The existing SGHMC behavior remains unchanged by default: `build_kernel()` still uses the original Euler SGHMC diffusion unless a custom integrator is passed. The new integrator provides a splitting-based SGHMC update with a deterministic leapfrog Hamiltonian step followed by an exact Ornstein-Uhlenbeck momentum update.

## Related issues / discussions

N/A

## Checklist

**General**
- [x ] The branch is rebased on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes (`mamba run -n blackjax python -m pytest tests/`)

**Code quality**
- [x] Public functions have docstrings following the [NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Naming follows existing conventions (`logdensity`, `jax.tree.map`, `jax.random.key()`, `jnp.clip(min=, max=)`)
- [x] All new code is JIT-compatible

**New sampler / algorithm** *(skip if not applicable)*
- [ ] There is an open issue discussing this algorithm (use the [sampler proposal template](https://github.com/blackjax-devs/blackjax/issues/new?template=sampler_proposal.yml))
- [ ] Follows the three-layer pattern: `init` / `build_kernel` / `as_top_level_api`
- [ ] Registered in `blackjax/__init__.py`
- [ ] An example notebook has been added or updated
