### PR TITLE
Fix low-rank Fisher mass-matrix adaptation: invert score covariance, fix regularization scale

### DIFF
--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -30,10 +30,24 @@ Key algorithmic choices that match nutpie:
 * **Population variance** (divide by *n*, not *n-1*) for diagonal scaling.
 * **σ clipping** to ``[1e-20, 1e20]`` to avoid premature saturation.
 * **Optimal translation** μ* = x̄ + σ²⊙ᾱ is computed and returned.
-* **Regularisation**: projected covariance is ``P P^T / (n·γ) + I``
-  (nutpie's convention; default γ=1 gives ``P P^T / n + I``).
-* **SPD mean** via eigendecomposition of the gradient covariance (not
-  Cholesky of the draw covariance).
+* **Regularisation**: projected covariance is ``P P^T / γ + I`` (nutpie's
+  convention: the *unnormalised* sum-of-outer-products is divided by ``γ``
+  directly, with no ``n`` scaling; see ``nuts-rs``
+  ``src/transform/adapt/low_rank.rs::estimate_mass_matrix``). Default
+  ``γ=1e-5`` matches nutpie's ``LowRankSettings::default``. The
+  regularisation therefore only matters when the projected subspace is
+  rank-deficient (few draws relative to ``2·max_rank``); it fades away as
+  the number of draws grows, consistent with Theorem 2.4 of
+  :cite:p:`seyboldt2026preconditioning` (exact recovery once draws exceed
+  ``d+1``).
+* **SPD mean of the draw covariance and the *inverse* score covariance**:
+  Theorem 2.3 / Eq. 9 of :cite:p:`seyboldt2026preconditioning` give the
+  (regularised) optimal inverse mass matrix as
+  ``M_γ⁻¹ = (cov(x)+γI) # (cov(∇log p)+γI)⁻¹`` — the AIRM geometric mean of
+  the draw covariance with the *inverse* of the score/gradient covariance.
+  Cross-validated against nutpie's own Rust ``spd_mean`` (``nuts-rs``
+  ``src/transform/adapt/low_rank.rs``), whose own unit test confirms
+  ``spd_mean(cov_draws, cov_grads) == cov_draws # cov_grads⁻¹``.
 * **Eigenvalue masking**: components with λ ∈ [1/cutoff, cutoff] are set
   to λ=1 rather than clipped (default cutoff=2, matching nutpie's ``c=2``).
 
@@ -162,9 +176,11 @@ def _compute_low_rank_metric(
     max_rank
         Maximum number of eigenvectors to retain.
     gamma
-        Regularisation scale.  The projected covariance is divided by
-        ``n * gamma`` before adding the identity, following nutpie's convention.
-        Larger values → stronger regularisation toward the identity.
+        Regularisation scale.  The projected covariance is divided by ``gamma``
+        (not scaled by ``n``) before adding the identity, following nutpie's
+        convention.  Smaller values → weaker regularisation (the identity term
+        matters less relative to the data term); the influence of the
+        regularisation fades as the number of draws grows.
     cutoff
         Eigenvectors whose eigenvalue falls in ``[1/cutoff, cutoff]`` are
         masked (eigenvalue set to 1), as they provide no useful preconditioning.
@@ -223,13 +239,20 @@ def _compute_low_rank_metric(
     P_a = Q.T @ A.T  # (q, B)
 
     # --- Step 6: projected covariance matrices ---
-    # nutpie: C = P P^T / (n * gamma) + I  (scale by 1/gamma, then add identity)
-    scale = n_safe * gamma
-    C_x = (P_x @ P_x.T) / scale + jnp.eye(q)
-    C_a = (P_a @ P_a.T) / scale + jnp.eye(q)
+    # nutpie: C = P P^T / gamma + I  (raw gamma, NOT scaled by n -- nuts-rs
+    # estimate_mass_matrix divides the unnormalised sum-of-outer-products by
+    # gamma directly; there is no /n anywhere in that pipeline).
+    C_x = (P_x @ P_x.T) / gamma + jnp.eye(q)
+    C_a = (P_a @ P_a.T) / gamma + jnp.eye(q)
 
-    # --- Step 7: SPD geometric mean Σ = C_x # C_a ---
-    Sigma = _spd_mean(C_x, C_a)
+    # --- Step 7: SPD geometric mean Σ = C_x # C_a^{-1} ---
+    # Theorem 2.3 / Eq. 9 (arXiv:2603.18845): the regularized optimal inverse
+    # mass matrix is M_gamma^{-1} = (cov(x)+gamma*I) # (cov(alpha)+gamma*I)^{-1}
+    # -- the score/gradient covariance must be INVERTED before the geometric
+    # mean. Cross-validated against nutpie's own `spd_mean` (nuts-rs
+    # src/transform/adapt/low_rank.rs), whose own unit test confirms
+    # spd_mean(cov_draws, cov_grads) == cov_draws # cov_grads^{-1}.
+    Sigma = _spd_mean(C_x, jnp.linalg.inv(C_a))
 
     # --- Step 8: eigendecompose Σ in the projected subspace ---
     vals, vecs = jnp.linalg.eigh(Sigma)  # vals ascending, (2k,)
@@ -265,7 +288,7 @@ def _compute_low_rank_metric(
 def base(
     max_rank: int = 10,
     target_acceptance_rate: float = 0.80,
-    gamma: float = 1.0,
+    gamma: float = 1e-5,
     cutoff: float = 2.0,
 ) -> tuple[Callable, Callable, Callable]:
     """Warmup scheme using the low-rank mass matrix adaptation.
@@ -281,9 +304,9 @@ def base(
     target_acceptance_rate
         Target acceptance rate for dual-averaging step-size adaptation.
     gamma
-        Regularisation scale.  The projected covariance is divided by
-        ``n * gamma`` before adding identity (nutpie convention).  Default
-        ``1.0`` gives ``C = P P^T / n + I``.
+        Regularisation scale.  The projected covariance is divided by ``gamma``
+        (nutpie convention -- no ``n`` scaling).  Default ``1e-5`` matches
+        nutpie's ``LowRankSettings::default``.
     cutoff
         Eigenvectors with eigenvalue in ``[1/cutoff, cutoff]`` are masked
         (eigenvalue set to 1).  Default ``2.0`` matches nutpie's ``c=2``.
@@ -442,7 +465,7 @@ def window_adaptation_low_rank(
     max_rank: int = 10,
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,
-    gamma: float = 1.0,
+    gamma: float = 1e-5,
     cutoff: float = 2.0,
     progress_bar: bool = False,
     adaptation_info_fn: Callable = return_all_adapt_info,
@@ -473,8 +496,9 @@ def window_adaptation_low_rank(
     target_acceptance_rate
         Target acceptance rate for dual averaging.
     gamma
-        Regularisation scale; projected covariance is divided by ``n * gamma``
-        before adding identity (nutpie convention).
+        Regularisation scale; projected covariance is divided by ``gamma``
+        before adding identity (nutpie convention -- no ``n`` scaling).
+        Default ``1e-5`` matches nutpie's ``LowRankSettings::default``.
     cutoff
         Eigenvectors with eigenvalue in ``[1/cutoff, cutoff]`` are masked.
         Default ``2.0`` matches nutpie's ``c=2``.

--- a/tests/adaptation/test_low_rank_adaptation.py
+++ b/tests/adaptation/test_low_rank_adaptation.py
@@ -23,6 +23,19 @@ from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.fixtures import BlackJAXTest
 
 
+def _low_rank_inverse_mass_matrix(sigma, U, lam):
+    """Reconstruct the dense inverse mass matrix from the low-rank factors.
+
+    ``M^{-1} = diag(sigma) (I + U (lam - I) U^T) diag(sigma)``, matching
+    Eq. (10)-(11) of :cite:p:`seyboldt2026preconditioning` and the docstring
+    of :func:`window_adaptation_low_rank`.
+    """
+    d = sigma.shape[0]
+    return (
+        jnp.diag(sigma) @ (jnp.eye(d) + U @ jnp.diag(lam - 1.0) @ U.T) @ jnp.diag(sigma)
+    )
+
+
 class SPDMeanTest(BlackJAXTest):
     """Tests for _spd_mean (SPD geometric mean)."""
 
@@ -291,6 +304,144 @@ class LowRankWindowAdaptationTest(BlackJAXTest):
         )
         new_state, _info = nuts.step(self.next_key(), chain0_state)
         self.assertEqual(new_state.position.shape, (d,))
+
+
+class LowRankCorrelationRecoveryTest(BlackJAXTest):
+    """Regression tests for the missing score-covariance inversion.
+
+    Finding: ``_spd_mean(C_x, C_a)`` in ``_compute_low_rank_metric`` omitted
+    the matrix inversion of ``C_a`` (the regularized score/gradient
+    covariance) required by Theorem 2.3 / Eq. (9) of
+    :cite:p:`seyboldt2026preconditioning`. Cross-validated against nutpie's
+    Rust reference implementation (``nuts-rs``
+    ``src/transform/adapt/low_rank.rs``). See the worklog case study
+    ``worklog/lessons/case-studies/gp_regression/2026-05-13-low-rank-wrong-sign-suspicion.md``
+    for the full diagnosis, including the exact controls reused below.
+    """
+
+    def _pairwise_mvn(self, rho, key, n=200_000):
+        """2-D correlated Gaussian: var 4/1, correlation rho (case study control)."""
+        cov = jnp.array([[4.0, rho * 2.0], [rho * 2.0, 1.0]])
+        draws = jax.random.multivariate_normal(key, jnp.zeros(2), cov, shape=(n,))
+        grads = -draws @ jnp.linalg.inv(cov).T
+        return draws, grads
+
+    def test_pairwise_sign_and_magnitude_recovery(self):
+        """Both the sign and the magnitude of a known pairwise correlation
+        are recovered (before the fix: exactly-degenerate eigenspectrum,
+        seed-unstable sign; see LowRankSeedStabilityTest below)."""
+        for rho in (0.7, -0.7, 0.9):
+            draws, grads = self._pairwise_mvn(rho, self.next_key())
+            sigma, _, U, lam = _compute_low_rank_metric(
+                draws, grads, draws.shape[0], 2, 1e-5, 2.0
+            )
+            minv = _low_rank_inverse_mass_matrix(sigma, U, lam)
+            implied_corr = float(minv[0, 1] / jnp.sqrt(minv[0, 0] * minv[1, 1]))
+            self.assertEqual(np.sign(implied_corr), np.sign(rho))
+            np.testing.assert_allclose(implied_corr, rho, atol=0.05)
+
+    def test_star_topology_sign_recovery(self):
+        """7-D hub-and-spoke topology (case study control #2 — closer to a
+        real hierarchical funnel than an isolated pair). Before the fix this
+        was *stably* wrong-signed (not noise): true +0.30 recovered as
+        approximately -0.20 at max_rank=1, shrinking to approximately -0.02
+        at max_rank=3-6."""
+        d = 7
+        rho = 0.3
+        cov = jnp.eye(d).at[0, 1:].set(rho).at[1:, 0].set(rho)
+        draws = jax.random.multivariate_normal(
+            self.next_key(), jnp.zeros(d), cov, shape=(200_000,)
+        )
+        grads = -draws @ jnp.linalg.inv(cov).T
+        for max_rank in (3, 6):
+            sigma, _, U, lam = _compute_low_rank_metric(
+                draws, grads, draws.shape[0], max_rank, 1e-5, 2.0
+            )
+            minv = _low_rank_inverse_mass_matrix(sigma, U, lam)
+            hub_spoke_corrs = minv[0, 1:] / jnp.sqrt(minv[0, 0] * jnp.diag(minv)[1:])
+            self.assertTrue(bool(jnp.all(hub_spoke_corrs > 0)))
+            np.testing.assert_allclose(np.asarray(hub_spoke_corrs), rho, atol=0.1)
+
+
+class LowRankGaussianLimitTest(BlackJAXTest):
+    """Gaussian-limit exact-recovery test (Theorem 2.4)."""
+
+    def test_recovers_known_covariance(self):
+        """Exact iid draws + exact scores from a known Sigma recover
+        M^{-1} == Sigma, matching Theorem 2.4's exact-recovery guarantee once
+        the number of draws exceeds d+1. ``cutoff=1.0`` disables eigenvalue
+        masking (masks only exactly-unity eigenvalues) so the full-rank
+        correction is retained."""
+        d = 5
+        key1, key2 = jax.random.split(self.next_key())
+        A = jax.random.normal(key1, (d, d))
+        cov = A @ A.T + d * jnp.eye(d)
+        draws = jax.random.multivariate_normal(key2, jnp.zeros(d), cov, shape=(50_000,))
+        grads = -draws @ jnp.linalg.inv(cov).T
+        sigma, _, U, lam = _compute_low_rank_metric(
+            draws, grads, draws.shape[0], d, 1e-5, 1.0
+        )
+        minv = _low_rank_inverse_mass_matrix(sigma, U, lam)
+        np.testing.assert_allclose(
+            np.asarray(minv), np.asarray(cov), rtol=0.1, atol=0.1
+        )
+
+
+class LowRankSeedStabilityTest(BlackJAXTest):
+    """Top-eigenvector seed-stability test.
+
+    Before the fix, an isolated 2x2 correlated block produced an exactly
+    degenerate ``_spd_mean`` eigenspectrum (eigenvalues equal to ~7
+    significant figures), so which eigenvector ``max_rank=1`` retained — and
+    hence the sign and magnitude of the implied correlation — was arbitrary,
+    seed-dependent noise even at n=1,000,000 iid draws (not finite-sample
+    noise: the degeneracy was exact). After the fix the recovered
+    correlation must be stable (consistent sign, low seed-to-seed variance).
+    """
+
+    def test_top_eigenvector_direction_stable_across_seeds(self):
+        rho = 0.7
+        cov = jnp.array([[4.0, rho * 2.0], [rho * 2.0, 1.0]])
+        corrs = []
+        for _ in range(6):
+            key = self.next_key()
+            draws = jax.random.multivariate_normal(
+                key, jnp.zeros(2), cov, shape=(200_000,)
+            )
+            grads = -draws @ jnp.linalg.inv(cov).T
+            sigma, _, U, lam = _compute_low_rank_metric(
+                draws, grads, draws.shape[0], 1, 1e-5, 2.0
+            )
+            minv = _low_rank_inverse_mass_matrix(sigma, U, lam)
+            corrs.append(float(minv[0, 1] / jnp.sqrt(minv[0, 0] * minv[1, 1])))
+        corrs = np.array(corrs)
+        self.assertTrue(bool(np.all(corrs > 0)), f"sign flipped across seeds: {corrs}")
+        self.assertLess(float(np.std(corrs)), 0.05, f"unstable across seeds: {corrs}")
+
+
+class LowRankDiagonalConsistencyTest(BlackJAXTest):
+    """1-D low-rank/diagonal consistency test.
+
+    In 1 dimension there is no possible correlation structure beyond the
+    diagonal scale itself, so Step 7's SPD-mean eigenvalue must reduce to
+    lambda=1 (no correction), leaving ``M^{-1} == sigma**2`` exactly matching
+    Step 1's diagonal formula. Before the fix, the un-inverted ``_spd_mean``
+    implied a spurious ``sqrt(var_x * var_g)``-flavoured correction,
+    contradicting the Step-1 diagonal's own ``sqrt(var_x / var_g)`` formula
+    three lines above it in the source.
+    """
+
+    def test_low_rank_path_agrees_with_diagonal_in_1d(self):
+        for var_x, var_g in [(4.0, 1.0), (0.1, 9.0), (25.0, 0.5)]:
+            key1, key2 = jax.random.split(self.next_key())
+            n = 50_000
+            x = jax.random.normal(key1, (n, 1)) * jnp.sqrt(var_x)
+            g = jax.random.normal(key2, (n, 1)) * jnp.sqrt(var_g)
+            sigma, _, U, lam = _compute_low_rank_metric(x, g, n, 1, 1e-5, 2.0)
+            diagonal_only = float(sigma[0] ** 2)
+            low_rank = float(_low_rank_inverse_mass_matrix(sigma, U, lam)[0, 0])
+            np.testing.assert_allclose(low_rank, diagonal_only, rtol=1e-3)
+            np.testing.assert_allclose(float(lam[0]), 1.0, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/adaptation/test_low_rank_adaptation.py
+++ b/tests/adaptation/test_low_rank_adaptation.py
@@ -444,5 +444,56 @@ class LowRankDiagonalConsistencyTest(BlackJAXTest):
             np.testing.assert_allclose(float(lam[0]), 1.0, atol=1e-3)
 
 
+class LowRankSmallNRobustnessTest(BlackJAXTest):
+    """Small-n robustness (early-warmup buffer sizes) -- reviewer finding.
+
+    Statistician correctness review (stat-e1) surfaced this adversarial
+    check during the fix's review: at borderline-rank-deficient buffer
+    sizes typical of the *first* slow window in warmup (n as low as 4, up
+    to n=200), the fixed estimator with the corrected ``gamma=1e-5``
+    regularisation must (a) never produce NaN/Inf at JAX's default float32
+    precision, and (b) already recover the correct sign -- and a
+    non-trivial fraction of the true magnitude -- at n=4, where the OLD
+    ``gamma=1.0`` default's n-scaled regularisation shows essentially
+    nothing (implied correlation collapses to ~0.0 at n=4; see PR draft for
+    the side-by-side numbers). This locks in that the gamma-scale fix is
+    *more* robust in the small-n regime, not just asymptotically correct.
+    """
+
+    def test_no_nan_inf_and_correct_sign_across_small_n(self):
+        rho = 0.7
+        cov = jnp.array([[4.0, rho * 2.0], [rho * 2.0, 1.0]])
+        for n in (4, 10, 50, 200):
+            draws = jax.random.multivariate_normal(
+                self.next_key(), jnp.zeros(2), cov, shape=(n,)
+            )
+            grads = -draws @ jnp.linalg.inv(cov).T
+            sigma, mu_star, U, lam = _compute_low_rank_metric(
+                draws, grads, n, 2, 1e-5, 2.0
+            )
+            for name, arr in [
+                ("sigma", sigma),
+                ("mu_star", mu_star),
+                ("U", U),
+                ("lam", lam),
+            ]:
+                self.assertTrue(
+                    bool(jnp.all(jnp.isfinite(arr))),
+                    f"n={n} -- {name} has NaN/Inf: {arr}",
+                )
+            minv = _low_rank_inverse_mass_matrix(sigma, U, lam)
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(minv))), f"n={n} -- M^-1 has NaN/Inf"
+            )
+            implied_corr = round(
+                float(minv[0, 1] / jnp.sqrt(minv[0, 0] * minv[1, 1])), 4
+            )
+            self.assertGreater(
+                implied_corr,
+                0.3,
+                f"n={n} -- correlation not recovered (got {implied_corr})",
+            )
+
+
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## Summary

`window_adaptation_low_rank`'s low-rank metric estimator
(`blackjax/adaptation/low_rank_adaptation.py`, `_compute_low_rank_metric`)
implements the Fisher-divergence-minimizing preconditioner of
[Seyboldt, Carlson & Carpenter, arXiv:2603.18845](https://arxiv.org/abs/2603.18845)
("Preconditioning Hamiltonian Monte Carlo by minimizing Fisher Divergence").
Two independent, compounding bugs made it recover **wrong-signed and/or
severely damped correlation structure** for any correlated target:

1. **Missing matrix inversion.** Step 7 computed `Sigma = _spd_mean(C_x, C_a)`
   — the AIRM geometric mean of the (regularized) draw covariance and the
   (regularized) score/gradient covariance **used directly, without
   inverting it**. The correct formula (Theorem 2.3 of the paper) requires
   the score covariance to be **inverted** before the geometric mean.
2. **Wrong regularization scale.** The projected covariance was regularized
   as `P P^T / (n·γ) + I` with default `γ=1.0`. nutpie's actual Rust
   implementation regularizes as `P P^T / γ + I` (**no `n` scaling at all**)
   with default `γ=1e-5`. With the old convention, the `+I` term was
   comparable in magnitude to the real signal *regardless of how many
   warmup draws had accumulated* — permanently damping the recovered
   correlation toward the identity.

Both bugs are efficiency-only: the low-rank metric only ever appears as an
inverse mass matrix (preconditioner) inside NUTS/HMC, so a wrong-signed or
degenerate preconditioner changes acceptance/mixing efficiency, not sample
validity — MCMC remains asymptotically exact for any positive-definite mass
matrix. However, any prior efficiency comparison using
`window_adaptation_low_rank` is confounded by this bug and should be re-run
once this lands.

## Mechanism confirmations

**(a) Internal inconsistency.** The function's own Step 1 computes the
diagonal scale as `sigma = (var_x / var_g) ** 0.25`, i.e. the diagonal
inverse-mass-matrix element is `sigma**2 = sqrt(var_x / var_g)` — a
**quotient**. The un-inverted Step 7 implies, in the 1-D limit, a term
proportional to `sqrt(var_x * var_g)` — a **product** — directly
contradicting the formula three lines above it in the same function. The
new `LowRankDiagonalConsistencyTest` makes this precise: after the fix, the
low-rank path's 1-D limit exactly equals `sigma**2` (eigenvalue `lambda ==
1.0` always — the only mathematically sensible answer in 1 dimension).

**(b) Gaussian-limit degeneracy.** For any 2-D correlated Gaussian, the
whitened position covariance and whitened score covariance have **exactly
opposite-sign off-diagonals** (a generic 2×2-matrix-inversion property).
Calling `_spd_mean` on the un-inverted matrices produces an
**exactly-degenerate** eigenspectrum (eigenvalues equal to 7 significant
figures) — with no unique top eigenvector, `max_rank<d` retains an
arbitrary seed-dependent direction.

**(c) Paper verification** (read from the primary-source PDF, not an
HTML/summarized reading):

**Theorem 2.3 (Dense minimization)**, p.7-8:
> The estimated Fisher divergence `D̂` is minimized over `A` when
> `AA^T cov(α) AA^T = cov(x)`. ... the minimum is unique and achieved when
> `M⁻¹ = cov(x) # cov(α)⁻¹`, where `A # B` is the geometric mean in the
> affine-invariant Riemannian metric (AIRM).

**Eq. (9), the regularized dense case** (p.8) — the exact form to
implement, not a bare `inv()` patch on the unregularized quantity:
> We add a regularization term `γ(tr(AA^T) + tr((AA^T)⁻¹))` ... which
> yields the unique solution `M_γ⁻¹ = (cov(x) + γI) # (cov(α) + γI)⁻¹`.

*(Note: working through the paper's own §2.4.3 Algorithm 1 + Algorithm 2
pseudocode by hand surfaced an apparent internal inconsistency in the
preprint's own listing — Algorithm 2's `spdm(A,B)` as literally specified
algebraically reduces to `A⁻¹ # B`, the reciprocal of what Algorithm 1's
inline comment claims it solves — likely a pseudocode transcription slip
(a second, unrelated Algorithm-1 typo was also found in the σ-scaling
line). Given the ambiguity, the implementation is grounded in the
unambiguous Theorem 2.3 + Eq. 9 prose statements, and cross-validated
independently against nutpie's actual shipped Rust code below, which
resolves the ambiguity decisively.)*

**(d) nutpie Rust reference implementation** (read from source, not
guessed). nutpie is a thin Python wrapper; the actual sampling/adaptation
engine lives in the separate `nuts-rs` crate (same author, pinned via
nutpie's `Cargo.toml`).

`nuts-rs/src/transform/adapt/low_rank.rs:237-262`, function `spd_mean`:

```rust
fn spd_mean(cov_draws: Mat<f64>, cov_grads: Mat<f64>) -> Option<Mat<f64>> {
    let eigs_grads = cov_grads.self_adjoint_eigen(...)?;   // eigendecompose cov_grads
    let cov_grads_sqrt = ...;                               // cov_grads^{1/2}
    let m = (&cov_grads_sqrt) * cov_draws * cov_grads_sqrt; // cov_grads^{1/2} cov_draws cov_grads^{1/2}
    let m_sqrt = ...;                                        // m^{1/2}
    let grads_inv_sqrt = ...;                                // cov_grads^{-1/2}
    Some((&grads_inv_sqrt) * m_sqrt * grads_inv_sqrt)        // cov_grads^{-1/2} m^{1/2} cov_grads^{-1/2}
}
```

Algebraically this is `cov_grads⁻¹ # cov_draws = cov_draws # cov_grads⁻¹`
(AIRM commutativity) — **exactly Theorem 2.3's `M⁻¹ = cov(x) # cov(α)⁻¹`**,
confirmed against nutpie's **own unit test**,
`nuts-rs/src/transform/adapt/low_rank.rs:354-381`:

```rust
#[test]
fn test_spd_mean() {
    let x_diag = faer::col![1., 4., 8.];
    let y_diag = faer::col![1., 1., 0.5];
    let out = spd_mean(x, y)...
    let expected_diag = faer::col![1., 2., 4.];   // == sqrt(x_diag / y_diag) elementwise
}
```

`sqrt([1,4,8] / [1,1,0.5]) == [1, 2, 4]` — replayed this exact test against
`_spd_mean(C_x, jnp.linalg.inv(C_a))` and it reproduces `[1, 2, 4]` to
float32 precision.

**Regularization scale** — `nuts-rs/src/transform/adapt/low_rank.rs:205-234`
(`estimate_mass_matrix`, dividing the raw unnormalized sum-of-outer-products
by `gamma` alone, no `n` anywhere) and
`nuts-rs/src/transform/low_rank.rs:194-205` (`LowRankSettings::default`,
`gamma: 1e-5`). This matches the paper's own stated experimental default
(§4, p.11): *"For nutpie's low-rank mode, we use an eigenvalue cutoff
`c=2`, and regularization parameter `γ=10⁻⁵`."*

## Fix

`_compute_low_rank_metric`, Step 6-7:

```python
# Step 6 (fixed): raw gamma, no n scaling
C_x = (P_x @ P_x.T) / gamma + jnp.eye(q)
C_a = (P_a @ P_a.T) / gamma + jnp.eye(q)

# Step 7 (fixed): invert the score covariance before the geometric mean
Sigma = _spd_mean(C_x, jnp.linalg.inv(C_a))
```

Public API default changed: `gamma: float = 1.0` → `gamma: float = 1e-5` in
both `base()` and `window_adaptation_low_rank()`, matching nutpie's
`LowRankSettings::default` exactly. Docstrings updated throughout.

## Before / after recovery tables

**2-D pairwise block** (`Sigma = [[4, 2ρ], [2ρ, 1]]`, exact iid draws,
n=200,000-1,000,000):

| ρ (true) | pre-fix (no inversion, γ=1.0, n-scaled) | post-fix (inverted, γ=1e-5, raw-scaled) |
|---:|---:|---:|
| +0.70 | −0.0001 | **+0.7000** |
| −0.70 | +0.0001 | **−0.7000** |
| +0.90 | −0.0001 | **+0.9000** |
| +0.30 | −0.0000 | +0.0000 *(masked — see note below)* |

*Note on ρ=+0.30*: with `cutoff=2.0` (nutpie's own default), an eigenvalue
within `[0.5, 2.0]` of the identity is treated as "not informative enough to
correct" and masked to `λ=1` — intentional design (Algorithm 1's own
filtering step), not a residual bug. `LowRankGaussianLimitTest` with
`cutoff=1.0` (masking effectively disabled) recovers a full 5-D correlated
covariance to ~1e-9 absolute error (float64), confirming full recovery is
not blocked by cutoff design once an eigenvalue clears the informativeness
threshold.

**7-D hub-and-spoke star topology** (hub + 6 spokes, each ρ=+0.30 with the
hub, 0 pairwise between spokes — closer to an actual hierarchical funnel
than an isolated pair):

| max_rank | pre-fix | post-fix |
|---:|---:|---:|
| 1 | ≈ −0.20 (wrong sign) | **+0.18** (correct sign) |
| 3 | ≈ −0.015 to −0.02 (wrong sign) | **+0.311** (correct sign, ~4% rel. error) |
| 6 | ≈ −0.015 to −0.02 (wrong sign) | **+0.311** (correct sign, ~4% rel. error) |

**Seed stability** (isolated 2×2 pairwise block, ρ=0.7, `max_rank=1`, 6
independent seeds, n=200,000 each): pre-fix, the recovered correlation was
unstable and sign-flipped across random seeds even at n=1,000,000 (a
genuine degeneracy — eigenvalues equal to 7 sig. figs. — not finite-sample
noise). Post-fix: all 6 seeds recover the same sign, std < 0.05.

**1-D diagonal consistency** (three `(var_x, var_g)` combinations, exact
independent Gaussian draws, n=50,000): post-fix, the low-rank path's
implied 1-D inverse-mass-matrix element exactly equals `sigma**2` from Step
1 (`λ = 1.000000` in every case, to float64 precision).

**Gaussian-limit exact recovery** (5-D correlated covariance, `max_rank=5`,
`cutoff=1.0`, n=50,000 exact iid draws + exact scores): recovered `M⁻¹`
matches the true `Σ` to max absolute difference `1.4e-9` (float64),
matching Theorem 2.4's guarantee of exact recovery once draws exceed `d+1`.

**Small-n robustness** (n=4, 10, 50, 200, ρ=0.7 true, float32): the fixed
estimator (γ=1e-5) recovers implied correlation +0.48 to +0.70 across
independent seeds at n=4 with zero NaN/Inf, while the old γ=1.0 default
collapses to ~0.0 at the same n=4 (over-regularized regardless of sample
count) — the gamma-scale fix is more robust in the small-n regime, not
just correct asymptotically.

## Regression tests added

`tests/adaptation/test_low_rank_adaptation.py`, five new test classes:

- `LowRankCorrelationRecoveryTest` — 2-D pairwise + 7-D star sign/magnitude.
- `LowRankGaussianLimitTest` — 5-D exact-recovery (Theorem 2.4).
- `LowRankSeedStabilityTest` — 6-seed stability check on the previously
  exactly-degenerate isolated pair.
- `LowRankDiagonalConsistencyTest` — 1-D low-rank/diagonal internal
  consistency, 3 `(var_x, var_g)` combinations.
- `LowRankSmallNRobustnessTest` — no-NaN/Inf + correct-sign check at
  n=4..200 (reviewer-suggested adversarial check).

All 26 tests in the file pass at JAX's default float32 precision, at both
`-n auto` and `-n 2`. Full local suite (1174 tests): 1152 passed / 21 failed,
all 21 failures traced to an unrelated environment gap (missing
`fastprogress`, the `progress` extra dependency) — 0 failures in
`tests/adaptation/` or anywhere touching this change; re-verified 113/113
passing on the two affected files once the extra was installed.

## Reviewed-by

Reviewed-by: statistician agent — independent re-verification (Theorem
2.3/Eq. 9 re-derived from the primary-source PDF independently, from-scratch
recovery grids on fresh constructions, small-n robustness adversarial
check that fed the `LowRankSmallNRobustnessTest` above).

## Test plan

- [x] `tests/adaptation/test_low_rank_adaptation.py` — 26/26 passing
- [x] Full local suite — 1152/1152 non-environmental tests passing (21
      pre-existing environmental failures traced to a missing dependency
      extra, unrelated to this change)
- [x] Closure check: re-run of the original gp_regression probes (in
      progress) — implied hyperparameter correlation must flip positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt9Qcy31ieBEAaesAbp5Bx