### PR TITLE
Add GIST sampler family: self-tuning step size (autoStep-style) and trajectory length (no-U-turn)

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -21,6 +21,8 @@ from .mcmc import barker as _barker
 from .mcmc import dynamic_hmc as _dynamic_hmc
 from .mcmc import elliptical_slice as _elliptical_slice
 from .mcmc import ghmc as _ghmc
+from .mcmc import gist_step_size as _gist_step_size
+from .mcmc import gist_trajectory_length as _gist_trajectory_length
 from .mcmc import hmc as _hmc
 from .mcmc import laplace_dynamic_hmc as _laplace_dynamic_hmc
 from .mcmc import laplace_hmc as _laplace_hmc
@@ -135,6 +137,8 @@ coordinate_slice = GenerateSamplingAPI(
 ghmc = generate_top_level_api_from(_ghmc)
 barker = generate_top_level_api_from(_barker)
 barker_proposal = barker  # backwards-compatible alias
+gist_step_size = generate_top_level_api_from(_gist_step_size)
+gist_trajectory_length = generate_top_level_api_from(_gist_trajectory_length)
 
 mhmc = GenerateSamplingAPI(
     functools.partial(
@@ -258,6 +262,8 @@ __all__ = [
     "elliptical_slice",
     "slice_sampling",
     "coordinate_slice",
+    "gist_step_size",
+    "gist_trajectory_length",
     "mclmc",
     "adjusted_mclmc",
     "adjusted_mclmc_dynamic",

--- a/blackjax/mcmc/gist.py
+++ b/blackjax/mcmc/gist.py
@@ -244,6 +244,23 @@ def build_kernel(divergence_threshold: float = 1000) -> Callable:
         ``extra_info`` is threaded straight into the instance's own ``Info``
         NamedTuple; it must carry (at least) a ``num_integration_steps``
         field.
+
+    Note on tracing cost
+    --------------------
+    Because ``tuning_parameter_fn`` and ``apply_fn`` each receive
+    ``logdensity_fn``/``metric`` fresh from this seam (not a shared
+    pre-built trajectory function), an instance whose ``apply_fn`` re-runs
+    the tuning-parameter search at the proposal (as both shipped instances
+    do, for the reversibility/no-return check) pays one extra
+    ``logdensity_fn`` trace for that re-check, on top of the forward
+    search and the accepted-move build -- three per kernel call, not the
+    two of a single-forward-pass sampler like hmc/nuts. This is a
+    deliberate seam-simplicity tradeoff, not a retracing bug: threading a
+    shared pre-built trajectory function through this seam could bring it
+    down to two, at the cost of a more complex seam contract. See
+    ``gist_step_size``/``gist_trajectory_length``'s own
+    ``chex.assert_max_traces(n=4)`` tests (1 at ``init`` + 3 per kernel
+    trace) for the empirically-verified count.
     """
 
     def kernel(

--- a/blackjax/mcmc/gist.py
+++ b/blackjax/mcmc/gist.py
@@ -1,0 +1,319 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""General spine for the GIST (Gibbs self-tuning) sampler family.
+
+GIST (:cite:p:`bou2024gist`) augments the Hamiltonian phase space ``(theta,
+rho)`` with a tuning parameter ``alpha`` (a step size, a trajectory length,
+...) drawn from a user-supplied conditional density ``p(alpha | theta, rho)``,
+then applies a measure-preserving involution ``G(theta, rho, alpha) = (S o
+F(alpha)(theta, rho), g(theta, rho)(alpha))`` where ``S`` is the momentum-flip
+map and ``F(alpha)`` a reversible, volume-preserving map indexed by ``alpha``
+(typically a fixed number of leapfrog steps, or a variable number of steps at
+a fixed step size). Provided ``G`` is measure preserving, the resulting
+Metropolis-Hastings chain is reversible w.r.t. the target and the
+``theta``-marginal recovers the original target exactly.
+
+This module implements the *general* kernel (Gibbs-refresh momentum,
+Gibbs-refresh tuning parameter, apply the involution, one Metropolis test) --
+it is not user-facing on its own. Concrete instances plug in
+``tuning_parameter_fn``/``apply_fn`` and are exposed as
+``blackjax.gist_step_size`` (:mod:`blackjax.mcmc.gist_step_size`) and
+``blackjax.gist_trajectory_length`` (:mod:`blackjax.mcmc.gist_trajectory_length`).
+
+Both shipped instances take ``g(theta, rho) = identity`` on the tuning
+parameter, which is a sufficient condition for ``G`` to be a
+measure-preserving involution (Corollary 4): since ``S o F(alpha)`` is a
+volume-preserving involution for every fixed ``alpha``, Fubini's theorem lifts
+this to the product space ``R^{2d} x A`` without needing a nontrivial ``g``.
+
+References
+----------
+.. [1] Bou-Rabee, Carpenter, Marsden, "GIST: Gibbs self-tuning for locally
+   adaptive Hamiltonian Monte Carlo", arXiv:2404.15253, Statistical Surveys
+   2026, Vol. 20, pp. 135-179. Algorithm 1 (p.6), eq. 9 (p.7).
+"""
+from typing import Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+import blackjax.mcmc.hmc as hmc
+import blackjax.mcmc.metrics as metrics
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.mcmc.integrators import IntegratorState
+from blackjax.mcmc.proposal import safe_energy_diff
+from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
+
+__all__ = ["GISTState", "GISTInfo", "init", "build_kernel", "as_top_level_api"]
+
+
+class GISTState(NamedTuple):
+    """State of the GIST sampling chain.
+
+    position
+        Current position of the chain.
+    logdensity
+        Log-density of the target at ``position``.
+    logdensity_grad
+        Gradient of the log-density at ``position``.
+    """
+
+    position: ArrayTree
+    logdensity: float
+    logdensity_grad: ArrayTree
+
+
+class GISTInfo(NamedTuple):
+    """Additional information on a GIST transition.
+
+    momentum
+        The momentum sampled at the start of the transition (before the
+        involution is applied) -- the Gibbs draw ``rho ~ N(0, Sigma)``.
+    tuning_parameter
+        The tuning parameter ``alpha`` drawn from ``p(. | position,
+        momentum)`` (a PyTree; e.g. an integer step-count for
+        ``gist_trajectory_length``, or ``(a, b, j)`` for ``gist_step_size``).
+    is_accepted
+        Whether the involution's output was accepted.
+    is_divergent
+        Whether the *energy* term of the acceptance ratio (``-delta_energy``)
+        exceeded ``divergence_threshold``. This is distinct from a structural
+        rejection (e.g. the step-size reversibility check failing, or the
+        tuning parameter falling outside the reverse U-turn interval) --
+        those are reported via instance-specific ``Info`` fields, not here.
+    acceptance_rate
+        The realized GIST acceptance probability actually used -- already
+        includes any tuning-density-ratio factor (the reversibility-check
+        indicator for ``gist_step_size``, or the interval-width ratio for
+        ``gist_trajectory_length``), not just the bare energy-based
+        Metropolis term.
+    energy
+        Total Hamiltonian energy of the proposal state.
+    num_integration_steps
+        Number of leapfrog evaluations spent on the accepted/rejected
+        proposal's own trajectory (NOT counting any extra evaluations spent
+        inside the tuning-parameter sampler itself, e.g. the step-size
+        doubling/halving search or the forward/reverse U-turn rollouts --
+        see the instance-specific ``Info`` fields for those separately, since
+        they matter for tuning-inclusive cost accounting).
+
+    References
+    ----------
+    Bou-Rabee, Carpenter, Marsden, "GIST: Gibbs self-tuning for locally
+    adaptive Hamiltonian Monte Carlo", arXiv:2404.15253, Algorithm 1 (p.6),
+    eq. 9 (p.7).
+    """
+
+    momentum: ArrayTree
+    tuning_parameter: ArrayTree
+    is_accepted: Array
+    is_divergent: Array
+    acceptance_rate: Array
+    energy: float
+    num_integration_steps: Array
+
+
+def init(position: ArrayLikeTree, logdensity_fn: Callable) -> GISTState:
+    """Create the initial GIST state.
+
+    Numerically identical to :func:`blackjax.mcmc.hmc.init` (same
+    ``value_and_grad`` computation); re-wrapped into :class:`GISTState`
+    rather than aliased directly (``init = hmc.init``) so that every
+    ``GISTState`` produced by this module is actually an instance of
+    ``GISTState``, not ``HMCState``. This matters because ``jax.lax.cond`` in
+    :func:`build_kernel` branches between a freshly built ``GISTState`` and
+    the incoming ``state`` -- both branches must share the exact same pytree
+    treedef, which a bare alias would violate on the very first call.
+    """
+    state = hmc.init(position, logdensity_fn)
+    return GISTState(state.position, state.logdensity, state.logdensity_grad)
+
+
+def _step(
+    rng_key: PRNGKey,
+    state: GISTState,
+    logdensity_fn: Callable,
+    tuning_parameter_fn: Callable,
+    apply_fn: Callable,
+    inverse_mass_matrix: metrics.MetricTypes,
+    divergence_threshold: float,
+) -> tuple[GISTState, GISTInfo, ArrayTree]:
+    """Shared implementation of the general GIST kernel.
+
+    Returns the ``(new_state, info, extra_info)`` triple. The public
+    :func:`build_kernel` discards ``extra_info`` to honor the kernel's
+    documented ``(GISTState, GISTInfo)`` contract; instance modules
+    (``gist_step_size``, ``gist_trajectory_length``) call this directly so
+    they can thread ``extra_info`` (e.g. the reversibility-check index, the
+    forward/reverse U-turn counts) into their own, richer ``Info`` NamedTuple
+    without recomputing it.
+    """
+    metric = metrics.default_metric(inverse_mass_matrix)
+    key_momentum, key_tuning, key_accept = jax.random.split(rng_key, 3)
+
+    position, logdensity, logdensity_grad = state
+    momentum = metric.sample_momentum(key_momentum, position)  # GIBBS: rho
+    integrator_state = IntegratorState(
+        position, momentum, logdensity, logdensity_grad
+    )
+
+    # GIBBS: alpha ~ p(. | theta, rho)
+    alpha, aux = tuning_parameter_fn(
+        key_tuning, integrator_state, logdensity_fn, metric
+    )
+
+    # METROPOLIS: (theta', rho') = S o F(alpha)(theta, rho)
+    proposal_state, log_tuning_density_ratio, extra_info = apply_fn(
+        integrator_state, alpha, aux, logdensity_fn, metric
+    )
+
+    initial_energy = -logdensity + metric.kinetic_energy(momentum)
+    proposal_energy = -proposal_state.logdensity + metric.kinetic_energy(
+        proposal_state.momentum
+    )
+    delta_energy = safe_energy_diff(initial_energy, proposal_energy)
+    is_diverging = -delta_energy > divergence_threshold
+
+    log_accept = delta_energy + log_tuning_density_ratio
+    accept_prob = jnp.exp(jnp.minimum(log_accept, 0.0))  # log_accept=-inf -> 0
+    do_accept = jax.random.uniform(key_accept) < accept_prob
+
+    new_state = jax.lax.cond(
+        do_accept,
+        lambda: GISTState(
+            proposal_state.position,
+            proposal_state.logdensity,
+            proposal_state.logdensity_grad,
+        ),
+        lambda: state,
+    )
+    info = GISTInfo(
+        momentum,
+        alpha,
+        do_accept,
+        is_diverging,
+        accept_prob,
+        proposal_energy,
+        extra_info.num_integration_steps,
+    )
+    return new_state, info, extra_info
+
+
+def build_kernel(divergence_threshold: float = 1000) -> Callable:
+    """Build the general GIST kernel.
+
+    Parameters
+    ----------
+    divergence_threshold
+        Threshold on the energy term of the acceptance ratio above which a
+        transition is flagged ``is_divergent`` (same convention as
+        ``hmc``/``nuts``).
+
+    Returns
+    -------
+    A kernel with signature ``kernel(rng_key, state, logdensity_fn,
+    tuning_parameter_fn, apply_fn, inverse_mass_matrix) -> (GISTState,
+    GISTInfo)`` where:
+
+    ``tuning_parameter_fn(rng_key, state: IntegratorState, logdensity_fn,
+    metric) -> (alpha, aux)``
+        The GIBBS step: draws ``alpha ~ p(. | theta, rho)``. ``aux`` is an
+        opaque PyTree threaded to ``apply_fn`` for anything computed here
+        that ``apply_fn`` would otherwise have to recompute (e.g. the
+        forward U-turn count ``U(theta, rho)``, or the ``(a, b)``
+        thresholds).
+    ``apply_fn(state: IntegratorState, alpha, aux, logdensity_fn, metric) ->
+    (proposal_state: IntegratorState, log_tuning_density_ratio: Array,
+    extra_info: ArrayTree)``
+        Computes the involution ``G(theta, rho, alpha) = (S o
+        F(alpha)(theta, rho), g(theta, rho)(alpha))`` and returns ``log[
+        p(g(theta, rho)(alpha) | S o F(alpha)(theta, rho)) / p(alpha |
+        theta, rho) ]`` directly as a scalar log-ratio -- NOT two separate
+        density evaluations (a Dirac-measure ``p``, as in ``gist_step_size``,
+        has no well-defined value away from its atom, so the ratio must be
+        computed directly rather than as two independent evaluations).
+        ``extra_info`` is threaded straight into the instance's own ``Info``
+        NamedTuple; it must carry (at least) a ``num_integration_steps``
+        field.
+    """
+
+    def kernel(
+        rng_key: PRNGKey,
+        state: GISTState,
+        logdensity_fn: Callable,
+        tuning_parameter_fn: Callable,
+        apply_fn: Callable,
+        inverse_mass_matrix: metrics.MetricTypes,
+    ) -> tuple[GISTState, GISTInfo]:
+        """Generate a new sample with the general GIST kernel."""
+        new_state, info, _ = _step(
+            rng_key,
+            state,
+            logdensity_fn,
+            tuning_parameter_fn,
+            apply_fn,
+            inverse_mass_matrix,
+            divergence_threshold,
+        )
+        return new_state, info
+
+    return kernel
+
+
+def as_top_level_api(
+    logdensity_fn: Callable,
+    inverse_mass_matrix: metrics.MetricTypes,
+    tuning_parameter_fn: Callable,
+    apply_fn: Callable,
+    *,
+    divergence_threshold: float = 1000,
+) -> SamplingAlgorithm:
+    """Build a ``SamplingAlgorithm`` from the general GIST kernel.
+
+    This is mainly an internal building block for the two instance modules
+    (:mod:`blackjax.mcmc.gist_step_size`,
+    :mod:`blackjax.mcmc.gist_trajectory_length`) -- end users call
+    ``blackjax.gist_step_size(...)`` / ``blackjax.gist_trajectory_length(...)``,
+    not this function directly (mirroring how ``nuts.as_top_level_api``
+    doesn't route end users through ``hmc.as_top_level_api``, even though it
+    reuses ``hmc.py``'s pieces internally). There is deliberately no
+    top-level ``blackjax.gist``; reach this via
+    ``blackjax.mcmc.gist.as_top_level_api``.
+
+    Parameters
+    ----------
+    logdensity_fn
+        The log-density function we wish to draw samples from.
+    inverse_mass_matrix
+        The value to use for the inverse mass matrix when drawing a value
+        for the momentum and computing the kinetic energy.
+    tuning_parameter_fn
+        The GIBBS seam, see :func:`build_kernel`.
+    apply_fn
+        The involution seam, see :func:`build_kernel`.
+    divergence_threshold
+        The absolute value of the difference in energy between two states
+        above which we say that the transition is divergent.
+
+    Returns
+    -------
+    A ``SamplingAlgorithm``.
+    """
+    kernel = build_kernel(divergence_threshold)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        logdensity_fn,
+        kernel_args=(tuning_parameter_fn, apply_fn, inverse_mass_matrix),
+    )

--- a/blackjax/mcmc/gist.py
+++ b/blackjax/mcmc/gist.py
@@ -164,9 +164,7 @@ def _step(
 
     position, logdensity, logdensity_grad = state
     momentum = metric.sample_momentum(key_momentum, position)  # GIBBS: rho
-    integrator_state = IntegratorState(
-        position, momentum, logdensity, logdensity_grad
-    )
+    integrator_state = IntegratorState(position, momentum, logdensity, logdensity_grad)
 
     # GIBBS: alpha ~ p(. | theta, rho)
     alpha, aux = tuning_parameter_fn(

--- a/blackjax/mcmc/gist_step_size.py
+++ b/blackjax/mcmc/gist_step_size.py
@@ -42,7 +42,7 @@ References
    "asymmetric"``, provided for cross-validation against the original paper
    only -- can get stuck near the mode/in the tails).
 """
-from typing import Callable, NamedTuple
+from typing import Callable, NamedTuple, cast
 
 import jax
 import jax.numpy as jnp
@@ -177,8 +177,7 @@ def step_size_selector(
     """
     if criterion not in ("symmetric", "asymmetric"):
         raise ValueError(
-            "criterion must be 'symmetric' or 'asymmetric', got "
-            f"{criterion!r}"
+            "criterion must be 'symmetric' or 'asymmetric', got " f"{criterion!r}"
         )
     is_symmetric = criterion == "symmetric"
 
@@ -230,9 +229,7 @@ def step_size_selector(
             jnp.asarray(0, dtype=jnp.int32),
             v == 0,
         )
-        j_final, _, terminated_final = jax.lax.while_loop(
-            cond_fn, body_fn, init_carry
-        )
+        j_final, _, terminated_final = jax.lax.while_loop(cond_fn, body_fn, init_carry)
         search_exhausted = jnp.logical_not(terminated_final) & (v != 0)
         # "Final halving": on a successful *expansion*, report one step back
         # (section 2.1.2) -- necessary for the reversibility check to ever
@@ -321,8 +318,7 @@ def build_kernel(
     """
     if criterion not in ("symmetric", "asymmetric"):
         raise ValueError(
-            "criterion must be 'symmetric' or 'asymmetric', got "
-            f"{criterion!r}"
+            "criterion must be 'symmetric' or 'asymmetric', got " f"{criterion!r}"
         )
     gist_step = gist._step
 
@@ -347,7 +343,7 @@ def build_kernel(
             integrator, num_integration_steps, initial_step_size, selector
         )
 
-        new_state, info, extra_info = gist_step(
+        new_state, info, raw_extra_info = gist_step(
             rng_key,
             state,
             logdensity_fn,
@@ -356,15 +352,20 @@ def build_kernel(
             inverse_mass_matrix,
             divergence_threshold,
         )
+        # `info.tuning_parameter`/`raw_extra_info` are declared as the generic
+        # `ArrayTree` in the general spine (opaque to it by design); cast back
+        # to the concrete instance types this kernel actually produces.
+        tuning_parameter = cast(StepSizeTuningParameter, info.tuning_parameter)
+        extra_info = cast(_StepSizeExtra, raw_extra_info)
         step_size_info = GISTStepSizeInfo(
             info.momentum,
-            info.tuning_parameter,
+            tuning_parameter,
             info.is_accepted,
             info.is_divergent,
             info.acceptance_rate,
             info.energy,
             info.num_integration_steps,
-            info.tuning_parameter.step_index,
+            tuning_parameter.step_index,
             extra_info.reverse_step_index,
             extra_info.search_exhausted,
             extra_info.step_size,

--- a/blackjax/mcmc/gist_step_size.py
+++ b/blackjax/mcmc/gist_step_size.py
@@ -1,0 +1,449 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GIST instance (a): self-tuning step size, autoStep-style.
+
+The tuning parameter is ``alpha = (a, b, j)``: ``(a, b)`` are soft
+acceptance-ratio thresholds freshly drawn every transition from the uniform
+distribution on the triangle ``Delta = {(a, b) in (0, 1)^2 : a < b}``, and
+``j`` is the integer log2 step-size index (``step_size = initial_step_size *
+2**j``) selected *deterministically* given ``(theta, rho, a, b)`` by the
+doubling/halving selector :func:`step_size_selector` (section 2.1.2).
+
+Because ``p(a, b, j | theta, rho) = Uniform_Delta(a, b) . 1{j = mu(theta, rho,
+a, b)}`` is a Dirac measure in its ``j``-argument, the GIST tuning-density
+ratio (eq. 9) collapses to an indicator that the *reverse* selection ``j' =
+mu(theta', rho', a, b)`` (re-run at the proposal, with the *same* ``(a, b)``)
+matches the forward ``j`` -- the "reversibility check" of
+[autoMALA]/[AutoStep], derived directly from the GIST framework rather than
+bolted on as a separate correctness patch (section 2.1.3).
+
+References
+----------
+.. [1] Bou-Rabee, Carpenter, Marsden, "GIST: Gibbs self-tuning for locally
+   adaptive Hamiltonian Monte Carlo", arXiv:2404.15253, section 2 (mapping
+   onto the general kernel).
+.. [2] Liu, Surjanovic, Biron-Lattes, Bouchard-Cote, Campbell, "AutoStep:
+   Locally adaptive involutive MCMC", arXiv:2410.18929, Algorithm 2 (the
+   symmetric selector, default here).
+.. [3] Biron-Lattes, Surjanovic, Syed, Campbell, Bouchard-Cote, "autoMALA:
+   Locally adaptive Metropolis-adjusted Langevin algorithm",
+   arXiv:2310.16782, Algorithm 2 (the asymmetric selector, ``criterion=
+   "asymmetric"``, provided for cross-validation against the original paper
+   only -- can get stuck near the mode/in the tails).
+"""
+from typing import Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+import blackjax.mcmc.gist as gist
+import blackjax.mcmc.hmc as hmc
+import blackjax.mcmc.integrators as integrators
+import blackjax.mcmc.metrics as metrics
+import blackjax.mcmc.trajectory as trajectory
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.mcmc.integrators import IntegratorState
+from blackjax.mcmc.proposal import safe_energy_diff
+from blackjax.types import Array, PRNGKey
+
+__all__ = [
+    "GISTStepSizeInfo",
+    "StepSizeTuningParameter",
+    "init",
+    "step_size_selector",
+    "build_kernel",
+    "as_top_level_api",
+]
+
+init = gist.init
+
+
+class StepSizeTuningParameter(NamedTuple):
+    """The GIST tuning parameter ``alpha = (a, b, j)``, section 2.1.1.
+
+    a, b
+        Soft acceptance-ratio thresholds, freshly drawn ~ Uniform on
+        ``{(a, b) in (0, 1)^2 : a < b}`` every transition (the Gibbs refresh
+        of the tuning parameter). The uniform density cancels in the
+        acceptance ratio since ``g = identity`` carries ``(a, b)`` through
+        the involution unchanged (section 2.1.3) -- any consistent
+        (deterministic-given-key) way of drawing them would do, but the
+        uniform-on-the-triangle draw is what the paper's own ``p(alpha |
+        theta, rho)`` factorization assumes.
+    step_index
+        ``j``, the integer log2 step-size index:
+        ``step_size = initial_step_size * 2**j``.
+    """
+
+    a: Array
+    b: Array
+    step_index: Array
+
+
+class _StepSizeExtra(NamedTuple):
+    """Extra info computed by ``apply_fn``, threaded into
+    :class:`GISTStepSizeInfo` without recomputation."""
+
+    num_integration_steps: Array
+    reverse_step_index: Array
+    search_exhausted: Array
+    step_size: Array
+
+
+class GISTStepSizeInfo(NamedTuple):
+    """Additional information for a ``gist_step_size`` transition.
+
+    momentum, tuning_parameter, is_accepted, is_divergent, acceptance_rate,
+    energy, num_integration_steps
+        Same as :class:`~blackjax.mcmc.gist.GISTInfo` (this instance's Info
+        extends it with flat, named fields rather than nesting -- matches
+        the ``NUTSInfo``-extends-``HMCInfo``-fields precedent, not literal
+        NamedTuple inheritance).
+    step_index, reverse_step_index
+        ``j`` (selected forward) and ``j'`` (re-selected at the proposal,
+        the "reversibility check", section 2.1.3). ``is_accepted`` is False
+        whenever ``reverse_step_index != step_index``, in addition to the
+        ordinary energy-based rejection path -- both are folded into
+        ``is_accepted``; these two fields let you tell them apart.
+    search_exhausted
+        True if the doubling/halving search (forward OR reverse) hit
+        ``max_search_steps`` without the selection criterion terminating.
+        When True, the transition was forced to reject regardless of the
+        energy term (section 2.1.2).
+    step_size
+        The step size ``epsilon = initial_step_size * 2**step_index``
+        actually used to build the proposal.
+    """
+
+    momentum: Array
+    tuning_parameter: StepSizeTuningParameter
+    is_accepted: Array
+    is_divergent: Array
+    acceptance_rate: Array
+    energy: float
+    num_integration_steps: Array
+    step_index: Array
+    reverse_step_index: Array
+    search_exhausted: Array
+    step_size: Array
+
+
+def step_size_selector(
+    integrator: Callable,
+    num_integration_steps: int,
+    initial_step_size: float,
+    max_search_steps: int = 10,
+    criterion: str = "symmetric",
+) -> Callable:
+    """Build the ``mu(state, a, b, logdensity_fn, metric) -> (step_index,
+    search_exhausted)`` selector, section 2.1.2.
+
+    (``logdensity_fn``/``metric`` extend the paper's ``mu(state, a, b)``
+    shorthand: evaluating ``F(alpha)`` fundamentally requires both, they are
+    not a free design choice.)
+
+    Parameters
+    ----------
+    integrator
+        Symplectic integrator used for the ``num_integration_steps``-step
+        trial trajectories.
+    num_integration_steps
+        ``L``, the fixed number of leapfrog steps per trial trajectory.
+    initial_step_size
+        ``epsilon_init``, the fixed base step size the doubling/halving
+        search starts from and reports its selection relative to.
+    max_search_steps
+        Cap on doubling/halving iterations.
+    criterion
+        ``"symmetric"`` ([AutoStep] Algorithm 2, default -- proven
+        irreducible and aperiodic) or ``"asymmetric"`` ([autoMALA]'s
+        original criterion, provided for cross-validation against the
+        original paper only).
+
+    Returns
+    -------
+    The selector ``mu``.
+    """
+    if criterion not in ("symmetric", "asymmetric"):
+        raise ValueError(
+            "criterion must be 'symmetric' or 'asymmetric', got "
+            f"{criterion!r}"
+        )
+    is_symmetric = criterion == "symmetric"
+
+    def log_acceptance_ratio(state, step_size, logdensity_fn, metric):
+        """``ell(theta, rho, epsilon)`` -- ``-delta_energy`` at one trial
+        step size, section 2.1.2. Renamed from the paper's terse ``ell`` to
+        a descriptive name, per the naming-conventions checklist.
+        """
+        symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
+        build_trajectory = trajectory.static_integration(symplectic_integrator)
+        end_state = build_trajectory(state, step_size, num_integration_steps)
+        end_state = hmc.flip_momentum(end_state)
+        initial_energy = -state.logdensity + metric.kinetic_energy(state.momentum)
+        new_energy = -end_state.logdensity + metric.kinetic_energy(end_state.momentum)
+        return safe_energy_diff(initial_energy, new_energy)
+
+    def mu(state: IntegratorState, a, b, logdensity_fn, metric):
+        log_a = jnp.log(a)
+        log_b = jnp.log(b)
+        ell0 = log_acceptance_ratio(state, initial_step_size, logdensity_fn, metric)
+
+        if is_symmetric:
+            do_expand = jnp.abs(ell0) < jnp.abs(log_b)  # too small a step
+            do_shrink = jnp.abs(ell0) > jnp.abs(log_a)  # too large a step
+        else:
+            do_expand = ell0 >= log_b
+            do_shrink = ell0 <= log_a
+        v = jnp.where(do_expand, 1, jnp.where(do_shrink, -1, 0)).astype(jnp.int32)
+
+        def cond_fn(carry):
+            _, n, terminated = carry
+            return jnp.logical_not(terminated) & (n < max_search_steps)
+
+        def body_fn(carry):
+            j, n, _ = carry
+            j_next = j + v
+            step_size = initial_step_size * 2.0 ** j_next.astype(jnp.float32)
+            ell = log_acceptance_ratio(state, step_size, logdensity_fn, metric)
+            if is_symmetric:
+                term_expand = (v == 1) & (jnp.abs(ell) >= jnp.abs(log_b))
+                term_shrink = (v == -1) & (jnp.abs(ell) <= jnp.abs(log_a))
+            else:
+                term_expand = (v == 1) & (ell < log_b)
+                term_shrink = (v == -1) & (ell > log_a)
+            return j_next, n + 1, term_expand | term_shrink
+
+        init_carry = (
+            jnp.asarray(0, dtype=jnp.int32),
+            jnp.asarray(0, dtype=jnp.int32),
+            v == 0,
+        )
+        j_final, _, terminated_final = jax.lax.while_loop(
+            cond_fn, body_fn, init_carry
+        )
+        search_exhausted = jnp.logical_not(terminated_final) & (v != 0)
+        # "Final halving": on a successful *expansion*, report one step back
+        # (section 2.1.2) -- necessary for the reversibility check to ever
+        # pass in the doubling sub-case ([autoMALA] p.4).
+        step_index = jnp.where(terminated_final & (v == 1), j_final - 1, j_final)
+        return step_index, search_exhausted
+
+    return mu
+
+
+def _tuning_parameter_fn(selector: Callable) -> Callable:
+    def tuning_parameter_fn(rng_key, state, logdensity_fn, metric):
+        u = jax.random.uniform(rng_key, shape=(2,))
+        a = jnp.minimum(u[0], u[1])
+        b = jnp.maximum(u[0], u[1])
+        step_index, search_exhausted = selector(state, a, b, logdensity_fn, metric)
+        alpha = StepSizeTuningParameter(a, b, step_index)
+        return alpha, search_exhausted
+
+    return tuning_parameter_fn
+
+
+def _apply_fn(
+    integrator: Callable,
+    num_integration_steps: int,
+    initial_step_size: float,
+    selector: Callable,
+) -> Callable:
+    def apply_fn(state, alpha, aux, logdensity_fn, metric):
+        a, b, step_index = alpha
+        search_exhausted_forward = aux
+        step_size = initial_step_size * 2.0 ** step_index.astype(jnp.float32)
+
+        symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
+        build_trajectory = trajectory.static_integration(symplectic_integrator)
+        proposal_state = build_trajectory(state, step_size, num_integration_steps)
+        proposal_state = hmc.flip_momentum(proposal_state)
+
+        reverse_step_index, search_exhausted_reverse = selector(
+            proposal_state, a, b, logdensity_fn, metric
+        )
+        search_exhausted = search_exhausted_forward | search_exhausted_reverse
+        is_reversible = reverse_step_index == step_index
+        log_tuning_density_ratio = jnp.where(
+            is_reversible & jnp.logical_not(search_exhausted), 0.0, -jnp.inf
+        )
+        extra_info = _StepSizeExtra(
+            num_integration_steps=jnp.asarray(num_integration_steps),
+            reverse_step_index=reverse_step_index,
+            search_exhausted=search_exhausted,
+            step_size=step_size,
+        )
+        return proposal_state, log_tuning_density_ratio, extra_info
+
+    return apply_fn
+
+
+def build_kernel(
+    integrator: Callable = integrators.velocity_verlet,
+    divergence_threshold: float = 1000,
+    criterion: str = "symmetric",
+    max_search_steps: int = 10,
+) -> Callable:
+    """Build a ``gist_step_size`` kernel.
+
+    Parameters
+    ----------
+    integrator
+        The symplectic integrator to use to integrate the Hamiltonian
+        dynamics.
+    divergence_threshold
+        Value of the difference in energy above which we consider that the
+        transition is divergent.
+    criterion
+        ``"symmetric"`` (default) or ``"asymmetric"``, see
+        :func:`step_size_selector`.
+    max_search_steps
+        Cap on doubling/halving iterations (both the forward selection and
+        the reversibility-check re-selection).
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current
+    state of the chain and that returns a new state of the chain along with
+    information about the transition.
+    """
+    if criterion not in ("symmetric", "asymmetric"):
+        raise ValueError(
+            "criterion must be 'symmetric' or 'asymmetric', got "
+            f"{criterion!r}"
+        )
+    gist_step = gist._step
+
+    def kernel(
+        rng_key: PRNGKey,
+        state: gist.GISTState,
+        logdensity_fn: Callable,
+        initial_step_size: float,
+        inverse_mass_matrix: metrics.MetricTypes,
+        num_integration_steps: int = 1,
+    ) -> tuple[gist.GISTState, GISTStepSizeInfo]:
+        """Generate a new sample with the ``gist_step_size`` kernel."""
+        selector = step_size_selector(
+            integrator,
+            num_integration_steps,
+            initial_step_size,
+            max_search_steps,
+            criterion,
+        )
+        tuning_parameter_fn = _tuning_parameter_fn(selector)
+        apply_fn = _apply_fn(
+            integrator, num_integration_steps, initial_step_size, selector
+        )
+
+        new_state, info, extra_info = gist_step(
+            rng_key,
+            state,
+            logdensity_fn,
+            tuning_parameter_fn,
+            apply_fn,
+            inverse_mass_matrix,
+            divergence_threshold,
+        )
+        step_size_info = GISTStepSizeInfo(
+            info.momentum,
+            info.tuning_parameter,
+            info.is_accepted,
+            info.is_divergent,
+            info.acceptance_rate,
+            info.energy,
+            info.num_integration_steps,
+            info.tuning_parameter.step_index,
+            extra_info.reverse_step_index,
+            extra_info.search_exhausted,
+            extra_info.step_size,
+        )
+        return new_state, step_size_info
+
+    return kernel
+
+
+def as_top_level_api(
+    logdensity_fn: Callable,
+    inverse_mass_matrix: metrics.MetricTypes,
+    initial_step_size: float,
+    num_integration_steps: int = 1,
+    *,
+    criterion: str = "symmetric",
+    max_search_steps: int = 10,
+    divergence_threshold: float = 1000,
+    integrator: Callable = integrators.velocity_verlet,
+) -> SamplingAlgorithm:
+    """``blackjax.gist_step_size`` -- GIST self-tuning step size (autoStep-style).
+
+    Examples
+    --------
+
+    A new ``gist_step_size`` kernel can be initialized and used with the
+    following code:
+
+    .. code::
+
+        gist_step_size = blackjax.gist_step_size(
+            logdensity_fn, inverse_mass_matrix, initial_step_size=0.1
+        )
+        state = gist_step_size.init(position)
+        new_state, info = gist_step_size.step(rng_key, state)
+
+    Parameters
+    ----------
+    logdensity_fn
+        The log-density function we wish to draw samples from.
+    inverse_mass_matrix
+        The value to use for the inverse mass matrix when drawing a value
+        for the momentum and computing the kinetic energy.
+    initial_step_size
+        ``epsilon_init``, section 2.1.1; the fixed base step size the
+        doubling/halving search starts from and reports its selection
+        relative to (``epsilon = initial_step_size * 2**j``). NOT re-tuned
+        by this kernel -- round-based re-tuning of ``initial_step_size``
+        ([AutoStep]/[autoMALA] Algorithm 3) is out of scope; it belongs in
+        ``blackjax/adaptation/``.
+    num_integration_steps
+        ``L``, the (fixed) number of leapfrog steps per proposal at the
+        selected step size. Default 1 reproduces the MALA-equivalent
+        single-leapfrog-step case both source papers analyze.
+    criterion
+        ``"symmetric"`` (default, [AutoStep] Algorithm 2 -- proven
+        irreducible and aperiodic) or ``"asymmetric"`` ([autoMALA]'s
+        original criterion -- provided for cross-validation against the
+        original paper only; can get stuck near the mode/in the tails, see
+        the module docstring).
+    max_search_steps
+        Cap on doubling/halving iterations (both the forward selection and
+        the reversibility-check re-selection). On exhaustion the transition
+        is forced to reject; see ``GISTStepSizeInfo.search_exhausted``.
+    divergence_threshold
+        The absolute value of the difference in energy between two states
+        above which we say that the transition is divergent.
+    integrator
+        (algorithm parameter) The symplectic integrator to use to integrate
+        the trajectory.
+
+    Returns
+    -------
+    A ``SamplingAlgorithm``.
+    """
+    kernel = build_kernel(integrator, divergence_threshold, criterion, max_search_steps)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        logdensity_fn,
+        kernel_args=(initial_step_size, inverse_mass_matrix, num_integration_steps),
+    )

--- a/blackjax/mcmc/gist_step_size.py
+++ b/blackjax/mcmc/gist_step_size.py
@@ -181,60 +181,111 @@ def step_size_selector(
         )
     is_symmetric = criterion == "symmetric"
 
-    def log_acceptance_ratio(state, step_size, logdensity_fn, metric):
-        """``ell(theta, rho, epsilon)`` -- ``-delta_energy`` at one trial
-        step size, section 2.1.2. Renamed from the paper's terse ``ell`` to
-        a descriptive name, per the naming-conventions checklist.
-        """
-        symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
-        build_trajectory = trajectory.static_integration(symplectic_integrator)
-        end_state = build_trajectory(state, step_size, num_integration_steps)
-        end_state = hmc.flip_momentum(end_state)
-        initial_energy = -state.logdensity + metric.kinetic_energy(state.momentum)
-        new_energy = -end_state.logdensity + metric.kinetic_energy(end_state.momentum)
-        return safe_energy_diff(initial_energy, new_energy)
+    def mu(
+        state: IntegratorState,
+        a,
+        b,
+        logdensity_fn,
+        metric,
+        *,
+        build_trajectory: Callable | None = None,
+    ):
+        # Build (or reuse a caller-supplied) trajectory builder exactly once
+        # per `mu` call -- this is what `integrator(logdensity_fn,
+        # metric.kinetic_energy)` wraps `logdensity_fn` in a fresh
+        # `jax.value_and_grad` (matching the hmc/nuts convention of building
+        # the symplectic integrator once and threading it through, rather
+        # than rebuilding per trial step size -- the latter tripped
+        # `chex.assert_max_traces` during implementation: rebuilding inside
+        # the trial-evaluation helper counted as a separate trace per call).
+        # `apply_fn` passes its own already-built trajectory function so the
+        # reverse selection re-run shares it instead of re-wrapping
+        # `logdensity_fn` a second time.
+        if build_trajectory is None:
+            symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
+            build_trajectory = trajectory.static_integration(symplectic_integrator)
 
-    def mu(state: IntegratorState, a, b, logdensity_fn, metric):
+        def log_acceptance_ratio(step_size):
+            """``ell(theta, rho, epsilon)`` -- ``-delta_energy`` at one
+            trial step size, section 2.1.2. Renamed from the paper's terse
+            ``ell`` to a descriptive name, per the naming-conventions
+            checklist.
+            """
+            end_state = build_trajectory(state, step_size, num_integration_steps)
+            end_state = hmc.flip_momentum(end_state)
+            initial_energy = -state.logdensity + metric.kinetic_energy(state.momentum)
+            new_energy = -end_state.logdensity + metric.kinetic_energy(
+                end_state.momentum
+            )
+            return safe_energy_diff(initial_energy, new_energy)
+
         log_a = jnp.log(a)
         log_b = jnp.log(b)
-        ell0 = log_acceptance_ratio(state, initial_step_size, logdensity_fn, metric)
 
-        if is_symmetric:
-            do_expand = jnp.abs(ell0) < jnp.abs(log_b)  # too small a step
-            do_shrink = jnp.abs(ell0) > jnp.abs(log_a)  # too large a step
-        else:
-            do_expand = ell0 >= log_b
-            do_shrink = ell0 <= log_a
-        v = jnp.where(do_expand, 1, jnp.where(do_shrink, -1, 0)).astype(jnp.int32)
-
+        # Deciding `v` from `ell0` (section 2.1.2) is folded into iteration 0
+        # of the same `while_loop` that runs the doubling/halving search,
+        # rather than a separate call to `log_acceptance_ratio` before the
+        # loop -- `jax.lax.while_loop` traces its body exactly once
+        # regardless of how many concrete iterations run, so folding this in
+        # keeps `log_acceptance_ratio` (hence `logdensity_fn`) to a single
+        # trace-time call site per `mu` invocation, instead of two (one for
+        # `ell0`, one inside the loop body) -- the latter tripped
+        # `chex.assert_max_traces` during implementation.
         def cond_fn(carry):
-            _, n, terminated = carry
-            return jnp.logical_not(terminated) & (n < max_search_steps)
+            _, n, terminated, _ = carry
+            return jnp.logical_not(terminated) & (n < max_search_steps + 1)
 
         def body_fn(carry):
-            j, n, _ = carry
-            j_next = j + v
-            step_size = initial_step_size * 2.0 ** j_next.astype(jnp.float32)
-            ell = log_acceptance_ratio(state, step_size, logdensity_fn, metric)
+            j, n, _, v = carry
+            is_deciding = n == 0
+            # Iteration 0 evaluates at the *current* j (i.e. `ell0`, j
+            # unchanged); iteration n>=1 evaluates at j+v using the v
+            # decided at iteration 0.
+            trial_j = jnp.where(is_deciding, j, j + v)
+            step_size = initial_step_size * 2.0 ** trial_j.astype(jnp.float32)
+            ell = log_acceptance_ratio(step_size)
+
             if is_symmetric:
-                term_expand = (v == 1) & (jnp.abs(ell) >= jnp.abs(log_b))
-                term_shrink = (v == -1) & (jnp.abs(ell) <= jnp.abs(log_a))
+                do_expand = jnp.abs(ell) < jnp.abs(log_b)  # too small a step
+                do_shrink = jnp.abs(ell) > jnp.abs(log_a)  # too large a step
             else:
-                term_expand = (v == 1) & (ell < log_b)
-                term_shrink = (v == -1) & (ell > log_a)
-            return j_next, n + 1, term_expand | term_shrink
+                do_expand = ell >= log_b
+                do_shrink = ell <= log_a
+            v_decided = jnp.where(do_expand, 1, jnp.where(do_shrink, -1, 0)).astype(
+                jnp.int32
+            )
+            v_next = jnp.where(is_deciding, v_decided, v)
+
+            if is_symmetric:
+                term_expand = (v_next == 1) & (jnp.abs(ell) >= jnp.abs(log_b))
+                term_shrink = (v_next == -1) & (jnp.abs(ell) <= jnp.abs(log_a))
+            else:
+                term_expand = (v_next == 1) & (ell < log_b)
+                term_shrink = (v_next == -1) & (ell > log_a)
+            # At the deciding iteration (n=0), "ell op threshold" can never
+            # also satisfy the opposite-direction termination test (the two
+            # are complementary comparisons of the same ell against the same
+            # threshold), so `term_expand | term_shrink` is always False
+            # there; termination at n=0 is instead exactly `v_decided == 0`.
+            terminated_search = term_expand | term_shrink
+            terminated_next = jnp.where(is_deciding, v_next == 0, terminated_search)
+
+            return trial_j, n + 1, terminated_next, v_next
 
         init_carry = (
             jnp.asarray(0, dtype=jnp.int32),
             jnp.asarray(0, dtype=jnp.int32),
-            v == 0,
+            jnp.asarray(False),
+            jnp.asarray(0, dtype=jnp.int32),
         )
-        j_final, _, terminated_final = jax.lax.while_loop(cond_fn, body_fn, init_carry)
-        search_exhausted = jnp.logical_not(terminated_final) & (v != 0)
+        j_final, _, terminated_final, v_final = jax.lax.while_loop(
+            cond_fn, body_fn, init_carry
+        )
+        search_exhausted = jnp.logical_not(terminated_final) & (v_final != 0)
         # "Final halving": on a successful *expansion*, report one step back
         # (section 2.1.2) -- necessary for the reversibility check to ever
         # pass in the doubling sub-case ([autoMALA] p.4).
-        step_index = jnp.where(terminated_final & (v == 1), j_final - 1, j_final)
+        step_index = jnp.where(terminated_final & (v_final == 1), j_final - 1, j_final)
         return step_index, search_exhausted
 
     return mu
@@ -268,8 +319,16 @@ def _apply_fn(
         proposal_state = build_trajectory(state, step_size, num_integration_steps)
         proposal_state = hmc.flip_momentum(proposal_state)
 
+        # Reuse this apply_fn's own trajectory builder for the reversibility
+        # re-check instead of letting the selector build (and re-wrap
+        # `logdensity_fn` in) another one -- see the comment in `mu`.
         reverse_step_index, search_exhausted_reverse = selector(
-            proposal_state, a, b, logdensity_fn, metric
+            proposal_state,
+            a,
+            b,
+            logdensity_fn,
+            metric,
+            build_trajectory=build_trajectory,
         )
         search_exhausted = search_exhausted_forward | search_exhausted_reverse
         is_reversible = reverse_step_index == step_index

--- a/blackjax/mcmc/gist_trajectory_length.py
+++ b/blackjax/mcmc/gist_trajectory_length.py
@@ -32,7 +32,7 @@ References
    Algorithm 2 (p.21), eq. 33 (the no-U-turn condition), eq. 34-35 (the step
    distributions).
 """
-from typing import Callable, NamedTuple
+from typing import Callable, NamedTuple, cast
 
 import jax
 import jax.numpy as jnp
@@ -275,7 +275,7 @@ def build_kernel(
         )
         apply_fn = _apply_fn(integrator, step_size, max_num_steps, path_fraction)
 
-        new_state, info, extra_info = gist._step(
+        new_state, info, raw_extra_info = gist._step(
             rng_key,
             state,
             logdensity_fn,
@@ -284,6 +284,10 @@ def build_kernel(
             inverse_mass_matrix,
             divergence_threshold,
         )
+        # `raw_extra_info` is declared as the generic `ArrayTree` in the
+        # general spine (opaque to it by design); cast back to the concrete
+        # type this kernel actually produces.
+        extra_info = cast(_TrajectoryLengthExtra, raw_extra_info)
         trajectory_length_info = GISTTrajectoryLengthInfo(
             info.momentum,
             info.tuning_parameter,
@@ -359,7 +363,9 @@ def as_top_level_api(
     -------
     A ``SamplingAlgorithm``.
     """
-    kernel = build_kernel(integrator, divergence_threshold, path_fraction, max_num_steps)
+    kernel = build_kernel(
+        integrator, divergence_threshold, path_fraction, max_num_steps
+    )
     return build_sampling_algorithm(
         kernel,
         init,

--- a/blackjax/mcmc/gist_trajectory_length.py
+++ b/blackjax/mcmc/gist_trajectory_length.py
@@ -116,9 +116,12 @@ def num_steps_to_uturn(
     The dot product uses the **metric-corrected velocity**
     ``M^{-1} rho`` (the gradient of the kinetic energy) rather than the raw
     momentum, so the criterion generalizes correctly to a non-identity
-    ``inverse_mass_matrix`` (diagonal / dense / low-rank) -- matching how
-    ``metrics.gaussian_euclidean``'s own ``check_turning`` generalizes the
-    analogous inner product for NUTS. This changes no formula for the
+    ``inverse_mass_matrix`` (diagonal / dense / low-rank). This is eq. 33's
+    position-displacement-times-velocity condition, a *different* turning
+    criterion from NUTS's momentum-sum ``check_turning`` -- the analogy to
+    ``metrics.gaussian_euclidean``'s ``check_turning`` is only in *how* it
+    substitutes ``M^{-1} rho`` for raw momentum in a dot product, not that
+    the two criteria coincide. This changes no formula for the
     identity-metric case the paper's own experiments use.
 
     ``max_num_steps`` is a hard cap, exactly analogous to NUTS's

--- a/blackjax/mcmc/gist_trajectory_length.py
+++ b/blackjax/mcmc/gist_trajectory_length.py
@@ -1,0 +1,368 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GIST instance (b): self-tuning trajectory length (no-U-turn, GIST paper
+section 5) -- NOT NUTS's recursive doubling.
+
+The tuning parameter is ``alpha = L``, the number of leapfrog steps at a
+*fixed* step size ``h``. ``L`` is drawn uniformly from ``[Lo(theta, rho) :
+U(theta, rho)]`` where ``U(theta, rho)`` is the number of leapfrog steps
+until the no-U-turn condition first fires (a single forward ``while_loop``
+rollout, materially simpler than NUTS's recursive-doubling tree, section
+2.2.2) and ``Lo`` shifts the lower end of that range by a fixed path
+fraction ``psi``. Because ``g = identity`` on ``L``, the reversibility of the
+resulting kernel is automatic (Corollary 4); the only thing the acceptance
+ratio has to account for is that the forward and reverse draws are uniform
+over *different-width* intervals containing the same ``L`` (section 2.2.4).
+
+References
+----------
+.. [1] Bou-Rabee, Carpenter, Marsden, "GIST: Gibbs self-tuning for locally
+   adaptive Hamiltonian Monte Carlo", arXiv:2404.15253, section 5 (p.20-25),
+   Algorithm 2 (p.21), eq. 33 (the no-U-turn condition), eq. 34-35 (the step
+   distributions).
+"""
+from typing import Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+
+import blackjax.mcmc.gist as gist
+import blackjax.mcmc.hmc as hmc
+import blackjax.mcmc.integrators as integrators
+import blackjax.mcmc.metrics as metrics
+import blackjax.mcmc.trajectory as trajectory
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.mcmc.integrators import IntegratorState
+from blackjax.types import Array, PRNGKey
+
+__all__ = [
+    "GISTTrajectoryLengthInfo",
+    "init",
+    "num_steps_to_uturn",
+    "build_kernel",
+    "as_top_level_api",
+]
+
+init = gist.init
+
+
+class _TrajectoryLengthExtra(NamedTuple):
+    """Extra info computed by ``apply_fn``, threaded into
+    :class:`GISTTrajectoryLengthInfo` without recomputation."""
+
+    num_integration_steps: Array
+    num_steps_to_uturn_forward: Array
+    num_steps_to_uturn_reverse: Array
+    is_no_return_rejected: Array
+
+
+class GISTTrajectoryLengthInfo(NamedTuple):
+    """Additional information for a ``gist_trajectory_length`` transition.
+
+    momentum, tuning_parameter, is_accepted, is_divergent, acceptance_rate,
+    energy, num_integration_steps
+        Same convention as :class:`~blackjax.mcmc.gist_step_size.GISTStepSizeInfo`
+        (flat extension, not nesting). ``tuning_parameter`` is ``L`` itself
+        (an integer, not a compound PyTree, since ``g = identity`` is the
+        only tuning-parameter component here).
+    num_steps_to_uturn_forward, num_steps_to_uturn_reverse
+        ``U(theta, rho) = M`` and ``U(theta', rho') = N``, section 2.2.2 --
+        the (possibly capped) leapfrog-step counts to the no-return
+        condition, forward from the current state and from the proposal.
+    is_no_return_rejected
+        True when ``L`` fell outside ``[Lo(theta', rho'), N]`` -- the
+        paper's own "no-return" rejection category (Fig. 5, section 2.2.4),
+        tracked separately from an ordinary energy-based Metropolis
+        rejection.
+    """
+
+    momentum: Array
+    tuning_parameter: Array
+    is_accepted: Array
+    is_divergent: Array
+    acceptance_rate: Array
+    energy: float
+    num_integration_steps: Array
+    num_steps_to_uturn_forward: Array
+    num_steps_to_uturn_reverse: Array
+    is_no_return_rejected: Array
+
+
+def num_steps_to_uturn(
+    integrator: Callable,
+    step_size: float,
+    metric: metrics.Metric,
+    max_num_steps: int,
+) -> Callable:
+    """Build the ``U(theta, rho)`` forward-rollout function, section 2.2.2.
+
+    A single forward ``while_loop``, one leapfrog step at a time, checking
+    the sign of the (metric-corrected) no-return condition after every step
+    -- no tree/doubling data structure, no recursion, no sub-U-turn
+    bookkeeping, unlike NUTS's ``1sub-U-turn`` criterion (section 3.5).
+
+    The dot product uses the **metric-corrected velocity**
+    ``M^{-1} rho`` (the gradient of the kinetic energy) rather than the raw
+    momentum, so the criterion generalizes correctly to a non-identity
+    ``inverse_mass_matrix`` (diagonal / dense / low-rank) -- matching how
+    ``metrics.gaussian_euclidean``'s own ``check_turning`` generalizes the
+    analogous inner product for NUTS. This changes no formula for the
+    identity-metric case the paper's own experiments use.
+
+    ``max_num_steps`` is a hard cap, exactly analogous to NUTS's
+    ``max_num_doublings`` (except here it bounds a *linear* rollout, not
+    ``2**max`` leapfrog steps). Capping is not an approximation: as long as
+    ``p(L|theta,rho)`` and the acceptance ratio consistently use this capped
+    ``U``, the resulting ``p(L|theta,rho)`` is still an exact, well-defined,
+    strictly-positive conditional density (the GIST reversibility guarantee,
+    Theorem 3, does not care that ``U`` is a capped version of the "true"
+    U-turn step count).
+
+    Parameters
+    ----------
+    integrator
+        Symplectic integrator used for the one-leapfrog-at-a-time rollout.
+    step_size
+        ``h``, the fixed step size (not GIST-adapted in this instance).
+    metric
+        The (already-resolved) :class:`~blackjax.mcmc.metrics.Metric`.
+    max_num_steps
+        Hard cap on the rollout length.
+
+    Returns
+    -------
+    ``uturn_fn(state: IntegratorState, logdensity_fn) -> Array``, the
+    (possibly capped) number of leapfrog steps to the no-return condition.
+    """
+    velocity_fn = jax.grad(metric.kinetic_energy)
+
+    def uturn_fn(state: IntegratorState, logdensity_fn: Callable) -> Array:
+        symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
+        theta0, _ = ravel_pytree(state.position)
+
+        def cond_fn(carry):
+            n, _, no_return = carry
+            return jnp.logical_not(no_return) & (n < max_num_steps)
+
+        def body_fn(carry):
+            n, current, _ = carry
+            nxt = symplectic_integrator(current, step_size)
+            delta = ravel_pytree(nxt.position)[0] - theta0
+            velocity, _ = ravel_pytree(velocity_fn(nxt.momentum, nxt.position))
+            no_return = jnp.dot(delta, velocity) < 0.0
+            return n + 1, nxt, no_return
+
+        n_final, _, _ = jax.lax.while_loop(
+            cond_fn, body_fn, (jnp.asarray(0), state, jnp.asarray(False))
+        )
+        return n_final
+
+    return uturn_fn
+
+
+def _step_distribution(num_steps_to_uturn_value: Array, path_fraction: float):
+    """``Lo(theta,rho)`` and ``W(theta,rho)``, section 2.2.3 (eq. 34-35)."""
+    lo = jnp.maximum(
+        1, jnp.floor(path_fraction * num_steps_to_uturn_value).astype(jnp.int32)
+    )
+    width = num_steps_to_uturn_value - lo + 1
+    return lo, width
+
+
+def _tuning_parameter_fn(
+    integrator: Callable, step_size: float, max_num_steps: int, path_fraction: float
+) -> Callable:
+    def tuning_parameter_fn(rng_key, state, logdensity_fn, metric):
+        uturn_fn = num_steps_to_uturn(integrator, step_size, metric, max_num_steps)
+        forward = uturn_fn(state, logdensity_fn)
+        lo, _ = _step_distribution(forward, path_fraction)
+        num_steps = jax.random.randint(rng_key, shape=(), minval=lo, maxval=forward + 1)
+        return num_steps, forward
+
+    return tuning_parameter_fn
+
+
+def _apply_fn(
+    integrator: Callable, step_size: float, max_num_steps: int, path_fraction: float
+) -> Callable:
+    def apply_fn(state, alpha, aux, logdensity_fn, metric):
+        num_steps = alpha
+        forward = aux
+
+        symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
+        build_trajectory = trajectory.static_integration(symplectic_integrator)
+        proposal_state = build_trajectory(state, step_size, num_steps)
+        proposal_state = hmc.flip_momentum(proposal_state)
+
+        uturn_fn = num_steps_to_uturn(integrator, step_size, metric, max_num_steps)
+        reverse = uturn_fn(proposal_state, logdensity_fn)
+
+        _, width_forward = _step_distribution(forward, path_fraction)
+        lo_reverse, width_reverse = _step_distribution(reverse, path_fraction)
+
+        is_in_reverse_interval = (num_steps >= lo_reverse) & (num_steps <= reverse)
+        log_tuning_density_ratio = jnp.where(
+            is_in_reverse_interval,
+            jnp.log(width_forward.astype(jnp.float32))
+            - jnp.log(width_reverse.astype(jnp.float32)),
+            -jnp.inf,
+        )
+        extra_info = _TrajectoryLengthExtra(
+            num_integration_steps=num_steps,
+            num_steps_to_uturn_forward=forward,
+            num_steps_to_uturn_reverse=reverse,
+            is_no_return_rejected=jnp.logical_not(is_in_reverse_interval),
+        )
+        return proposal_state, log_tuning_density_ratio, extra_info
+
+    return apply_fn
+
+
+def build_kernel(
+    integrator: Callable = integrators.velocity_verlet,
+    divergence_threshold: float = 1000,
+    path_fraction: float = 0.5,
+    max_num_steps: int = 1024,
+) -> Callable:
+    """Build a ``gist_trajectory_length`` kernel.
+
+    Parameters
+    ----------
+    integrator
+        The symplectic integrator to use to integrate the Hamiltonian
+        dynamics.
+    divergence_threshold
+        Value of the difference in energy above which we consider that the
+        transition is divergent.
+    path_fraction
+        ``psi`` in ``[0, 1]``, section 2.2.3. Default 0.5 per the paper's
+        own recommendation (comparable leapfrog-step counts to NUTS;
+        ``psi=0`` is the simpler eq. 34 special case).
+    max_num_steps
+        Hard cap on each U-turn rollout (forward and reverse); analogous to
+        NUTS's ``max_num_doublings``, but bounds a *linear* rollout here,
+        not ``2**max`` leapfrog steps.
+
+    Returns
+    -------
+    A kernel that takes a rng_key and a Pytree that contains the current
+    state of the chain and that returns a new state of the chain along with
+    information about the transition.
+    """
+
+    def kernel(
+        rng_key: PRNGKey,
+        state: gist.GISTState,
+        logdensity_fn: Callable,
+        step_size: float,
+        inverse_mass_matrix: metrics.MetricTypes,
+    ) -> tuple[gist.GISTState, GISTTrajectoryLengthInfo]:
+        """Generate a new sample with the ``gist_trajectory_length`` kernel."""
+        tuning_parameter_fn = _tuning_parameter_fn(
+            integrator, step_size, max_num_steps, path_fraction
+        )
+        apply_fn = _apply_fn(integrator, step_size, max_num_steps, path_fraction)
+
+        new_state, info, extra_info = gist._step(
+            rng_key,
+            state,
+            logdensity_fn,
+            tuning_parameter_fn,
+            apply_fn,
+            inverse_mass_matrix,
+            divergence_threshold,
+        )
+        trajectory_length_info = GISTTrajectoryLengthInfo(
+            info.momentum,
+            info.tuning_parameter,
+            info.is_accepted,
+            info.is_divergent,
+            info.acceptance_rate,
+            info.energy,
+            info.num_integration_steps,
+            extra_info.num_steps_to_uturn_forward,
+            extra_info.num_steps_to_uturn_reverse,
+            extra_info.is_no_return_rejected,
+        )
+        return new_state, trajectory_length_info
+
+    return kernel
+
+
+def as_top_level_api(
+    logdensity_fn: Callable,
+    inverse_mass_matrix: metrics.MetricTypes,
+    step_size: float,
+    *,
+    path_fraction: float = 0.5,
+    max_num_steps: int = 1024,
+    divergence_threshold: float = 1000,
+    integrator: Callable = integrators.velocity_verlet,
+) -> SamplingAlgorithm:
+    """``blackjax.gist_trajectory_length`` -- GIST self-tuning path length
+    (no-U-turn condition, section 2.2; NOT NUTS's recursive doubling).
+
+    Examples
+    --------
+
+    A new ``gist_trajectory_length`` kernel can be initialized and used with
+    the following code:
+
+    .. code::
+
+        gist_trajectory_length = blackjax.gist_trajectory_length(
+            logdensity_fn, inverse_mass_matrix, step_size=0.1
+        )
+        state = gist_trajectory_length.init(position)
+        new_state, info = gist_trajectory_length.step(rng_key, state)
+
+    Parameters
+    ----------
+    logdensity_fn
+        The log-density function we wish to draw samples from.
+    inverse_mass_matrix
+        The value to use for the inverse mass matrix when drawing a value
+        for the momentum and computing the kinetic energy.
+    step_size
+        ``h``, fixed (not GIST-adapted in this instance; see the module
+        docstring for composing with ``gist_step_size``).
+    path_fraction
+        ``psi`` in ``[0, 1]``, section 2.2.3. Default 0.5 per the paper's
+        own recommendation (comparable leapfrog-step counts to NUTS;
+        ``psi=0`` is the simpler eq. 34 special case).
+    max_num_steps
+        Hard cap on each U-turn rollout (forward and reverse); analogous to
+        NUTS's ``max_num_doublings``, but bounds a *linear* rollout here,
+        not ``2**max`` leapfrog steps -- size accordingly (NUTS's default of
+        10 doublings caps at 1023 steps; a directly-comparable cap here is
+        ``max_num_steps ~= 1024``).
+    divergence_threshold
+        The absolute value of the difference in energy between two states
+        above which we say that the transition is divergent.
+    integrator
+        (algorithm parameter) The symplectic integrator to use to integrate
+        the trajectory.
+
+    Returns
+    -------
+    A ``SamplingAlgorithm``.
+    """
+    kernel = build_kernel(integrator, divergence_threshold, path_fraction, max_num_steps)
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        logdensity_fn,
+        kernel_args=(step_size, inverse_mass_matrix),
+    )

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -75,3 +75,48 @@ def std_normal_logdensity(x, scale=1.0):
         return -0.5 / (scale**2) * sum(jnp.sum(leaf**2) for leaf in leaves)
     flat_x, _ = ravel_pytree(x)
     return -0.5 * jnp.sum((flat_x / scale) ** 2)
+
+
+def neal_funnel_logdensity(x):
+    """Neal's funnel (unnormalised): the canonical stress test for
+    per-location step-size adaptation.
+
+    ``x[0]`` is the "neck" variable ``y ~ N(0, 3**2)``; ``x[1:]`` are
+    ``N(0, exp(y))`` i.i.d. given ``y``. A single global step size cannot
+    work well here: the conditional scale of ``x[1:]`` ranges over
+    ``exp(y / 2)`` as ``y`` sweeps its prior, from tiny near the neck
+    (``y`` very negative) to huge in the mouth (``y`` very positive).
+
+    Works with any array position of length >= 2 (one neck coordinate plus
+    at least one funnel coordinate).
+    """
+    y = x[0]
+    v = x[1:]
+    logdensity_y = -0.5 * (y / 3.0) ** 2
+    logdensity_v = -0.5 * jnp.exp(-y) * jnp.sum(v**2) - 0.5 * v.shape[0] * y
+    return logdensity_y + logdensity_v
+
+
+def smooth_skewed_logdensity(x):
+    """A smooth, gradient-friendly asymmetric target: ``y = log(u)`` for
+    ``u ~ Exponential(1)``, i.e. ``-y ~ Gumbel(0, 1)``.
+
+    Unnormalised log density ``y - exp(y)``, defined and differentiable on
+    all of ``R`` (gradient ``1 - exp(y)``, never zero/degenerate). A
+    symmetric Gaussian target cannot detect a reversed-direction/sign bug in
+    a leapfrog+flip or a forward-vs-reverse rollout, but an asymmetric one
+    can (mirrors ``test_slice.py::test_multivariate_skewed_exponential``'s
+    rationale) -- **without** the raw ``jnp.where(x > 0, ..., -inf)``
+    representation of ``Exponential`` directly, whose *zero* gradient
+    outside the support lets a leapfrog trajectory that crosses the
+    boundary drift forever under a purely linear potential (no restoring
+    force once ``logdensity_grad`` clamps to 0) -- pathologically
+    degenerate for a gradient-based (HMC-family) sampler, even though it is
+    perfectly fine for a density-evaluation-only sampler like slice
+    sampling.
+
+    Closed-form moments (per-coordinate, i.i.d.): mean ``-gamma`` (negative
+    Euler-Mascheroni, approx -0.5772), variance ``pi**2 / 6`` (approx
+    1.6449), skewness approx -1.1395 (left-skewed).
+    """
+    return jnp.sum(x - jnp.exp(x))

--- a/tests/mcmc/test_gist_step_size.py
+++ b/tests/mcmc/test_gist_step_size.py
@@ -1,4 +1,12 @@
-"""Tests for the GIST self-tuning step-size sampler (autoStep-style)."""
+"""Tests for the GIST self-tuning step-size sampler (autoStep-style).
+
+CI note: run with ``--benchmark-disable`` when parallelizing under xdist
+(e.g. ``-n 2``) -- a bare ``-n 2`` run hits an ``INTERNALERROR`` from
+pytest-benchmark x xdist under this project's ``filterwarnings = error``
+(the same masking-bug family as the probdiffeq migration saga). Not a code
+issue in this module; the documented blackjax test command already
+includes ``--benchmark-disable``.
+"""
 import chex
 import jax
 import jax.numpy as jnp
@@ -62,7 +70,9 @@ class SingleStepTest(chex.TestCase):
 
     def test_jit(self):
         algo = blackjax.gist_step_size(
-            std_normal_logdensity, inverse_mass_matrix=jnp.ones(3), initial_step_size=0.3
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(3),
+            initial_step_size=0.3,
         )
         state = algo.init(jnp.zeros(3))
         new_state, _ = jax.jit(algo.step)(jax.random.key(0), state)
@@ -142,15 +152,15 @@ class StationarityTest(BlackJAXTest):
         chex.assert_trees_all_close(
             jnp.mean(samples, axis=0), jnp.zeros((d,)), atol=0.15, rtol=0.15
         )
-        chex.assert_trees_all_close(
-            jnp.cov(samples.T), jnp.eye(d), atol=0.2, rtol=0.2
-        )
+        chex.assert_trees_all_close(jnp.cov(samples.T), jnp.eye(d), atol=0.2, rtol=0.2)
 
 
 class MomentRecoveryTest(BlackJAXTest):
     def test_isotropic_std_normal(self):
         algo = blackjax.gist_step_size(
-            std_normal_logdensity, inverse_mass_matrix=jnp.ones(3), initial_step_size=0.8
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(3),
+            initial_step_size=0.8,
         )
         pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 6000)
         s = np.asarray(pos[3000:])
@@ -163,7 +173,9 @@ class MomentRecoveryTest(BlackJAXTest):
         Sigma = jnp.array([[2.0, 1.2], [1.2, 1.0]])
         Sinv = jnp.linalg.inv(Sigma)
         logp = lambda x: -0.5 * x @ Sinv @ x
-        algo = blackjax.gist_step_size(logp, inverse_mass_matrix=Sigma, initial_step_size=0.5)
+        algo = blackjax.gist_step_size(
+            logp, inverse_mass_matrix=Sigma, initial_step_size=0.5
+        )
         pos, _ = run_chain(algo, jnp.zeros(2), self.next_key(), 8000)
         emp = np.cov(np.asarray(pos[4000:]), rowvar=False)
         np.testing.assert_allclose(emp, np.asarray(Sigma), atol=0.5)
@@ -178,14 +190,23 @@ class MomentRecoveryTest(BlackJAXTest):
         # Exponential representation is a poor fit for a gradient-based
         # sampler).
         algo = blackjax.gist_step_size(
-            smooth_skewed_logdensity, inverse_mass_matrix=jnp.ones(2), initial_step_size=0.4
+            smooth_skewed_logdensity,
+            inverse_mass_matrix=jnp.ones(2),
+            initial_step_size=0.4,
         )
         pos, infos = run_chain(algo, jnp.zeros(2), self.next_key(), 8000)
         s = np.asarray(pos[4000:])
+        # The mean/std bounds are the actual reversed-direction/sign-bug
+        # detector here (confirmed empirically against a planted direction
+        # bug in review: a broken rollout inflates std well outside this
+        # band, well before the skew sign would flip). The skew check below
+        # is a secondary correctness check, tightened to a band around the
+        # closed-form truth (-1.1395) rather than a bare sign check, so it
+        # earns its own assertion.
         np.testing.assert_allclose(s.mean(axis=0), -0.5772, atol=0.2)
         np.testing.assert_allclose(s.std(axis=0), 1.2825, rtol=0.2)
         skew = np.mean(((s - s.mean(0)) / s.std(0)) ** 3, axis=0)
-        self.assertTrue((skew < 0.0).all())  # left-skewed, not mirrored
+        np.testing.assert_allclose(skew, -1.1395, atol=0.9)
 
     def test_neal_funnel_neck_marginal(self):
         # The canonical stress test for step-size adaptation (a single
@@ -233,7 +254,11 @@ class SelectorUnitTest(BlackJAXTest):
             state.logdensity_grad,
         )
         step_index, search_exhausted = selector(
-            integrator_state, jnp.array(0.4), jnp.array(0.6), std_normal_logdensity, metric
+            integrator_state,
+            jnp.array(0.4),
+            jnp.array(0.6),
+            std_normal_logdensity,
+            metric,
         )
         self.assertFalse(bool(search_exhausted))
         self.assertGreater(int(step_index), 0)  # expanded away from the tiny step
@@ -257,7 +282,11 @@ class SelectorUnitTest(BlackJAXTest):
             state.logdensity_grad,
         )
         _, search_exhausted = selector(
-            integrator_state, jnp.array(0.3), jnp.array(0.7), std_normal_logdensity, metric
+            integrator_state,
+            jnp.array(0.3),
+            jnp.array(0.7),
+            std_normal_logdensity,
+            metric,
         )
         self.assertTrue(bool(search_exhausted))
 
@@ -293,7 +322,10 @@ class EdgeCaseTest(BlackJAXTest):
         # reciprocal-sqrt derivative formula itself inherits the NaN.
         logp = lambda x: -jnp.sum(jnp.sqrt(x))
         algo = blackjax.gist_step_size(
-            logp, inverse_mass_matrix=jnp.ones(2), initial_step_size=2.0, max_search_steps=5
+            logp,
+            inverse_mass_matrix=jnp.ones(2),
+            initial_step_size=2.0,
+            max_search_steps=5,
         )
         pos, infos = run_chain(algo, jnp.array([1.0, 1.0]), self.next_key(), 500)
         self.assertTrue(np.all(np.isfinite(np.asarray(pos))))

--- a/tests/mcmc/test_gist_step_size.py
+++ b/tests/mcmc/test_gist_step_size.py
@@ -1,0 +1,335 @@
+"""Tests for the GIST self-tuning step-size sampler (autoStep-style)."""
+import chex
+import jax
+import jax.numpy as jnp
+import jax.scipy.stats as st
+import numpy as np
+from absl.testing import absltest, parameterized
+
+import blackjax
+from blackjax.mcmc import gist, gist_step_size, integrators, metrics
+from tests.fixtures import (
+    BlackJAXTest,
+    neal_funnel_logdensity,
+    smooth_skewed_logdensity,
+    std_normal_logdensity,
+)
+
+CRITERIA = ["symmetric", "asymmetric"]
+
+
+def run_chain(algo, position, key, n):
+    state = algo.init(position)
+
+    def body(s, k):
+        s, info = algo.step(k, s)
+        return s, (s.position, info)
+
+    _, (positions, infos) = jax.lax.scan(body, state, jax.random.split(key, n))
+    return positions, infos
+
+
+class InitTest(chex.TestCase):
+    def test_init_stores_position_and_gradients(self):
+        position = jnp.array([1.0, 2.0])
+        state = gist_step_size.init(position, std_normal_logdensity)
+        self.assertIsInstance(state, gist.GISTState)
+        np.testing.assert_allclose(state.position, position)
+        np.testing.assert_allclose(
+            float(state.logdensity), float(std_normal_logdensity(position))
+        )
+
+
+class SingleStepTest(chex.TestCase):
+    @parameterized.parameters(*CRITERIA)
+    def test_step_shapes_and_types(self, criterion):
+        algo = blackjax.gist_step_size(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(3),
+            initial_step_size=0.5,
+            criterion=criterion,
+        )
+        state = algo.init(jnp.zeros(3))
+        new_state, info = algo.step(jax.random.key(0), state)
+        self.assertIsInstance(new_state, gist.GISTState)
+        self.assertIsInstance(info, gist_step_size.GISTStepSizeInfo)
+        self.assertEqual(new_state.position.shape, (3,))
+        np.testing.assert_allclose(
+            float(new_state.logdensity),
+            float(std_normal_logdensity(new_state.position)),
+            atol=1e-5,
+        )
+
+    def test_jit(self):
+        algo = blackjax.gist_step_size(
+            std_normal_logdensity, inverse_mass_matrix=jnp.ones(3), initial_step_size=0.3
+        )
+        state = algo.init(jnp.zeros(3))
+        new_state, _ = jax.jit(algo.step)(jax.random.key(0), state)
+        self.assertEqual(new_state.position.shape, (3,))
+
+    def test_invalid_criterion_raises(self):
+        with self.assertRaises(ValueError):
+            gist_step_size.build_kernel(criterion="not-a-criterion")
+
+
+class CompilationTest(chex.TestCase):
+    def test_no_excess_retracing(self):
+        """The logdensity should compile at most 4 times: init, plus 3 within
+        one kernel trace -- the forward selector search, the accepted-move
+        trajectory, and the reverse-selector re-check (section 2.1.3) each
+        need their own gradient evaluation, unlike hmc/nuts's single forward
+        trajectory (n=2 there). Verified empirically: the count stabilizes
+        at 4 after the first `step()` call and does not grow on further
+        calls with the same shapes (no spurious per-call retracing).
+        """
+
+        @chex.assert_max_traces(n=4)
+        def logdensity_fn(x):
+            return jnp.sum(st.norm.logpdf(x))
+
+        chex.clear_trace_counter()
+
+        algo = blackjax.gist_step_size(
+            logdensity_fn, inverse_mass_matrix=jnp.ones(2), initial_step_size=0.3
+        )
+        state = algo.init(jnp.zeros(2))
+        step = jax.jit(algo.step)
+
+        rng_key = jax.random.key(0)
+        for i in range(5):
+            sample_key = jax.random.fold_in(rng_key, i)
+            state, _ = step(sample_key, state)
+
+
+class StationarityTest(BlackJAXTest):
+    """If the population starts exactly at stationarity, it should stay there.
+
+    Modeled on ``tests/mcmc/test_barker.py::test_invariance``: a cheaper,
+    directly automatable proxy for reversibility than a literal pairwise
+    detailed-balance check. This is exactly the test to catch a bug in the
+    ``j' = j`` reversibility-check reconciliation (section 2.1.3) -- such a
+    bug would show up as population drift even from an exact stationary
+    start.
+    """
+
+    @parameterized.parameters(*CRITERIA)
+    def test_stationarity_from_exact_draws(self, criterion):
+        d = 2
+        n_samples, m_steps = 2000, 20
+
+        algo = blackjax.gist_step_size(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(d),
+            initial_step_size=0.7,
+            criterion=criterion,
+        )
+
+        init_key, inference_key = jax.random.split(self.next_key())
+        init_samples = jax.random.normal(init_key, shape=(n_samples, d))
+        inference_keys = jax.random.split(inference_key, n_samples)
+
+        def loop(state, key_):
+            state, _ = algo.step(key_, state)
+            return state, None
+
+        def get_samples(init_sample, key_):
+            state = algo.init(init_sample)
+            out, _ = jax.lax.scan(loop, state, jax.random.split(key_, m_steps))
+            return out.position
+
+        samples = jax.vmap(get_samples)(init_samples, inference_keys)
+        chex.assert_trees_all_close(
+            jnp.mean(samples, axis=0), jnp.zeros((d,)), atol=0.15, rtol=0.15
+        )
+        chex.assert_trees_all_close(
+            jnp.cov(samples.T), jnp.eye(d), atol=0.2, rtol=0.2
+        )
+
+
+class MomentRecoveryTest(BlackJAXTest):
+    def test_isotropic_std_normal(self):
+        algo = blackjax.gist_step_size(
+            std_normal_logdensity, inverse_mass_matrix=jnp.ones(3), initial_step_size=0.8
+        )
+        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 6000)
+        s = np.asarray(pos[3000:])
+        np.testing.assert_allclose(s.mean(), 0.0, atol=0.12)
+        np.testing.assert_allclose(s.std(), 1.0, rtol=0.15)
+        self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
+
+    def test_correlated_gaussian_dense_metric(self):
+        # Exercises a non-identity (dense) inverse_mass_matrix.
+        Sigma = jnp.array([[2.0, 1.2], [1.2, 1.0]])
+        Sinv = jnp.linalg.inv(Sigma)
+        logp = lambda x: -0.5 * x @ Sinv @ x
+        algo = blackjax.gist_step_size(logp, inverse_mass_matrix=Sigma, initial_step_size=0.5)
+        pos, _ = run_chain(algo, jnp.zeros(2), self.next_key(), 8000)
+        emp = np.cov(np.asarray(pos[4000:]), rowvar=False)
+        np.testing.assert_allclose(emp, np.asarray(Sigma), atol=0.5)
+
+    def test_smooth_skewed_target(self):
+        # Asymmetric target: a symmetric Gaussian cannot detect a
+        # reversed-direction/sign bug in the leapfrog+flip, but a skewed
+        # target can (mirrors test_slice.py's
+        # test_multivariate_skewed_exponential rationale, but with a smooth
+        # log-space target -- see
+        # tests/fixtures.py::smooth_skewed_logdensity for why the raw
+        # Exponential representation is a poor fit for a gradient-based
+        # sampler).
+        algo = blackjax.gist_step_size(
+            smooth_skewed_logdensity, inverse_mass_matrix=jnp.ones(2), initial_step_size=0.4
+        )
+        pos, infos = run_chain(algo, jnp.zeros(2), self.next_key(), 8000)
+        s = np.asarray(pos[4000:])
+        np.testing.assert_allclose(s.mean(axis=0), -0.5772, atol=0.2)
+        np.testing.assert_allclose(s.std(axis=0), 1.2825, rtol=0.2)
+        skew = np.mean(((s - s.mean(0)) / s.std(0)) ** 3, axis=0)
+        self.assertTrue((skew < 0.0).all())  # left-skewed, not mirrored
+
+    def test_neal_funnel_neck_marginal(self):
+        # The canonical stress test for step-size adaptation (a single
+        # global step size cannot work). Check only the well-behaved "neck"
+        # marginal y ~ N(0, 3**2) exactly -- the funnel coordinates' marginal
+        # variance is a log-normal mixture (heavy-tailed, high MC variance),
+        # not a useful numeric target at feasible sample sizes.
+        algo = blackjax.gist_step_size(
+            neal_funnel_logdensity,
+            inverse_mass_matrix=jnp.ones(3),
+            initial_step_size=0.3,
+            max_search_steps=20,
+        )
+        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 6000)
+        y = np.asarray(pos[3000:, 0])
+        np.testing.assert_allclose(y.mean(), 0.0, atol=0.6)
+        np.testing.assert_allclose(y.std(), 3.0, rtol=0.35)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        # Regression guard: the symmetric default must not silently degrade
+        # to near-zero acceptance the way the asymmetric criterion can
+        # ([AutoStep] Fig. 1).
+        self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
+
+
+class SelectorUnitTest(BlackJAXTest):
+    """Direct tests of ``step_size_selector``'s mu function, section 2.1.2."""
+
+    def test_final_halving_on_successful_expansion(self):
+        # A tiny initial_step_size on a std normal, with wide (a, b), should
+        # trigger v=+1 (expand) and terminate normally; the "final halving"
+        # means the reported step_index is one less than the index at which
+        # the loop actually detected termination.
+        selector = gist_step_size.step_size_selector(
+            integrators.velocity_verlet,
+            num_integration_steps=1,
+            initial_step_size=1e-4,
+            max_search_steps=30,
+        )
+        state = gist.init(jnp.zeros(2), std_normal_logdensity)
+        metric = metrics.default_metric(jnp.ones(2))
+        integrator_state = integrators.IntegratorState(
+            state.position,
+            jnp.ones(2),
+            state.logdensity,
+            state.logdensity_grad,
+        )
+        step_index, search_exhausted = selector(
+            integrator_state, jnp.array(0.4), jnp.array(0.6), std_normal_logdensity, metric
+        )
+        self.assertFalse(bool(search_exhausted))
+        self.assertGreater(int(step_index), 0)  # expanded away from the tiny step
+
+    def test_search_exhausted_on_zero_budget(self):
+        # An absurdly large initial_step_size forces v=-1 (shrink) for
+        # virtually any (a, b) in (0, 1); with max_search_steps=0 the search
+        # cannot even take one step, so it must report search_exhausted.
+        selector = gist_step_size.step_size_selector(
+            integrators.velocity_verlet,
+            num_integration_steps=1,
+            initial_step_size=1e8,
+            max_search_steps=0,
+        )
+        state = gist.init(jnp.zeros(2), std_normal_logdensity)
+        metric = metrics.default_metric(jnp.ones(2))
+        integrator_state = integrators.IntegratorState(
+            state.position,
+            jnp.ones(2),
+            state.logdensity,
+            state.logdensity_grad,
+        )
+        _, search_exhausted = selector(
+            integrator_state, jnp.array(0.3), jnp.array(0.7), std_normal_logdensity, metric
+        )
+        self.assertTrue(bool(search_exhausted))
+
+
+class EdgeCaseTest(BlackJAXTest):
+    def test_search_exhausted_forces_rejection(self):
+        algo = blackjax.gist_step_size(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(2),
+            initial_step_size=1e8,  # forces v=-1 for virtually any (a, b)
+            max_search_steps=0,
+        )
+        state = algo.init(jnp.zeros(2))
+        new_state, info = jax.jit(algo.step)(self.next_key(), state)
+        self.assertTrue(bool(info.search_exhausted))
+        self.assertFalse(bool(info.is_accepted))
+        np.testing.assert_allclose(new_state.position, state.position)
+
+    def test_hard_constraint_boundary_no_crash(self):
+        # Half-normal: logdensity_fn = -inf outside x > 0. A large step size
+        # naturally crosses the boundary; the transition must reject cleanly
+        # (Delta_energy = +inf) rather than crash or return NaNs.
+        logp = lambda x: jnp.where(x[0] > 0, -0.5 * jnp.sum(x**2), -jnp.inf)
+        algo = blackjax.gist_step_size(
+            logp, inverse_mass_matrix=jnp.ones(2), initial_step_size=3.0
+        )
+        pos, infos = run_chain(algo, jnp.array([0.5, 0.5]), self.next_key(), 500)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        self.assertTrue(np.all(np.asarray(pos[:, 0]) > 0))
+
+    def test_nan_gradient_region_no_crash(self):
+        # sqrt has a NaN *gradient* (not just a NaN value) for x < 0: the
+        # reciprocal-sqrt derivative formula itself inherits the NaN.
+        logp = lambda x: -jnp.sum(jnp.sqrt(x))
+        algo = blackjax.gist_step_size(
+            logp, inverse_mass_matrix=jnp.ones(2), initial_step_size=2.0, max_search_steps=5
+        )
+        pos, infos = run_chain(algo, jnp.array([1.0, 1.0]), self.next_key(), 500)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+
+    def test_reversibility_check_failure_forces_rejection(self):
+        # Direct unit test of _apply_fn with a mock selector that
+        # deliberately disagrees between the forward and reverse call, so
+        # that j' != j regardless of the energy term. Use a tiny step size
+        # so the *energy* term alone would almost certainly accept.
+        initial_position = jnp.zeros(2)
+        state = gist.init(initial_position, std_normal_logdensity)
+        metric = metrics.default_metric(jnp.ones(2))
+        integrator_state = integrators.IntegratorState(
+            state.position, jnp.ones(2), state.logdensity, state.logdensity_grad
+        )
+
+        def mock_selector(s, a, b, logdensity_fn, metric, *, build_trajectory=None):
+            del build_trajectory
+            is_initial = jnp.allclose(s.position, initial_position)
+            return jnp.where(is_initial, 0, 5), jnp.asarray(False)
+
+        apply_fn = gist_step_size._apply_fn(
+            integrators.velocity_verlet,
+            num_integration_steps=1,
+            initial_step_size=1e-6,  # tiny: energy term alone would accept
+            selector=mock_selector,
+        )
+        alpha = gist_step_size.StepSizeTuningParameter(
+            jnp.array(0.3), jnp.array(0.7), jnp.array(0)
+        )
+        _, log_tuning_density_ratio, extra_info = apply_fn(
+            integrator_state, alpha, jnp.asarray(False), std_normal_logdensity, metric
+        )
+        self.assertEqual(float(log_tuning_density_ratio), float("-inf"))
+        self.assertEqual(int(extra_info.reverse_step_index), 5)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -1,0 +1,354 @@
+"""Tests for the GIST self-tuning trajectory-length sampler (no-U-turn,
+NOT NUTS's recursive doubling)."""
+import chex
+import jax
+import jax.numpy as jnp
+import jax.scipy.stats as st
+import numpy as np
+from absl.testing import absltest, parameterized
+
+import blackjax
+from blackjax.mcmc import gist, gist_trajectory_length, integrators, metrics
+from tests.fixtures import (
+    BlackJAXTest,
+    neal_funnel_logdensity,
+    smooth_skewed_logdensity,
+    std_normal_logdensity,
+)
+
+
+def run_chain(algo, position, key, n):
+    state = algo.init(position)
+
+    def body(s, k):
+        s, info = algo.step(k, s)
+        return s, (s.position, info)
+
+    _, (positions, infos) = jax.lax.scan(body, state, jax.random.split(key, n))
+    return positions, infos
+
+
+class InitTest(chex.TestCase):
+    def test_init_stores_position_and_gradients(self):
+        position = jnp.array([1.0, 2.0])
+        state = gist_trajectory_length.init(position, std_normal_logdensity)
+        self.assertIsInstance(state, gist.GISTState)
+        np.testing.assert_allclose(state.position, position)
+        np.testing.assert_allclose(
+            float(state.logdensity), float(std_normal_logdensity(position))
+        )
+
+
+class SingleStepTest(chex.TestCase):
+    @parameterized.parameters(0.0, 0.5)
+    def test_step_shapes_and_types(self, path_fraction):
+        algo = blackjax.gist_trajectory_length(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(3),
+            step_size=0.3,
+            path_fraction=path_fraction,
+        )
+        state = algo.init(jnp.zeros(3))
+        new_state, info = algo.step(jax.random.key(0), state)
+        self.assertIsInstance(new_state, gist.GISTState)
+        self.assertIsInstance(info, gist_trajectory_length.GISTTrajectoryLengthInfo)
+        self.assertEqual(new_state.position.shape, (3,))
+        np.testing.assert_allclose(
+            float(new_state.logdensity),
+            float(std_normal_logdensity(new_state.position)),
+            atol=1e-5,
+        )
+
+    def test_jit(self):
+        algo = blackjax.gist_trajectory_length(
+            std_normal_logdensity, inverse_mass_matrix=jnp.ones(3), step_size=0.2
+        )
+        state = algo.init(jnp.zeros(3))
+        new_state, _ = jax.jit(algo.step)(jax.random.key(0), state)
+        self.assertEqual(new_state.position.shape, (3,))
+
+
+class CompilationTest(chex.TestCase):
+    def test_no_excess_retracing(self):
+        """The logdensity should compile at most 4 times: init, plus 3
+        within one kernel trace -- the forward U-turn rollout, the accepted
+        trajectory build, and the reverse U-turn rollout (section 2.2.4)
+        each need their own gradient evaluation, unlike hmc/nuts's single
+        forward trajectory (n=2 there). Verified empirically: the count
+        stabilizes at 4 after the first `step()` call and does not grow on
+        further calls with the same shapes.
+        """
+
+        @chex.assert_max_traces(n=4)
+        def logdensity_fn(x):
+            return jnp.sum(st.norm.logpdf(x))
+
+        chex.clear_trace_counter()
+
+        algo = blackjax.gist_trajectory_length(
+            logdensity_fn, inverse_mass_matrix=jnp.ones(2), step_size=0.3
+        )
+        state = algo.init(jnp.zeros(2))
+        step = jax.jit(algo.step)
+
+        rng_key = jax.random.key(0)
+        for i in range(5):
+            sample_key = jax.random.fold_in(rng_key, i)
+            state, _ = step(sample_key, state)
+
+
+class StationarityTest(BlackJAXTest):
+    """If the population starts exactly at stationarity, it should stay
+    there (modeled on ``tests/mcmc/test_barker.py::test_invariance``)."""
+
+    @parameterized.parameters(0.0, 0.5)
+    def test_stationarity_from_exact_draws(self, path_fraction):
+        d = 2
+        n_samples, m_steps = 1500, 15
+
+        algo = blackjax.gist_trajectory_length(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(d),
+            step_size=0.5,
+            path_fraction=path_fraction,
+            max_num_steps=64,
+        )
+
+        init_key, inference_key = jax.random.split(self.next_key())
+        init_samples = jax.random.normal(init_key, shape=(n_samples, d))
+        inference_keys = jax.random.split(inference_key, n_samples)
+
+        def loop(state, key_):
+            state, _ = algo.step(key_, state)
+            return state, None
+
+        def get_samples(init_sample, key_):
+            state = algo.init(init_sample)
+            out, _ = jax.lax.scan(loop, state, jax.random.split(key_, m_steps))
+            return out.position
+
+        samples = jax.vmap(get_samples)(init_samples, inference_keys)
+        chex.assert_trees_all_close(
+            jnp.mean(samples, axis=0), jnp.zeros((d,)), atol=0.15, rtol=0.15
+        )
+        chex.assert_trees_all_close(jnp.cov(samples.T), jnp.eye(d), atol=0.2, rtol=0.2)
+
+
+class MomentRecoveryTest(BlackJAXTest):
+    def test_isotropic_std_normal(self):
+        algo = blackjax.gist_trajectory_length(
+            std_normal_logdensity, inverse_mass_matrix=jnp.ones(3), step_size=0.4
+        )
+        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 3000)
+        s = np.asarray(pos[1500:])
+        np.testing.assert_allclose(s.mean(), 0.0, atol=0.12)
+        np.testing.assert_allclose(s.std(), 1.0, rtol=0.15)
+        self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
+
+    def test_correlated_gaussian_dense_metric(self):
+        # Exercises a non-identity (dense) inverse_mass_matrix -- the direct
+        # test of the metric-generalization decision for num_steps_to_uturn.
+        Sigma = jnp.array([[2.0, 1.2], [1.2, 1.0]])
+        Sinv = jnp.linalg.inv(Sigma)
+        logp = lambda x: -0.5 * x @ Sinv @ x
+        algo = blackjax.gist_trajectory_length(
+            logp, inverse_mass_matrix=Sigma, step_size=0.3
+        )
+        pos, _ = run_chain(algo, jnp.zeros(2), self.next_key(), 4000)
+        emp = np.cov(np.asarray(pos[2000:]), rowvar=False)
+        np.testing.assert_allclose(emp, np.asarray(Sigma), atol=0.6)
+
+    def test_smooth_skewed_target(self):
+        # Asymmetric target: the single highest-value test for this
+        # instance's rollout direction -- a symmetric Gaussian cannot
+        # detect a reversed-direction/sign bug in the forward-vs-reverse
+        # U-turn rollout or the momentum flip (mirrors
+        # test_slice.py::test_multivariate_skewed_exponential's rationale,
+        # but with a smooth log-space target -- see
+        # tests/fixtures.py::smooth_skewed_logdensity for why the raw
+        # Exponential representation is a poor fit for a gradient-based
+        # sampler: its zero gradient outside the support can make a
+        # boundary-crossing trajectory drift forever, degenerate for the
+        # no-U-turn rollout specifically).
+        algo = blackjax.gist_trajectory_length(
+            smooth_skewed_logdensity, inverse_mass_matrix=jnp.ones(2), step_size=0.3
+        )
+        pos, infos = run_chain(algo, jnp.zeros(2), self.next_key(), 6000)
+        s = np.asarray(pos[3000:])
+        np.testing.assert_allclose(s.mean(axis=0), -0.5772, atol=0.25)
+        np.testing.assert_allclose(s.std(axis=0), 1.2825, rtol=0.25)
+        skew = np.mean(((s - s.mean(0)) / s.std(0)) ** 3, axis=0)
+        self.assertTrue((skew < 0.0).all())  # left-skewed, not mirrored
+        self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
+
+    def test_neal_funnel_neck_marginal(self):
+        algo = blackjax.gist_trajectory_length(
+            neal_funnel_logdensity,
+            inverse_mass_matrix=jnp.ones(3),
+            step_size=0.15,
+            max_num_steps=128,
+        )
+        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 4000)
+        y = np.asarray(pos[2000:, 0])
+        np.testing.assert_allclose(y.mean(), 0.0, atol=0.7)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+
+
+class ClosedFormCrossCheckTest(BlackJAXTest):
+    """Section 4.3: cheap, exact-to-float-tolerance derivation cross-checks."""
+
+    def test_psi_zero_reduces_to_paper_simple_form(self):
+        # At psi=0, Lo (and Lo') are identically 1, so the general-psi
+        # formula must reduce to a_GIST = 1 wedge [e^{-DeltaH} M/N 1{L<=N}]
+        # (section 2.2.4). Cross-check against the *actual* apply_fn
+        # (not a reimplementation of the U-turn rollout).
+        state = gist.init(jnp.zeros(2), std_normal_logdensity)
+        metric = metrics.default_metric(jnp.ones(2))
+        integrator_state = integrators.IntegratorState(
+            jnp.zeros(2), jnp.array([1.0, 0.5]), state.logdensity, state.logdensity_grad
+        )
+        uturn_fn = gist_trajectory_length.num_steps_to_uturn(
+            integrators.velocity_verlet, step_size=0.3, metric=metric, max_num_steps=50
+        )
+        forward = uturn_fn(integrator_state, std_normal_logdensity)
+        L = jnp.minimum(forward, jnp.asarray(2))
+
+        apply_fn = gist_trajectory_length._apply_fn(
+            integrators.velocity_verlet,
+            step_size=0.3,
+            max_num_steps=50,
+            path_fraction=0.0,
+        )
+        _, log_ratio, extra = apply_fn(
+            integrator_state, L, forward, std_normal_logdensity, metric
+        )
+        reverse = extra.num_steps_to_uturn_reverse
+        expected = jnp.where(
+            L <= reverse,
+            jnp.log(forward.astype(jnp.float32)) - jnp.log(reverse.astype(jnp.float32)),
+            -jnp.inf,
+        )
+        np.testing.assert_allclose(float(log_ratio), float(expected), atol=1e-6)
+
+    def test_num_steps_to_uturn_quarter_period_anchor_d1(self):
+        # d=1 standard normal: the exact Hamiltonian flow is a rotation with
+        # period 2*pi. Starting at theta0=0 (a clean special case), the
+        # no-return condition (theta(t)-theta0)*rho(t) < 0 first fires at
+        # exactly the quarter period t=pi/2 (GIST paper section 4). Leapfrog
+        # approximates the exact flow well for small step_size.
+        step_size = 0.01
+        metric = metrics.default_metric(jnp.ones(1))
+        state = integrators.IntegratorState(
+            jnp.array([0.0]), jnp.array([1.0]), jnp.array(0.0), jnp.array([0.0])
+        )
+        uturn_fn = gist_trajectory_length.num_steps_to_uturn(
+            integrators.velocity_verlet, step_size, metric, max_num_steps=1000
+        )
+        n = int(uturn_fn(state, std_normal_logdensity))
+        expected = float(jnp.pi / 2) / step_size
+        np.testing.assert_allclose(n, expected, rtol=0.05)
+
+    def test_metric_corrected_velocity_used_not_raw_momentum(self):
+        # `[DECISION -- TL ratify]` option (ii): the no-U-turn dot product
+        # must use the metric-corrected velocity M^{-1} rho, not raw
+        # momentum. A strongly anisotropic diagonal metric makes the two
+        # disagree -- confirms the correction is load-bearing, not a no-op.
+        inv_mass = jnp.array([100.0, 0.01])
+        metric = metrics.default_metric(inv_mass)
+        state = integrators.IntegratorState(
+            jnp.array([0.0, 0.0]), jnp.array([1.0, 1.0]), jnp.array(0.0), jnp.array([0.0, 0.0])
+        )
+        uturn_fn = gist_trajectory_length.num_steps_to_uturn(
+            integrators.velocity_verlet, step_size=0.05, metric=metric, max_num_steps=200
+        )
+        corrected = int(uturn_fn(state, std_normal_logdensity))
+
+        symplectic_integrator = integrators.velocity_verlet(
+            std_normal_logdensity, metric.kinetic_energy
+        )
+        theta0 = state.position
+        current = state
+        n_raw = 0
+        while n_raw < 200:
+            nxt = symplectic_integrator(current, 0.05)
+            delta = nxt.position - theta0
+            if float(jnp.dot(delta, nxt.momentum)) < 0.0:  # raw momentum, not velocity
+                break
+            current = nxt
+            n_raw += 1
+
+        self.assertNotEqual(corrected, n_raw)
+
+
+class EdgeCaseTest(BlackJAXTest):
+    def test_all_reject_on_absurd_step_size(self):
+        algo = blackjax.gist_trajectory_length(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(2),
+            step_size=1e6,
+            max_num_steps=8,
+        )
+        pos, infos = run_chain(algo, jnp.zeros(2), self.next_key(), 200)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        np.testing.assert_allclose(np.asarray(pos), 0.0)  # chain never moved
+        self.assertFalse(bool(jnp.any(infos.is_accepted)))
+
+    def test_hard_constraint_boundary_no_crash(self):
+        logp = lambda x: jnp.where(x[0] > 0, -0.5 * jnp.sum(x**2), -jnp.inf)
+        algo = blackjax.gist_trajectory_length(
+            logp, inverse_mass_matrix=jnp.ones(2), step_size=1.0
+        )
+        pos, _ = run_chain(algo, jnp.array([0.5, 0.5]), self.next_key(), 500)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        self.assertTrue(np.all(np.asarray(pos[:, 0]) > 0))
+
+    def test_nan_gradient_region_no_crash(self):
+        logp = lambda x: -jnp.sum(jnp.sqrt(x))
+        algo = blackjax.gist_trajectory_length(
+            logp, inverse_mass_matrix=jnp.ones(2), step_size=0.5, max_num_steps=16
+        )
+        pos, _ = run_chain(algo, jnp.array([1.0, 1.0]), self.next_key(), 500)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+
+    def test_no_return_rejection_direct(self):
+        # Direct unit test: pick L far larger than any plausible reverse
+        # U-turn count N, so L must fall outside [Lo', N].
+        state = gist.init(jnp.zeros(2), std_normal_logdensity)
+        metric = metrics.default_metric(jnp.ones(2))
+        integrator_state = integrators.IntegratorState(
+            jnp.zeros(2), jnp.array([1.0, 0.5]), state.logdensity, state.logdensity_grad
+        )
+        apply_fn = gist_trajectory_length._apply_fn(
+            integrators.velocity_verlet,
+            step_size=0.3,
+            max_num_steps=50,
+            path_fraction=0.5,
+        )
+        implausibly_large_L = jnp.asarray(50)
+        _, log_ratio, extra = apply_fn(
+            integrator_state,
+            implausibly_large_L,
+            jnp.asarray(3),
+            std_normal_logdensity,
+            metric,
+        )
+        self.assertTrue(bool(extra.is_no_return_rejected))
+        self.assertEqual(float(log_ratio), float("-inf"))
+
+    def test_max_num_steps_cap_used_as_is(self):
+        # A tiny max_num_steps caps num_steps_to_uturn without erroring; the
+        # capped U is still used as an exact (not approximate) density, so
+        # the chain should keep running validly, not crash or NaN out.
+        algo = blackjax.gist_trajectory_length(
+            std_normal_logdensity,
+            inverse_mass_matrix=jnp.ones(2),
+            step_size=0.3,
+            max_num_steps=2,
+        )
+        pos, infos = run_chain(algo, jnp.zeros(2), self.next_key(), 300)
+        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        self.assertTrue(np.all(np.asarray(infos.num_steps_to_uturn_forward) <= 2))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -1,5 +1,13 @@
 """Tests for the GIST self-tuning trajectory-length sampler (no-U-turn,
-NOT NUTS's recursive doubling)."""
+NOT NUTS's recursive doubling).
+
+CI note: run with ``--benchmark-disable`` when parallelizing under xdist
+(e.g. ``-n 2``) -- a bare ``-n 2`` run hits an ``INTERNALERROR`` from
+pytest-benchmark x xdist under this project's ``filterwarnings = error``
+(the same masking-bug family as the probdiffeq migration saga). Not a code
+issue in this module; the documented blackjax test command already
+includes ``--benchmark-disable``.
+"""
 import chex
 import jax
 import jax.numpy as jnp
@@ -175,10 +183,17 @@ class MomentRecoveryTest(BlackJAXTest):
         )
         pos, infos = run_chain(algo, jnp.zeros(2), self.next_key(), 6000)
         s = np.asarray(pos[3000:])
+        # The mean/std bounds are the actual reversed-direction/sign-bug
+        # detector here (confirmed empirically against a planted direction
+        # bug in review: a broken rollout inflates std well outside this
+        # band, well before the skew sign would flip). The skew check below
+        # is a secondary correctness check, tightened to a band around the
+        # closed-form truth (-1.1395) rather than a bare sign check, so it
+        # earns its own assertion.
         np.testing.assert_allclose(s.mean(axis=0), -0.5772, atol=0.25)
         np.testing.assert_allclose(s.std(axis=0), 1.2825, rtol=0.25)
         skew = np.mean(((s - s.mean(0)) / s.std(0)) ** 3, axis=0)
-        self.assertTrue((skew < 0.0).all())  # left-skewed, not mirrored
+        np.testing.assert_allclose(skew, -1.1395, atol=1.0)
         self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
 
     def test_neal_funnel_neck_marginal(self):
@@ -256,10 +271,16 @@ class ClosedFormCrossCheckTest(BlackJAXTest):
         inv_mass = jnp.array([100.0, 0.01])
         metric = metrics.default_metric(inv_mass)
         state = integrators.IntegratorState(
-            jnp.array([0.0, 0.0]), jnp.array([1.0, 1.0]), jnp.array(0.0), jnp.array([0.0, 0.0])
+            jnp.array([0.0, 0.0]),
+            jnp.array([1.0, 1.0]),
+            jnp.array(0.0),
+            jnp.array([0.0, 0.0]),
         )
         uturn_fn = gist_trajectory_length.num_steps_to_uturn(
-            integrators.velocity_verlet, step_size=0.05, metric=metric, max_num_steps=200
+            integrators.velocity_verlet,
+            step_size=0.05,
+            metric=metric,
+            max_num_steps=200,
         )
         corrected = int(uturn_fn(state, std_normal_logdensity))
 

--- a/tests/test_api_protocols.py
+++ b/tests/test_api_protocols.py
@@ -127,6 +127,16 @@ def _make_algorithm(name):
             std_normal_logdensity,
             max_expansions=5,
         ),
+        "gist_step_size": lambda: blackjax.gist_step_size(
+            std_normal_logdensity,
+            inverse_mass_matrix=inv_mass,
+            initial_step_size=0.1,
+        ),
+        "gist_trajectory_length": lambda: blackjax.gist_trajectory_length(
+            std_normal_logdensity,
+            inverse_mass_matrix=inv_mass,
+            step_size=0.1,
+        ),
     }
 
     if name not in factories:
@@ -157,6 +167,8 @@ _MCMC_ALGORITHMS = [
     "irmh",
     "slice_sampling",
     "coordinate_slice",
+    "gist_step_size",
+    "gist_trajectory_length",
 ]
 
 


### PR DESCRIPTION
## Summary

Implements two concrete instances of **GIST** (Gibbs self-tuning for locally
adaptive HMC — Bou-Rabee, Carpenter, Marsden, [arXiv:2404.15253](https://arxiv.org/abs/2404.15253)):

- **`blackjax.gist_step_size`** — per-orbit step-size self-tuning, autoStep
  ([Liu, Surjanovic, Biron-Lattes, Bouchard-Côté, Campbell,
  arXiv:2410.18929](https://arxiv.org/abs/2410.18929)) / autoMALA ([Biron-Lattes,
  Surjanovic, Syed, Campbell, Bouchard-Côté,
  arXiv:2310.16782](https://arxiv.org/abs/2310.16782)) style: a doubling/halving
  search picks a step-size index `j` deterministically given `(theta, rho, a, b)`;
  the "reversibility check" (re-running the search at the proposal and comparing
  `j' == j`) falls directly out of evaluating GIST's general acceptance ratio when
  `p(alpha|theta,rho)` is a Dirac measure in `j` — not a separately bolted-on
  correctness patch.
- **`blackjax.gist_trajectory_length`** — self-tuning path length via a
  no-U-turn condition (GIST paper §5), materially simpler than NUTS's
  recursive-doubling tree: a single forward `while_loop` rollout counts leapfrog
  steps to the first no-return event, and the trajectory length `L` is drawn
  uniformly from an interval shaped by a fixed path-fraction `psi`.

Both instances share a general spine (`blackjax/mcmc/gist.py`) implementing the
generic Gibbs-refresh-momentum / Gibbs-refresh-tuning-parameter /
apply-involution / one-Metropolis-test machinery (Algorithm 1, eq. 9 of the
paper), mirroring the `hmc.py`/`nuts.py` split. The general spine is **not**
registered as a top-level `blackjax.gist` — only `blackjax.gist_step_size` and
`blackjax.gist_trajectory_length` are public (reach the shared machinery via
`blackjax.mcmc.gist` if needed).

## Design decisions

- Step-size doubling/halving search cap → **forced rejection** on
  `search_exhausted` (exposed as `GISTStepSizeInfo.search_exhausted`), never a
  silent approximate acceptance.
- **Two-gate acceptance**: the reversibility check (`j' == j`) and the ordinary
  Metropolis energy test are two explicit, separately testable steps, folded
  into one `log_accept = delta_energy + log_tuning_density_ratio` expression at
  the general-spine layer.
- The no-U-turn dot product in `gist_trajectory_length` uses the
  **metric-corrected velocity** `M^-1 rho` (not raw momentum), generalizing
  correctly to non-identity `inverse_mass_matrix` (diagonal/dense/low-rank),
  matching how NUTS's own turning check generalizes for non-Euclidean metrics.
- `apply_fn` returns a scalar `log_tuning_density_ratio` directly, rather than
  two separate density callables — a Dirac-measure `p` (as in `gist_step_size`)
  has no well-defined value away from its atom, so the ratio must be computed
  directly.
- Added a reusable Neal's-funnel fixture (`tests/fixtures.py::neal_funnel_logdensity`)
  as the canonical stress test for step-size adaptation.

## Test evidence

37 new tests (`tests/mcmc/test_gist_step_size.py` + `test_gist_trajectory_length.py`),
all green, plus the full existing suite unaffected (additive changes only):

- **Population invariance from an exact stationary start** (modeled on
  `test_barker.py::test_invariance`), for both the symmetric/asymmetric
  step-size criteria and both `psi=0`/`psi=0.5` path fractions — catches a bug
  in the `j' == j` reversibility reconciliation as population drift.
- **Moments recovery**: isotropic Gaussian, correlated Gaussian (dense
  `inverse_mass_matrix`, exercising the metric-generalization decision), a
  smooth asymmetric target (`y = log(u)`, `u ~ Exponential(1)`, i.e.
  `-y ~ Gumbel(0,1)` — chosen over `jax.scipy.stats.expon.logpdf` directly
  because the latter's *zero* gradient outside its support makes a
  boundary-crossing leapfrog trajectory drift forever, pathological for the
  U-turn rollout though fine for density-evaluation-only samplers like slice
  sampling), and Neal's funnel.
- **Closed-form cross-checks**: the `psi=0` acceptance-ratio reduction against
  the actual `apply_fn` (not a reimplementation); a `d=1` quarter-period
  analytic anchor for the U-turn rollout; a regression check confirming the
  metric-corrected velocity is load-bearing (differs from raw momentum on an
  anisotropic metric).
- **Edge cases**: all-reject on an absurd step size, a hard `-inf` logdensity
  boundary, a NaN-gradient region, forced rejection on `search_exhausted` /
  `is_no_return_rejected`, and a direct unit test of the reversibility-check
  failure path.
- Both kernels' `chex.assert_max_traces(n=4)` (vs. `n=2` for hmc/nuts): GIST's
  two-gate design needs one trace each for the forward search, the
  accepted-move build, and the reverse re-check — a structural minimum, not a
  retracing regression (documented inline in `gist.py`).

**Full suite**: `JAX_PLATFORM_NAME=cpu uv run pytest -n 2 --benchmark-disable tests/`
→ 1213 passed, 1 skipped, 0 failed.

Note: these two test files need `--benchmark-disable` when run under xdist
(`-n 2`+) — a bare parallel run without it hits an `INTERNALERROR` from
pytest-benchmark × xdist under this repo's `filterwarnings = error` (unrelated
to this PR; documented inline in both files).

## Review

Reviewed-by: statistician agent — independent paper-to-code correctness review
(acceptance ratios checked line-for-line against arXiv:2404.15253 eq. 9,
AutoStep Algorithm 2, and autoMALA Algorithm 2; the forward/reverse U-turn
rollout direction and the autoMALA "final halving" asymmetry — the two
highest-risk points — were verified against the paper pseudocode; detector
power was empirically confirmed by planting a reversed-rollout direction bug
and confirming `test_smooth_skewed_target` fails on 3/3 seeds).

## Follow-ups (out of scope for this PR)

- Composing step-size and trajectory-length self-tuning in one kernel.
- Round-based tuning of `initial_step_size` (belongs in `blackjax/adaptation/`).
- Recovering NUTS/Multinomial-HMC/AAPS as GIST special cases (unification
  device in the paper, no user-facing value — these already exist as
  battle-tested implementations).
