### PR TITLE
fix(ns/tests): shrink heavy end-to-end test configs to fix CI OOM

### DIFF
--- a/tests/ns/test_nested_sampling.py
+++ b/tests/ns/test_nested_sampling.py
@@ -401,6 +401,12 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         super().setUp()
         self.key = jax.random.key(42)
 
+    def tearDown(self):
+        # Release compiled XLA kernels between heavy end-to-end tests to avoid
+        # cumulative memory pressure under pytest-xdist parallel workers.
+        jax.clear_caches()
+        super().tearDown()
+
     def test_1d_gaussian_evidence_estimation(self):
         """Test evidence estimation with analytic validation for unnormalized Gaussian."""
 
@@ -582,15 +588,16 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         positions = jax.random.multivariate_normal(
             init_key, prior_mean, prior_cov, (n_live,)
         )
-        # batch-delete a third of the live set per step so the run compresses in
-        # a handful of steps (keeps the test fast while exercising num_delete > 1)
+        # num_delete=2 exercises the batch-delete path while keeping the compiled
+        # kernel small (the kernel vmaps over num_delete replacements); the dynamic
+        # termination criterion converges well within the 200-step cap for dim=2.
         algo = nss.as_top_level_api(
-            logprior, loglikelihood, num_inner_steps=6, num_delete=10
+            logprior, loglikelihood, num_inner_steps=6, num_delete=2
         )
         state = algo.init(positions)
 
         step = jax.jit(algo.step)
-        for _ in range(500):  # dynamic termination (logZ_live - logZ < -3), capped
+        for _ in range(200):  # dynamic termination (logZ_live - logZ < -3), capped
             if float(state.integrator.logZ_live - state.integrator.logZ) < -3.0:
                 break
             key, sub = jax.random.split(key)
@@ -627,12 +634,12 @@ class NestedSamplingStatisticalTest(chex.TestCase):
             init_key, prior_mean, prior_cov, (n_live,)
         )
         algo = nss.swig_as_top_level_api(
-            logprior, loglikelihood, num_inner_steps=6, num_delete=10
+            logprior, loglikelihood, num_inner_steps=6, num_delete=2
         )
         state = algo.init(positions)
 
         step = jax.jit(algo.step)
-        for _ in range(500):  # dynamic termination (logZ_live - logZ < -3), capped
+        for _ in range(200):  # dynamic termination (logZ_live - logZ < -3), capped
             if float(state.integrator.logZ_live - state.integrator.logZ) < -3.0:
                 break
             key, sub = jax.random.split(key)
@@ -714,14 +721,16 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         positions = jax.random.multivariate_normal(
             init_key, prior_mean, prior_cov, (n_live,)
         )
+        # num_inner_steps=6 satisfies the >= max(5, 2*dim) = 5 floor for dim=2;
+        # num_delete=2 keeps the vmapped replacement kernel compact.
         init_fn, kernel = build_rw_nested_sampler(
-            logprior, loglikelihood, num_inner_steps=20, num_delete=10
+            logprior, loglikelihood, num_inner_steps=6, num_delete=2
         )
         state = init_fn(positions)
 
         step = jax.jit(kernel)
         info = None
-        for _ in range(500):  # dynamic termination (logZ_live - logZ < -3), capped
+        for _ in range(200):  # dynamic termination (logZ_live - logZ < -3), capped
             if float(state.integrator.logZ_live - state.integrator.logZ) < -3.0:
                 break
             key, sub = jax.random.split(key)


### PR DESCRIPTION
## Problem

The **Tests** CI job has been red since #947 (nested sampling) merged. The runner is OOM-killed mid-suite (~13–16 min, ~68% through) with a silent \"runner received a shutdown signal\" — no `FAILED` line, just a dead runner. This cancels the whole matrix via `fail-fast`.

**Root cause:** three end-to-end evidence tests each compiled a kernel that vmaps over `num_delete=10` particle replacements × `num_inner_steps` nested-while-loop slice moves. Under `pytest -n auto`, several workers compiling these simultaneously spiked peak RAM past the runner's limit.

The offenders:
- `test_2d_gaussian_evidence`: `num_inner_steps=6, num_delete=10, range(500)`
- `test_swig_2d_gaussian_evidence`: `num_inner_steps=6, num_delete=10, range(500)`
- `test_reject_constrained_step_rw_evidence`: `num_inner_steps=20, num_delete=10, range(500)`

## Fix

- `num_delete`: 10 → 2 (all three tests) — the kernel vmaps over this; 5× smaller compiled kernel
- `num_inner_steps`: 20 → 6 for the RW test — satisfies the `>= max(5, 2*dim) = 5` floor for dim=2 problems
- Iteration cap: `range(500)` → `range(200)` — dynamic termination (`logZ_live - logZ < -3`) converges in ~75 steps with `num_delete=2, n_live=50` on dim=2; 200 is a safe ceiling
- `jax.clear_caches()` in `tearDown` on `NestedSamplingStatisticalTest` — releases compiled kernels between tests under parallel workers

The statistical assertions are unchanged (generous `delta=0.75` / `delta=1.0`); all 26 tests still pass.

## Local verification

```
systemd-run --user --scope -p MemoryMax=8G \
  uv run pytest tests/ns/ -p no:cacheprovider -x -v
```
Result: **26 passed in 79s** (no OOM, all three heavy tests PASSED).

## Checklist
- [x] `uv run pre-commit run --all-files` passes clean
- [x] `tests/ns/` 26/26 PASSED under 8 GB memory cap
- [x] No change to algorithm correctness or test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QsWprwxuKW48PpEbzBFPwA