### PR TITLE
Generalize ghmc to accept dense / low-rank momentum metrics

### DIFF
--- a/blackjax/mcmc/ghmc.py
+++ b/blackjax/mcmc/ghmc.py
@@ -64,6 +64,42 @@ def init(
     return GHMCState(position, momentum, logdensity, logdensity_grad, slice)
 
 
+def _metric_from_momentum_inverse_scale(
+    momentum_inverse_scale: ArrayLikeTree | metrics.MetricTypes,
+) -> metrics.Metric:
+    """Build the momentum ``Metric`` from ``momentum_inverse_scale``.
+
+    ``momentum_inverse_scale`` is documented (and used by MEADS) as a
+    per-dimension *inverse scale*, not an inverse mass matrix: the legacy
+    diagonal/scalar path squares it elementwise -- turning an inverse
+    standard deviation into an inverse variance -- before handing it to
+    ``gaussian_euclidean``, which expects the latter. That elementwise
+    squaring only makes sense for the legacy input shape (an Array of ndim
+    <= 1, or a Pytree matching ``position``), so it is preserved exactly
+    there, keeping existing diagonal/scalar callers (including MEADS)
+    bit-for-bit unchanged.
+
+    A dense ``(d, d)`` array, a
+    :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`, a
+    :class:`~blackjax.mcmc.metrics.Metric`, or a callable already carry
+    inverse-mass-matrix (not inverse-scale) semantics -- exactly as
+    ``inverse_mass_matrix`` does for ``hmc``/``nuts`` -- so these are
+    forwarded to :func:`~blackjax.mcmc.metrics.default_metric` unchanged,
+    with no squaring.
+
+    """
+    if isinstance(
+        momentum_inverse_scale, (metrics.Metric, metrics.LowRankInverseMassMatrix)
+    ) or callable(momentum_inverse_scale):
+        return metrics.default_metric(momentum_inverse_scale)
+
+    if hasattr(momentum_inverse_scale, "ndim") and momentum_inverse_scale.ndim >= 2:
+        return metrics.default_metric(momentum_inverse_scale)
+
+    flat_inverse_scale = ravel_pytree(momentum_inverse_scale)[0]
+    return metrics.default_metric(flat_inverse_scale**2)
+
+
 def build_kernel(
     noise_fn: Callable = lambda _: 0.0,
     divergence_threshold: float = 1000,
@@ -101,7 +137,7 @@ def build_kernel(
         state: GHMCState,
         logdensity_fn: Callable,
         step_size: float,
-        momentum_inverse_scale: ArrayLikeTree,
+        momentum_inverse_scale: ArrayLikeTree | metrics.MetricTypes,
         alpha: float,
         delta: float,
     ) -> tuple[GHMCState, hmc.HMCInfo]:
@@ -118,9 +154,17 @@ def build_kernel(
         step_size
             Variable specifying the size of the integration step.
         momentum_inverse_scale
-            Pytree with the same structure as the targeted position variable
-            specifying the per dimension inverse scaling transformation applied
-            to the persistent momentum variable prior to the integration step.
+            Legacy usage: a Pytree with the same structure as the targeted
+            position variable (or a scalar/1-D array) specifying the per
+            dimension inverse *scale* applied to the persistent momentum
+            variable prior to the integration step; it is squared elementwise
+            to obtain the inverse mass matrix. To use a dense or low-rank
+            metric (mirroring ``hmc``/``nuts``), pass a ``(d, d)`` array (the
+            inverse mass matrix directly, no squaring), a
+            :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`, a
+            :class:`~blackjax.mcmc.metrics.Metric`, or a callable; these are
+            forwarded to :func:`~blackjax.mcmc.metrics.default_metric`
+            unchanged.
         alpha
             Variable specifying the degree of persistent momentum, complementary
             to independent new momentum.
@@ -130,17 +174,14 @@ def build_kernel(
 
         """
 
-        flat_inverse_scale = ravel_pytree(momentum_inverse_scale)[0]
-        momentum_generator, kinetic_energy_fn, *_ = metrics.gaussian_euclidean(
-            flat_inverse_scale**2
-        )
+        metric = _metric_from_momentum_inverse_scale(momentum_inverse_scale)
 
         symplectic_integrator = integrators.velocity_verlet(
-            logdensity_fn, kinetic_energy_fn
+            logdensity_fn, metric.kinetic_energy
         )
         proposal_generator = hmc.hmc_proposal(
             symplectic_integrator,
-            kinetic_energy_fn,
+            metric.kinetic_energy,
             step_size,
             divergence_threshold=divergence_threshold,
             sample_proposal=nonreversible_slice_sampling,
@@ -149,7 +190,7 @@ def build_kernel(
         key_momentum, key_noise = jax.random.split(rng_key)
         position, momentum, logdensity, logdensity_grad, slice = state
         # New momentum is persistent
-        momentum = update_momentum(key_momentum, state, alpha, momentum_generator)
+        momentum = update_momentum(key_momentum, state, alpha, metric.sample_momentum)
         # Slice is non-reversible
         slice = ((slice + 1.0 + delta + noise_fn(key_noise)) % 2) - 1.0
 
@@ -199,7 +240,7 @@ def update_momentum(rng_key, state, alpha, momentum_generator):
 def as_top_level_api(
     logdensity_fn: Callable,
     step_size: float,
-    momentum_inverse_scale: ArrayLikeTree,
+    momentum_inverse_scale: ArrayLikeTree | metrics.MetricTypes,
     alpha: float,
     delta: float,
     *,
@@ -250,9 +291,17 @@ def as_top_level_api(
         values used for as a step size for each dimension of the target space in
         the velocity verlet integrator.
     momentum_inverse_scale
-        Pytree with the same structure as the targeted position variable
-        specifying the per dimension inverse scaling transformation applied
-        to the persistent momentum variable prior to the integration step.
+        Legacy usage: a Pytree with the same structure as the targeted
+        position variable (or a scalar/1-D array) specifying the per
+        dimension inverse *scale* applied to the persistent momentum
+        variable prior to the integration step; it is squared elementwise
+        to obtain the inverse mass matrix. To use a dense or low-rank
+        metric (mirroring ``hmc``/``nuts``), pass a ``(d, d)`` array (the
+        inverse mass matrix directly, no squaring), a
+        :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`, a
+        :class:`~blackjax.mcmc.metrics.Metric`, or a callable; these are
+        forwarded to :func:`~blackjax.mcmc.metrics.default_metric`
+        unchanged.
     alpha
         The value defining the persistence of the momentum variable.
     delta
@@ -272,10 +321,11 @@ def as_top_level_api(
     """
 
     kernel = build_kernel(noise_fn, divergence_threshold)
+    metric = _metric_from_momentum_inverse_scale(momentum_inverse_scale)
     return build_sampling_algorithm(
         kernel,
         init,
         logdensity_fn,
-        kernel_args=(step_size, momentum_inverse_scale, alpha, delta),
+        kernel_args=(step_size, metric, alpha, delta),
         pass_rng_key_to_init=True,
     )

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -10,13 +10,16 @@ import jax.scipy.stats as stats
 import numpy as np
 import optax
 from absl.testing import absltest, parameterized
+from jax.flatten_util import ravel_pytree
 
 # import blackjax
 import blackjax.diagnostics as diagnostics
+import blackjax.mcmc.metrics as metrics
 import blackjax.mcmc.random_walk
 from blackjax.adaptation.base import get_filter_adapt_info_fn, return_all_adapt_info
 from blackjax.adaptation.laps import laps as run_laps
 from blackjax.mcmc.adjusted_mclmc import rescale
+from blackjax.mcmc.ghmc import _metric_from_momentum_inverse_scale
 from blackjax.mcmc.integrators import isokinetic_mclachlan
 from blackjax.util import run_inference_algorithm
 
@@ -1236,6 +1239,108 @@ class UnivariateNormalTest(chex.TestCase):
         self.univariate_normal_test_case(
             inference_algorithm, self.key, initial_state, 20000, 2_000
         )
+
+
+class GHMCRichMetricTest(chex.TestCase):
+    """Test blackjax.ghmc with dense and low-rank momentum metrics.
+
+    `momentum_inverse_scale` now accepts the same `metrics.MetricTypes`
+    that `hmc`/`nuts` already do (dense array, `LowRankInverseMassMatrix`,
+    `Metric`, callable) in addition to the legacy per-dimension inverse
+    scale.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.key = jax.random.key(7)
+
+    def correlated_gaussian(self):
+        """A 3-D correlated Gaussian target with a known mean/covariance."""
+        loc = jnp.array([1.0, -2.0, 0.5])
+        scale = jnp.array([1.0, 2.0, 0.5])
+        correlation = jnp.array([[1.0, 0.6, -0.3], [0.6, 1.0, 0.2], [-0.3, 0.2, 1.0]])
+        cov = correlation * scale[:, None] * scale[None, :]
+
+        def logdensity_fn(x):
+            return stats.multivariate_normal.logpdf(x, loc, cov).sum()
+
+        return logdensity_fn, loc, cov
+
+    def run_ghmc(self, momentum_inverse_scale, num_steps=8000, burnin=2000):
+        # `delta` is a translation applied modulo 2 to the persistent slice
+        # variable: a multiple of 2 (e.g. the `delta=2.0` used elsewhere in
+        # this file for a univariate target) leaves the slice frozen and
+        # severely biases mixing for a correlated target, so we pick a
+        # non-degenerate value here.
+        logdensity_fn, loc, cov = self.correlated_gaussian()
+        inference_algorithm = blackjax.ghmc(
+            logdensity_fn,
+            step_size=0.3,
+            momentum_inverse_scale=momentum_inverse_scale,
+            alpha=0.8,
+            delta=1.3,
+        )
+        init_key, sample_key = jax.random.split(self.key)
+        initial_state = inference_algorithm.init(loc, init_key)
+        _, states = run_inference_algorithm(
+            rng_key=sample_key,
+            initial_state=initial_state,
+            inference_algorithm=inference_algorithm,
+            transform=lambda state, info: state.position,
+            num_steps=num_steps,
+        )
+        return states[burnin:], loc, cov
+
+    def test_dense_metric_recovers_moments(self):
+        """A dense (d, d) inverse mass matrix recovers mean and covariance."""
+        _, loc, cov = self.correlated_gaussian()
+        samples, loc, cov = self.run_ghmc(cov)
+        np.testing.assert_allclose(jnp.mean(samples, axis=0), loc, atol=0.35)
+        np.testing.assert_allclose(jnp.cov(samples.T), cov, atol=0.6)
+
+    def test_low_rank_metric_recovers_moments(self):
+        """A LowRankInverseMassMatrix metric recovers mean and covariance."""
+        _, loc, cov = self.correlated_gaussian()
+        sigma = jnp.sqrt(jnp.diagonal(cov))
+        inv_sigma = 1.0 / sigma
+        correlation = cov * inv_sigma[:, None] * inv_sigma[None, :]
+        eigenvalues, eigenvectors = jnp.linalg.eigh(correlation)
+        # Keep the 2 (out of d=3) eigendirections farthest from an identity
+        # correlation -- a genuine rank-2 low-rank correction.
+        order = jnp.argsort(jnp.abs(eigenvalues - 1.0))[::-1]
+        top = order[:2]
+        imm = metrics.LowRankInverseMassMatrix(
+            sigma=sigma, U=eigenvectors[:, top], lam=eigenvalues[top]
+        )
+        samples, loc, cov = self.run_ghmc(imm)
+        np.testing.assert_allclose(jnp.mean(samples, axis=0), loc, atol=0.35)
+        np.testing.assert_allclose(jnp.cov(samples.T), cov, atol=0.6)
+
+    def test_diagonal_metric_matches_legacy_gaussian_euclidean(self):
+        """Diagonal/scalar `momentum_inverse_scale` is unchanged by the
+        generalization: it must still reproduce today's
+        `gaussian_euclidean(scale**2)` bit-for-bit. This is the scale-vs-
+        variance subtlety -- squaring is preserved exactly for the legacy
+        input shape, only the new rich types (dense array, low-rank,
+        `Metric`, callable) skip it.
+        """
+        for momentum_inverse_scale in (jnp.array(1.0), jnp.array([1.0, 2.0, 0.5])):
+            metric = _metric_from_momentum_inverse_scale(momentum_inverse_scale)
+            flat_scale = ravel_pytree(momentum_inverse_scale)[0]
+            legacy_metric = metrics.gaussian_euclidean(flat_scale**2)
+
+            position = jnp.zeros_like(flat_scale)
+            momentum = jnp.arange(flat_scale.shape[0], dtype=flat_scale.dtype) * 0.1
+            key = jax.random.key(0)
+
+            np.testing.assert_allclose(
+                metric.kinetic_energy(momentum),
+                legacy_metric.kinetic_energy(momentum),
+            )
+            np.testing.assert_allclose(
+                ravel_pytree(metric.sample_momentum(key, position))[0],
+                ravel_pytree(legacy_metric.sample_momentum(key, position))[0],
+            )
 
 
 mcse_test_cases = [


### PR DESCRIPTION
## What

Generalizes `blackjax.ghmc` to accept a **dense** or **low-rank** momentum metric, not just a diagonal one — bringing it in line with `hmc`/`nuts`, which already route their `inverse_mass_matrix` through `metrics.default_metric`.

## Why

`ghmc.build_kernel` previously forced a diagonal metric:

```python
flat_inverse_scale = ravel_pytree(momentum_inverse_scale)[0]
momentum_generator, kinetic_energy_fn, *_ = metrics.gaussian_euclidean(flat_inverse_scale ** 2)
```

`ravel_pytree` collapses any `(d, d)` array to 1-D and the elementwise square is only meaningful for a per-dimension inverse *scale* — so a full or low-rank metric could never reach `metrics.gaussian_euclidean` (which already supports dense) or `gaussian_euclidean_low_rank`. This blocks generalized-HMC use cases (e.g. MEADS-style ensembles, or any warmup producing a `LowRankInverseMassMatrix`) on correlated / ill-conditioned targets that need preconditioning.

## The change

A small private helper `_metric_from_momentum_inverse_scale` dispatches on the input **type/shape**, not one formula:

- `Metric` / `LowRankInverseMassMatrix` / callable → forwarded to `default_metric` unchanged (new capability, exactly as `hmc`/`nuts`).
- raw `(d, d)` array (`ndim >= 2`) → forwarded to `default_metric` unchanged, interpreted directly as the inverse mass matrix (no squaring) — the new dense capability.
- scalar / 1-D array / position-shaped pytree → the **legacy** `ravel_pytree(...) ** 2` path, preserved **bit-for-bit**.

The scale-vs-variance subtlety is why this dispatches on type rather than always calling `default_metric`: `momentum_inverse_scale` is documented and used (by MEADS) as an inverse *scale* that the legacy path squares into a variance, whereas `hmc`/`nuts`'s `inverse_mass_matrix` is already variance-like. Existing diagonal/scalar callers — including MEADS — are unaffected.

Public signature of `build_kernel` / `as_top_level_api` is unchanged; only the accepted *type* of `momentum_inverse_scale` broadens. Metric construction is hoisted into `as_top_level_api` (mirroring `hmc`/`nuts`) so a dense/low-rank factorization happens once at construction.

## Tests

- **Backward-compat (unchanged):** `test_ghmc` (scalar) 4/4; `tests/adaptation/test_meads.py` (diagonal, MEADS-driven) 13/13.
- **New bit-for-bit guard:** `test_diagonal_metric_matches_legacy_gaussian_euclidean` — confirms scalar + diagonal-array `kinetic_energy`/`sample_momentum` are identical to `gaussian_euclidean(scale ** 2)`.
- **New capability:** `test_dense_metric_recovers_moments` (full `(3,3)` inverse mass matrix) and `test_low_rank_metric_recovers_moments` (rank-2 `LowRankInverseMassMatrix`) both recover mean + covariance on a correlated Gaussian target. `tests/mcmc/test_metrics.py` 39/39.

## Heads-up (pre-existing, not addressed here)

While tuning the new tests I noticed that ghmc's `delta`, when a multiple of 2, degenerates the persistent-slice update `((slice + 1 + delta) % 2) - 1` to the identity — the slice variable freezes for the whole chain, biasing mixing. This is masked by the loose tolerance in the existing `delta=2.0` univariate test and is orthogonal to this PR (MEADS adapts `delta ∈ [0,1]`, so it's unaffected). Flagging for a possible follow-up doc note / validation. New tests here use a non-degenerate `delta`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
