### PR TITLE
MEADS-LRD: opt-in low-rank momentum metric for meads_adaptation

### DIFF
--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -348,15 +348,17 @@ _LRD_EIGENVALUE_FLOOR = 1e-6
 def _floor_lrd_eigenvalues(lam: Array) -> Array:
     """Clamp low-rank eigenvalues away from 0.
 
-    A collinear or otherwise rank-deficient ensemble (e.g. tuningfork's
-    canonical rank-1 initial ensemble) can make the sample/accumulated
-    correlation matrix singular along one or more of the selected top-k
-    directions, giving ``lam ~ 0``. Both whitening transforms
-    (``_low_rank_precondition_grad`` / ``_low_rank_precondition_pos``)
-    multiply or divide by ``sqrt(lam)``, so an unfloored near-zero
-    eigenvalue can self-reinforce into a degenerate metric (``rhat = inf``)
-    before the ensemble has a chance to decorrelate. Flooring keeps the
-    whitening transform's scale factor bounded.
+    A collinear or otherwise rank-deficient ensemble (e.g. a rank-1
+    initial ensemble) can make the sample/accumulated correlation matrix
+    singular along one or more of the selected top-k directions, giving
+    ``lam ~ 0`` — and ``float32`` ``eigh`` can even return slightly
+    *negative* eigenvalues, whose ``sqrt`` is NaN. The whitening transform
+    (``_low_rank_precondition_pos``) and the momentum metric both scale by
+    ``sqrt(lam)``, so flooring keeps those factors finite. This guard is
+    intentionally redundant with the step-size decoupling (which keeps
+    ``sqrt(lam)`` out of the step-size heuristic entirely): the degenerate
+    collapse (``rhat = inf``, NaN step size) only occurs if *both* guards
+    are defeated.
     """
     return jnp.maximum(lam, _LRD_EIGENVALUE_FLOOR)
 

--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -19,7 +19,6 @@ from jax.flatten_util import ravel_pytree
 
 import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
-from blackjax.adaptation.mclmc_lrd_adaptation import _extract_lrd_from_samples
 from blackjax.base import AdaptationAlgorithm
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
@@ -252,6 +251,130 @@ def _low_rank_precondition_pos(pos: Array, sigma: Array, U: Array, lam: Array) -
     return _low_rank_apply(pos, U, 1.0 / jnp.sqrt(lam)) / sigma
 
 
+class _LowRankAccumulatorState(NamedTuple):
+    """Running Chan/Welford covariance accumulator for MEADS-LRD's window
+    accumulation (high-d fix: see ``low_rank_rank``'s docstring).
+
+    Carries the mean, the Chan "M2" sum-of-outer-products, and the effective
+    sample count pooled across *all* ``num_chains`` chains and every
+    accumulated window step, so the low-rank metric can eventually be
+    estimated from effective ``n = num_chains * window_steps`` rather than a
+    single ``num_chains``-sized ensemble snapshot.
+    """
+
+    mean: Array
+    m2: Array
+    count: Array
+
+
+def _lrd_accumulator_init(d: int) -> _LowRankAccumulatorState:
+    return _LowRankAccumulatorState(
+        mean=jnp.zeros((d,)), m2=jnp.zeros((d, d)), count=jnp.zeros(())
+    )
+
+
+def _lrd_accumulator_update(
+    acc: _LowRankAccumulatorState, batch: Array
+) -> _LowRankAccumulatorState:
+    """Merge a batch of ``n_b`` samples, shape ``(n_b, d)``, into the running
+    accumulator via Chan et al.'s parallel/batch generalization of Welford's
+    algorithm -- the same recurrence
+    :func:`~blackjax.adaptation.mass_matrix.welford_algorithm` applies one
+    sample at a time, applied here to a whole ensemble at once.
+    """
+    mean_a, m2_a, n_a = acc
+    n_b = batch.shape[0]
+    mean_b = jnp.mean(batch, axis=0)
+    centered_b = batch - mean_b[None, :]
+    m2_b = centered_b.T @ centered_b
+
+    delta = mean_b - mean_a
+    n_ab = n_a + n_b
+    mean_ab = mean_a + delta * (n_b / n_ab)
+    m2_ab = m2_a + m2_b + jnp.outer(delta, delta) * (n_a * n_b / n_ab)
+    return _LowRankAccumulatorState(mean=mean_ab, m2=m2_ab, count=n_ab)
+
+
+def _lrd_from_accumulated_covariance(
+    acc: _LowRankAccumulatorState, k: int
+) -> tuple[Array, Array, Array]:
+    """Extract ``(sigma, U, lam)`` from a window-accumulated covariance
+    (effective ``n = num_chains * window_steps``) via ``eigh`` of the
+    accumulated correlation matrix, selecting the top-``k`` directions by
+    ``|lam - 1|`` (the directions that deviate most from isotropic). This is
+    what makes the low-rank metric estimable at high dimension (``d >>
+    num_chains``): a single ``num_chains``-sized ensemble snapshot is
+    ``p >> n`` noise-dominated once ``d`` exceeds ``num_chains``, but the
+    window-accumulated covariance's effective ``n`` can comfortably exceed
+    ``d`` given enough window steps.
+    """
+    mean, m2, count = acc
+    del mean  # only the second moment is needed below
+    covariance = m2 / jnp.maximum(count - 1.0, 1.0)
+    variance = jnp.diag(covariance)
+    sigma = jnp.sqrt(jnp.maximum(variance, 0.0))
+    sigma = jnp.where(sigma <= 0.0, 1.0, sigma)  # avoid div-by-zero
+
+    inv_sigma = 1.0 / sigma
+    correlation = covariance * inv_sigma[:, None] * inv_sigma[None, :]
+
+    # eigh gives ascending eigenvalues of the (symmetric) correlation matrix.
+    lam_all, V = jnp.linalg.eigh(correlation)
+    sort_idx = jnp.argsort(jnp.abs(lam_all - 1.0))[::-1]
+    top_idx = sort_idx[:k]
+    lam = lam_all[top_idx]
+    U = V[:, top_idx]
+    return sigma, U, lam
+
+
+def _lrd_diagonal_fallback(flat_positions: Array, k: int) -> tuple[Array, Array, Array]:
+    """Diagonal-only fallback ``(sigma, U, lam)`` for MEADS-LRD's momentum
+    metric, used before the accumulation window holds enough pooled samples
+    to support a rank-``k`` estimate (FIX 1).
+
+    Estimating an eigenbasis from a single ``num_chains``-sized ensemble
+    snapshot is exactly the noise-dominated (``p >> n``) estimator that
+    causes the high-d step-size/momentum instability these fixes address --
+    measured directly: routing through it even as a *pre-window* fallback
+    (rather than attempting a low-rank correction from too little data) was
+    enough to blow up the ensemble and collapse epsilon at ``d=40,
+    num_chains=32``. So instead this returns ``lam = 1`` (no correction --
+    ``_low_rank_apply``'s ``(lam_pow - 1)`` term vanishes identically),
+    degenerating the momentum metric to exactly the diagonal-only
+    preconditioning ``low_rank_rank=None`` uses. ``U``'s columns are then
+    irrelevant (they multiply a zero coefficient) -- any orthonormal set
+    works; the leading standard basis vectors are the cheapest choice. Only
+    ``sigma`` (a per-dimension population statistic, well-estimated from as
+    few as 2 samples per dimension, unlike a joint eigenbasis) carries real
+    information here.
+    """
+    sigma = jnp.std(flat_positions, axis=0)
+    sigma = jnp.where(sigma <= 0.0, 1.0, sigma)
+    d = flat_positions.shape[-1]
+    U = jnp.eye(d, k)
+    lam = jnp.ones((k,))
+    return sigma, U, lam
+
+
+_LRD_EIGENVALUE_FLOOR = 1e-6
+
+
+def _floor_lrd_eigenvalues(lam: Array) -> Array:
+    """Clamp low-rank eigenvalues away from 0.
+
+    A collinear or otherwise rank-deficient ensemble (e.g. tuningfork's
+    canonical rank-1 initial ensemble) can make the sample/accumulated
+    correlation matrix singular along one or more of the selected top-k
+    directions, giving ``lam ~ 0``. Both whitening transforms
+    (``_low_rank_precondition_grad`` / ``_low_rank_precondition_pos``)
+    multiply or divide by ``sqrt(lam)``, so an unfloored near-zero
+    eigenvalue can self-reinforce into a degenerate metric (``rhat = inf``)
+    before the ensemble has a chance to decorrelate. Flooring keeps the
+    whitening transform's scale factor bounded.
+    """
+    return jnp.maximum(lam, _LRD_EIGENVALUE_FLOOR)
+
+
 def meads_adaptation(
     logdensity_fn: Callable,
     num_chains: int,
@@ -260,6 +383,7 @@ def meads_adaptation(
     damping_slowdown: float = 1.0,
     adaptation_info_fn: Callable = return_all_adapt_info,
     low_rank_rank: int | None = None,
+    low_rank_window_fraction: float = 0.5,
 ) -> AdaptationAlgorithm:
     """Adapt the parameters of the Generalized HMC algorithm.
 
@@ -318,9 +442,59 @@ def meads_adaptation(
         now whiten by this shared global metric rather than a per-fold one,
         so they stay consistent with the metric ghmc actually samples with.
         The rank is clamped to ``num_chains - 1`` (raises ``ValueError`` if
-        this would be < 1). The metric *returned* by ``run()`` is estimated
-        the same way, once more from the final population after the last
-        step.
+        this would be < 1). The metric *returned* by ``run()`` is the final
+        state of the same window-accumulated estimator described under
+        ``low_rank_window_fraction`` below.
+
+        Two further fixes address a validated high-dimension (``d >>
+        num_chains``) failure mode where a single-snapshot low-rank metric
+        made MEADS-LRD *worse* than the diagonal baseline (a p >> n noise-
+        dominated eigenbasis fed into ghmc's step-size heuristic collapsed
+        ``epsilon`` to ~1e-3 and froze the chains):
+
+        - The step-size heuristic (Algorithm 3, line 8) always whitens its
+          gradients by the plain per-fold diagonal scale (``grad * sigma``),
+          never by the low-rank metric, even when ``low_rank_rank`` is set.
+          Whitening ``epsilon`` by a noisy low-rank eigenbasis couples the
+          step size to whichever direction the estimate currently
+          over-weights, which is what caused the collapse above; the
+          low-rank metric still preconditions the *momentum* (where it
+          helps), just not the step-size proxy.
+        - Selected eigenvalues are floored away from 0 (see
+          ``_floor_lrd_eigenvalues``) so a collinear/rank-deficient initial
+          ensemble can't seed a degenerate metric that self-reinforces into
+          ``rhat = inf``.
+    low_rank_window_fraction
+        Only used when ``low_rank_rank`` is not ``None``. Fraction of
+        warmup steps, counted from the end, over which the low-rank metric's
+        covariance is accumulated (default ``0.5``: the last half of
+        warmup). A single ``num_chains``-sized ensemble snapshot is
+        ``p >> n`` noise-dominated once the dimension ``d`` exceeds
+        ``num_chains`` -- exactly the regime a single fold's estimate was
+        already too noisy for (see ``low_rank_rank`` above), just worse,
+        since now the *whole* population's snapshot is undersized too, and
+        (measured directly) even routing through it as a one-off fallback
+        is enough to destabilize the ensemble. Instead, a running
+        Chan/Welford covariance accumulator (mirroring the pattern
+        :func:`~blackjax.adaptation.mass_matrix.welford_algorithm` uses for
+        the mass matrix, generalized to a whole ensemble per step) is
+        updated with every chain's position at every step *inside* the
+        window, giving an effective sample size of ``num_chains *
+        window_steps``. Once that effective size exceeds ``2 * d`` (a bare
+        minimum for the estimate to not be noise-dominated), the low-rank
+        momentum metric switches on and keeps improving every further
+        window step; before that point -- either because the step is
+        before the window (the initial, still-transient fraction of
+        warmup, mirroring why Stan's window adaptation excludes its own
+        initial/final fast windows from mass-matrix estimation), or because
+        the window hasn't yet pooled ``2 * d`` samples -- the momentum
+        metric falls back to a purely diagonal one
+        (:func:`_lrd_diagonal_fallback`, i.e. no low-rank correction at
+        all, matching ``low_rank_rank=None``'s momentum exactly), never a
+        low-rank estimate from too little data.
+        Must be in ``[0.0, 1.0]``; ``0.0`` accumulates from step 0, ``1.0``
+        disables accumulation entirely (falls back to the purely diagonal
+        momentum metric throughout the run).
 
     Returns
     -------
@@ -353,13 +527,19 @@ def meads_adaptation(
                 f"num_chains={num_chains} chains, and that estimate needs "
                 "num_chains - 1 >= 1. Increase num_chains."
             )
+        if not 0.0 <= low_rank_window_fraction <= 1.0:
+            raise ValueError(
+                "low_rank_window_fraction must be in [0.0, 1.0], got "
+                f"{low_rank_window_fraction}."
+            )
 
     ghmc_kernel = mcmc.ghmc.build_kernel()
     adapt_init, _ = base(num_folds, step_size_multiplier, damping_slowdown)
     batch_init = jax.vmap(lambda p, r: mcmc.ghmc.init(p, logdensity_fn, r))
 
-    def one_step(carry, rng_key):
-        states, adaptation_state = carry
+    def one_step(carry, xs):
+        rng_key, in_window = xs
+        states, adaptation_state, lrd_accum = carry
         t = adaptation_state.current_iteration
 
         # Fold to freeze this step (Algorithm 3, line 4: "excluding k = t mod K")
@@ -388,37 +568,61 @@ def meads_adaptation(
 
         # MEADS-LRD: estimate ONE rank-`low_rank_k` correlation eigenbasis
         # (sigma, U, lam) per step from the FULL population of all
-        # num_chains chains, via the same sample-based extractor MCLMC-LRD
-        # uses (`_extract_lrd_from_samples`) -- NOT from each fold's own
-        # noisy n_per_fold snapshot. A fold's ensemble is too small (paper
-        # default n_per_fold=16) for its top-k eigenvectors to be stable
+        # num_chains chains -- NOT from each fold's own noisy n_per_fold
+        # snapshot. A fold's ensemble is too small (paper default
+        # n_per_fold=16) for its top-k eigenvectors to be stable
         # step-to-step; the resulting eigenvector jitter destabilizes ghmc's
         # persistent momentum. The metric is a shared symmetric
         # preconditioner (unlike step-size/damping, which stay genuinely
         # per-fold below), so pooling all chains to estimate it needs no
         # per-fold isolation -- the same practice window adaptation uses for
-        # its diagonal/dense metric. This low-rank metric -- not just its
-        # diagonal sigma -- then preconditions the step-size and damping
-        # heuristics below (via `_low_rank_precondition_{grad,pos}`), so
-        # alpha/delta/step_size stay consistent with the metric actually
-        # handed to ghmc for sampling this step.
+        # its diagonal/dense metric. This low-rank metric then preconditions
+        # the damping heuristic below (via `_low_rank_precondition_pos`), so
+        # alpha/delta stay consistent with the metric actually handed to
+        # ghmc for sampling this step. It does NOT precondition the
+        # step-size heuristic (see the ε-decouple fix just below).
+        #
+        # FIX (high-d, p >> n): a single num_chains-sized snapshot is noise-
+        # dominated once d exceeds num_chains, so `lrd_accum` -- a running
+        # Chan/Welford covariance pooled over every chain at every step
+        # *inside* the accumulation window (see `low_rank_window_fraction`'s
+        # docstring) -- is used instead once its effective sample count
+        # exceeds 2*d (a bare minimum for a covariance estimate to not be
+        # noise-dominated). Before that (outside the window, or too early
+        # inside it), fall back to a purely diagonal metric
+        # (`_lrd_diagonal_fallback`) rather than ever attempting a low-rank
+        # estimate from too little data -- see that function's docstring for
+        # why a single-snapshot estimate is unsafe even as a fallback.
         if low_rank_rank is not None:
             flat_all_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(states.position)
-            flat_all_grads = jax.vmap(lambda g: ravel_pytree(g)[0])(
-                states.logdensity_grad
-            )
             d = flat_all_pos.shape[-1]
             flat_folded_pos = flat_all_pos.reshape((num_folds, n_per_fold, d))
-            flat_folded_grads = flat_all_grads.reshape((num_folds, n_per_fold, d))
 
-            global_sigma, global_U, global_lam, _ = _extract_lrd_from_samples(
-                flat_all_pos, k=low_rank_k
+            updated_lrd_accum = jax.lax.cond(
+                in_window,
+                lambda a: _lrd_accumulator_update(a, flat_all_pos),
+                lambda a: a,
+                lrd_accum,
             )
-            precond_grads_for_step_size = jax.vmap(
-                _low_rank_precondition_grad, in_axes=(0, None, None, None)
-            )(flat_folded_grads, global_sigma, global_U, global_lam)
+            enough_accumulated = updated_lrd_accum.count >= 2 * d
+            use_accumulated = jnp.logical_and(in_window, enough_accumulated)
+            global_sigma, global_U, global_lam = jax.lax.cond(
+                use_accumulated,
+                lambda a: _lrd_from_accumulated_covariance(a, low_rank_k),
+                lambda a: _lrd_diagonal_fallback(flat_all_pos, low_rank_k),
+                updated_lrd_accum,
+            )
+            global_lam = _floor_lrd_eigenvalues(global_lam)
         else:
-            precond_grads_for_step_size = precond_grads
+            updated_lrd_accum = lrd_accum
+
+        # ε-decouple: the step-size heuristic (Algorithm 3, line 8) always
+        # whitens by the plain per-fold diagonal scale, never by the
+        # low-rank metric -- whitening it by a noisy low-rank eigenbasis
+        # couples epsilon to whichever direction the estimate currently
+        # over-weights (measured: collapsed epsilon ~20x at d=390), and the
+        # low-rank metric's benefit is in the momentum, not the step size.
+        precond_grads_for_step_size = precond_grads
 
         # Per-fold step size from each fold's own preconditioned grads.
         # Then roll by 1 so fold k gets the step size from fold k-1.
@@ -544,9 +748,11 @@ def meads_adaptation(
                 new_states,
             )
 
-        return (new_states, new_adaptation_state), adaptation_info_fn(
-            new_states, info, new_adaptation_state
-        )
+        return (
+            new_states,
+            new_adaptation_state,
+            updated_lrd_accum,
+        ), adaptation_info_fn(new_states, info, new_adaptation_state)
 
     def run(rng_key: PRNGKey, positions: ArrayLikeTree, num_steps: int = 1000):
         key_init, key_adapt = jax.random.split(rng_key)
@@ -555,27 +761,50 @@ def meads_adaptation(
         init_states = batch_init(positions, rng_keys)
         init_adaptation_state = adapt_init(positions, init_states.logdensity_grad)
 
+        if low_rank_rank is not None:
+            # Accumulate the covariance over the LAST `low_rank_window_fraction`
+            # of warmup steps only (skip the still-transient early fraction),
+            # mirroring how Stan's window adaptation delimits its own windows.
+            # `window_start`/`in_window_flags` are plain Python/concrete-shape
+            # values -- num_steps is always a concrete int here, never traced.
+            window_start = int(low_rank_window_fraction * num_steps)
+            flat_init_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(init_states.position)
+            init_lrd_accum = _lrd_accumulator_init(flat_init_pos.shape[-1])
+        else:
+            window_start = num_steps
+            init_lrd_accum = None
+        in_window_flags = jnp.arange(num_steps) >= window_start
+
         keys = jax.random.split(key_adapt, num_steps)
-        (last_states, last_adaptation_state), info = jax.lax.scan(
-            one_step, (init_states, init_adaptation_state), keys
+        (last_states, last_adaptation_state, last_lrd_accum), info = jax.lax.scan(
+            one_step,
+            (init_states, init_adaptation_state, init_lrd_accum),
+            (keys, in_window_flags),
         )
 
         if low_rank_rank is not None:
-            # Re-estimate the metric returned to the caller from the full
-            # final population (num_chains chains, after the last step) --
-            # the same global-population estimator `one_step` already uses
-            # per-step, so this is a fresh draw of the same estimate rather
-            # than a different scheme. `low_rank_k` (== min(low_rank_rank,
-            # num_chains - 1)) is reused unchanged from above.
+            # The metric returned to the caller is the FINAL state of the
+            # same window-accumulated estimator `one_step` uses per-step
+            # (effective n = num_chains * window_steps), falling back to the
+            # diagonal-only estimate only if the window never accumulated
+            # enough samples (e.g. num_steps too small). See
+            # `low_rank_window_fraction`'s docstring. `low_rank_k` (==
+            # min(low_rank_rank, num_chains - 1)) is reused unchanged.
             flat_final_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(
                 last_states.position
             )
             # low_rank_k is set to a non-None int whenever low_rank_rank is
             # not None (validated above); assert narrows it for mypy.
             assert low_rank_k is not None
-            final_sigma, final_U, final_lam, _ = _extract_lrd_from_samples(
-                flat_final_pos, k=low_rank_k
+            d_final = flat_final_pos.shape[-1]
+            use_accumulated_final = last_lrd_accum.count >= 2 * d_final
+            final_sigma, final_U, final_lam = jax.lax.cond(
+                use_accumulated_final,
+                lambda a: _lrd_from_accumulated_covariance(a, low_rank_k),
+                lambda a: _lrd_diagonal_fallback(flat_final_pos, low_rank_k),
+                last_lrd_accum,
             )
+            final_lam = _floor_lrd_eigenvalues(final_lam)
             momentum_inverse_scale = LowRankInverseMassMatrix(
                 sigma=final_sigma, U=final_U, lam=final_lam
             )

--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -225,20 +225,6 @@ def _low_rank_apply(element: Array, U: Array, lam_pow: Array) -> Array:
     return element + (Ue * (lam_pow - 1.0)) @ U.T
 
 
-def _low_rank_precondition_grad(
-    grad: Array, sigma: Array, U: Array, lam: Array
-) -> Array:
-    """Low-rank generalization of the legacy ``grad * sigma`` preconditioning.
-
-    Mirrors ``M^{-1/2} grad`` (i.e. ``metric.scale(_, grad, inv=True,
-    trans=False)`` for
-    :func:`~blackjax.mcmc.metrics.gaussian_euclidean_low_rank`); reduces to
-    ``grad * sigma`` when ``lam == 1`` (the diagonal limit), matching the
-    legacy preconditioning bit-for-bit.
-    """
-    return _low_rank_apply(grad, U, jnp.sqrt(lam)) * sigma
-
-
 def _low_rank_precondition_pos(pos: Array, sigma: Array, U: Array, lam: Array) -> Array:
     """Low-rank generalization of the legacy ``pos / sigma`` preconditioning.
 
@@ -441,10 +427,12 @@ def meads_adaptation(
         damping heuristics (Algorithm 3) are otherwise unchanged, except they
         now whiten by this shared global metric rather than a per-fold one,
         so they stay consistent with the metric ghmc actually samples with.
-        The rank is clamped to ``num_chains - 1`` (raises ``ValueError`` if
-        this would be < 1). The metric *returned* by ``run()`` is the final
-        state of the same window-accumulated estimator described under
-        ``low_rank_window_fraction`` below.
+        The rank is clamped to ``min(low_rank_rank, num_chains - 1, d)`` (raises
+        ``ValueError`` if ``num_chains - 1 < 1``). A rank-``d`` metric equals the
+        full dense metric, so clamping by ``d`` is lossless and prevents shape
+        disagreements in the jax.lax.cond branches. The metric *returned* by
+        ``run()`` is the final state of the same window-accumulated estimator
+        described under ``low_rank_window_fraction`` below.
 
         Two further fixes address a validated high-dimension (``d >>
         num_chains``) failure mode where a single-snapshot low-rank metric
@@ -463,7 +451,11 @@ def meads_adaptation(
         - Selected eigenvalues are floored away from 0 (see
           ``_floor_lrd_eigenvalues``) so a collinear/rank-deficient initial
           ensemble can't seed a degenerate metric that self-reinforces into
-          ``rhat = inf``.
+          ``rhat = inf``. Collinear / near-collinear initial ensembles
+          (e.g. all chains on a 1-D offset line) do not crash — two redundant
+          guards (the step-size decoupling and the eigenvalue floor) prevent
+          the NaN collapse — but expect severe under-mixing (measured
+          rhat≈5 on a rank-1 init); use a dispersed, full-rank initialization.
     low_rank_window_fraction
         Only used when ``low_rank_rank`` is not ``None``. Fraction of
         warmup steps, counted from the end, over which the low-rank metric's
@@ -769,7 +761,13 @@ def meads_adaptation(
             # values -- num_steps is always a concrete int here, never traced.
             window_start = int(low_rank_window_fraction * num_steps)
             flat_init_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(init_states.position)
-            init_lrd_accum = _lrd_accumulator_init(flat_init_pos.shape[-1])
+            d = flat_init_pos.shape[-1]
+            # Clamp the rank to the flattened dimension as well: rank > d makes the
+            # two jax.lax.cond branches disagree on output shapes. A rank-d metric
+            # equals the full dense metric, so this clamp is lossless.
+            nonlocal low_rank_k
+            low_rank_k = min(low_rank_k, d)
+            init_lrd_accum = _lrd_accumulator_init(d)
         else:
             window_start = num_steps
             init_lrd_accum = None

--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -15,10 +15,13 @@ from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
 
 import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
+from blackjax.adaptation.mclmc_lrd_adaptation import _extract_lrd_from_samples
 from blackjax.base import AdaptationAlgorithm
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
 __all__ = ["MEADSAdaptationState", "base", "maximum_eigenvalue", "meads_adaptation"]
@@ -208,6 +211,47 @@ def base(
     return init, update
 
 
+def _low_rank_apply(element: Array, U: Array, lam_pow: Array) -> Array:
+    """Batched ``element + U @ ((lam_pow - 1) * (U.T @ element))``.
+
+    ``element`` has shape ``(n, d)`` (a batch of ``n`` flat vectors), ``U``
+    has shape ``(d, k)``, ``lam_pow`` has shape ``(k,)``. Shared building
+    block for the two low-rank whitening transforms below -- it mirrors the
+    ``B`` / ``A*`` matrices inside
+    :func:`~blackjax.mcmc.metrics.gaussian_euclidean_low_rank`'s ``scale``
+    closure, specialized to a batch of vectors so it composes with MEADS's
+    per-fold ``jax.vmap``.
+    """
+    Ue = element @ U  # (n, k)
+    return element + (Ue * (lam_pow - 1.0)) @ U.T
+
+
+def _low_rank_precondition_grad(
+    grad: Array, sigma: Array, U: Array, lam: Array
+) -> Array:
+    """Low-rank generalization of the legacy ``grad * sigma`` preconditioning.
+
+    Mirrors ``M^{-1/2} grad`` (i.e. ``metric.scale(_, grad, inv=True,
+    trans=False)`` for
+    :func:`~blackjax.mcmc.metrics.gaussian_euclidean_low_rank`); reduces to
+    ``grad * sigma`` when ``lam == 1`` (the diagonal limit), matching the
+    legacy preconditioning bit-for-bit.
+    """
+    return _low_rank_apply(grad, U, jnp.sqrt(lam)) * sigma
+
+
+def _low_rank_precondition_pos(pos: Array, sigma: Array, U: Array, lam: Array) -> Array:
+    """Low-rank generalization of the legacy ``pos / sigma`` preconditioning.
+
+    Mirrors ``M^{1/2} pos`` (i.e. ``metric.scale(_, pos, inv=False,
+    trans=False)`` for
+    :func:`~blackjax.mcmc.metrics.gaussian_euclidean_low_rank`); reduces to
+    ``pos / sigma`` when ``lam == 1`` (the diagonal limit), matching the
+    legacy preconditioning bit-for-bit.
+    """
+    return _low_rank_apply(pos, U, 1.0 / jnp.sqrt(lam)) / sigma
+
+
 def meads_adaptation(
     logdensity_fn: Callable,
     num_chains: int,
@@ -215,6 +259,7 @@ def meads_adaptation(
     step_size_multiplier: float = 0.5,
     damping_slowdown: float = 1.0,
     adaptation_info_fn: Callable = return_all_adapt_info,
+    low_rank_rank: int | None = None,
 ) -> AdaptationAlgorithm:
     """Adapt the parameters of the Generalized HMC algorithm.
 
@@ -247,6 +292,25 @@ def meads_adaptation(
         and get_filter_adapt_info_fn in blackjax.adaptation.base. By default all
         information is saved - this can result in excessive memory usage if the
         information is unused.
+    low_rank_rank
+        MEADS-LRD extension (opt-in, default ``None``). ``None`` adapts a
+        *diagonal* momentum metric from the fold ensemble -- exactly the
+        original behavior, bit-for-bit. An ``int`` instead adapts a
+        rank-``low_rank_rank`` :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`
+        from the fold ensemble (requires :func:`blackjax.mcmc.ghmc`'s
+        dense/low-rank momentum-metric support, blackjax#950), generalizing
+        MEADS the way MCLMC-LRD generalized MCLMC. Each fold only has
+        ``num_chains // num_folds`` chains, so the *internal* per-fold
+        estimate that drives the step-size/damping heuristics during warmup
+        is clamped to rank ``num_chains // num_folds - 1`` (a fold's ensemble
+        cannot span a higher rank than that -- raises ``ValueError`` if this
+        would be < 1). The metric ultimately *returned* by ``run()`` is
+        instead re-estimated once from the full final population of all
+        ``num_chains`` chains (clamped to ``num_chains - 1``): a richer,
+        less noisy estimate than any single fold's, and one that sidesteps
+        averaging per-fold eigenbases together -- unlike a diagonal scale,
+        per-fold eigenvectors have no canonical cross-fold alignment, so an
+        elementwise average across folds would not be meaningful.
 
     Returns
     -------
@@ -262,6 +326,24 @@ def meads_adaptation(
             f"num_chains ({num_chains}) must be divisible by num_folds ({num_folds})."
         )
     n_per_fold = num_chains // num_folds
+
+    low_rank_k: int | None = None
+    if low_rank_rank is not None:
+        if not hasattr(mcmc.ghmc, "_metric_from_momentum_inverse_scale"):
+            raise RuntimeError(
+                "low_rank_rank requires blackjax.mcmc.ghmc's dense/low-rank "
+                "momentum-metric support (blackjax#950); the installed ghmc "
+                "module predates it."
+            )
+        low_rank_k = min(low_rank_rank, n_per_fold - 1)
+        if low_rank_k < 1:
+            raise ValueError(
+                f"low_rank_rank={low_rank_rank} cannot be honored: each fold "
+                f"only has n_per_fold = num_chains // num_folds = {n_per_fold} "
+                "chains, and the per-fold low-rank estimate needs "
+                "n_per_fold - 1 >= 1. Increase num_chains or decrease "
+                "num_folds."
+            )
 
     ghmc_kernel = mcmc.ghmc.build_kernel()
     adapt_init, _ = base(num_folds, step_size_multiplier, damping_slowdown)
@@ -295,6 +377,30 @@ def meads_adaptation(
             folded_scales,
         )
 
+        # MEADS-LRD: each fold additionally estimates its own rank-`low_rank_k`
+        # correlation eigenbasis (sigma, U, lam) from its own n_per_fold
+        # position snapshot, via the same sample-based extractor MCLMC-LRD
+        # uses (`_extract_lrd_from_samples`). This low-rank metric -- not
+        # just its diagonal sigma -- then preconditions the step-size and
+        # damping heuristics below (via `_low_rank_precondition_{grad,pos}`),
+        # so alpha/delta/step_size stay consistent with the metric actually
+        # handed to ghmc for sampling this step.
+        if low_rank_rank is not None:
+            flat_folded_pos = jax.vmap(jax.vmap(lambda p: ravel_pytree(p)[0]))(
+                folded_pos
+            )
+            flat_folded_grads = jax.vmap(jax.vmap(lambda g: ravel_pytree(g)[0]))(
+                folded_grads
+            )
+            fold_sigma, fold_U, fold_lam, _ = jax.vmap(
+                lambda flat: _extract_lrd_from_samples(flat, k=low_rank_k)
+            )(flat_folded_pos)
+            precond_grads_for_step_size = jax.vmap(_low_rank_precondition_grad)(
+                flat_folded_grads, fold_sigma, fold_U, fold_lam
+            )
+        else:
+            precond_grads_for_step_size = precond_grads
+
         # Per-fold step size from each fold's own preconditioned grads.
         # Then roll by 1 so fold k gets the step size from fold k-1.
         # (Algorithm 3, line 8 + cross-fold roll)
@@ -304,7 +410,9 @@ def meads_adaptation(
                 1.0,
             )
 
-        step_size_own = jax.vmap(fold_step_size)(precond_grads)  # [num_folds]
+        step_size_own = jax.vmap(fold_step_size)(
+            precond_grads_for_step_size
+        )  # [num_folds]
         # fold k uses step_size from fold k-1
         step_size_rolled = jnp.roll(step_size_own, 1)  # [num_folds]
         # fold k uses the momentum scale (std) from fold k-1
@@ -334,7 +442,20 @@ def meads_adaptation(
             folded_pos,
             folded_scales,
         )
-        alphas, deltas = jax.vmap(fold_damping)(precond_pos, step_size_rolled)
+        if low_rank_rank is not None:
+            precond_pos_for_damping = jax.vmap(_low_rank_precondition_pos)(
+                flat_folded_pos, fold_sigma, fold_U, fold_lam
+            )
+            # fold k's momentum metric is fold (k-1)'s low-rank estimate,
+            # mirroring scales_rolled above.
+            low_rank_sigma_rolled = jnp.roll(fold_sigma, 1, axis=0)
+            low_rank_U_rolled = jnp.roll(fold_U, 1, axis=0)
+            low_rank_lam_rolled = jnp.roll(fold_lam, 1, axis=0)
+        else:
+            precond_pos_for_damping = precond_pos
+        alphas, deltas = jax.vmap(fold_damping)(
+            precond_pos_for_damping, step_size_rolled
+        )
 
         # Broadcast per-fold parameters to per-chain arrays
         chain_step_sizes = jnp.repeat(step_size_rolled, n_per_fold)
@@ -344,13 +465,26 @@ def meads_adaptation(
         chain_alphas = jnp.repeat(alphas, n_per_fold)
         chain_deltas = jnp.repeat(deltas, n_per_fold)
 
+        if low_rank_rank is not None:
+            # Feed ghmc a per-chain LowRankInverseMassMatrix instead of the
+            # diagonal chain_scales; blackjax#950 lets ghmc's
+            # momentum_inverse_scale accept this directly (no elementwise
+            # squaring, unlike the legacy diagonal path).
+            chain_momentum_inverse_scale = LowRankInverseMassMatrix(
+                sigma=jnp.repeat(low_rank_sigma_rolled, n_per_fold, axis=0),
+                U=jnp.repeat(low_rank_U_rolled, n_per_fold, axis=0),
+                lam=jnp.repeat(low_rank_lam_rolled, n_per_fold, axis=0),
+            )
+        else:
+            chain_momentum_inverse_scale = chain_scales
+
         # Step all chains with their fold's parameters
         new_states, info = jax.vmap(ghmc_kernel, in_axes=(0, 0, None, 0, 0, 0, 0))(
             chain_keys,
             states,
             logdensity_fn,
             chain_step_sizes,
-            chain_scales,
+            chain_momentum_inverse_scale,
             chain_alphas,
             chain_deltas,
         )
@@ -406,12 +540,35 @@ def meads_adaptation(
             one_step, (init_states, init_adaptation_state), keys
         )
 
+        if low_rank_rank is not None:
+            # Re-estimate the metric returned to the caller from the full
+            # final population (num_chains chains), rather than averaging the
+            # per-fold eigenbases used internally during warmup: unlike a
+            # diagonal sigma, per-fold (U, lam) eigenpairs have no canonical
+            # cross-fold alignment, so an elementwise average across folds
+            # would not be meaningful. Using the full population also gives a
+            # richer, less noisy estimate (num_chains samples instead of
+            # n_per_fold), hence the looser clamp (num_chains - 1) than the
+            # per-fold one (n_per_fold - 1) used above during warmup.
+            flat_final_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(
+                last_states.position
+            )
+            final_k = min(low_rank_rank, num_chains - 1)
+            final_sigma, final_U, final_lam, _ = _extract_lrd_from_samples(
+                flat_final_pos, k=final_k
+            )
+            momentum_inverse_scale = LowRankInverseMassMatrix(
+                sigma=final_sigma, U=final_U, lam=final_lam
+            )
+        else:
+            momentum_inverse_scale = jax.tree.map(
+                lambda s: s.mean(axis=0), last_adaptation_state.position_sigma
+            )
+
         # Return mean parameters across folds for use with a single ghmc kernel
         parameters = {
             "step_size": last_adaptation_state.step_size.mean(),
-            "momentum_inverse_scale": jax.tree.map(
-                lambda s: s.mean(axis=0), last_adaptation_state.position_sigma
-            ),
+            "momentum_inverse_scale": momentum_inverse_scale,
             "alpha": last_adaptation_state.alpha.mean(),
             "delta": last_adaptation_state.delta.mean(),
         }

--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -297,20 +297,30 @@ def meads_adaptation(
         *diagonal* momentum metric from the fold ensemble -- exactly the
         original behavior, bit-for-bit. An ``int`` instead adapts a
         rank-``low_rank_rank`` :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`
-        from the fold ensemble (requires :func:`blackjax.mcmc.ghmc`'s
-        dense/low-rank momentum-metric support, blackjax#950), generalizing
-        MEADS the way MCLMC-LRD generalized MCLMC. Each fold only has
-        ``num_chains // num_folds`` chains, so the *internal* per-fold
-        estimate that drives the step-size/damping heuristics during warmup
-        is clamped to rank ``num_chains // num_folds - 1`` (a fold's ensemble
-        cannot span a higher rank than that -- raises ``ValueError`` if this
-        would be < 1). The metric ultimately *returned* by ``run()`` is
-        instead re-estimated once from the full final population of all
-        ``num_chains`` chains (clamped to ``num_chains - 1``): a richer,
-        less noisy estimate than any single fold's, and one that sidesteps
-        averaging per-fold eigenbases together -- unlike a diagonal scale,
-        per-fold eigenvectors have no canonical cross-fold alignment, so an
-        elementwise average across folds would not be meaningful.
+        from the **full population of all ``num_chains`` chains** (requires
+        :func:`blackjax.mcmc.ghmc`'s dense/low-rank momentum-metric support,
+        blackjax#950), generalizing MEADS the way MCLMC-LRD generalized
+        MCLMC. Unlike the diagonal scale (estimated per-fold, from each
+        fold's own ``num_chains // num_folds`` chains), the low-rank
+        eigenbasis is estimated *once per step* from the pooled global
+        population and then shared across all folds: a single fold's
+        ensemble (paper default ``num_folds=4`` gives only 16 chains/fold)
+        is too small for its top-k eigenvectors to be stable step-to-step,
+        and the resulting jitter destabilizes ghmc's persistent momentum
+        (measured regression: low-rank underperformed diagonal at
+        ``num_folds=4`` despite beating it at ``num_folds=1``, where the
+        per-fold estimate happens to already be the global one). The metric
+        is a shared symmetric preconditioner, not a per-fold statistic like
+        step size or damping, so pooling all chains to estimate it needs no
+        special justification -- it is the same practice window adaptation
+        uses for its diagonal/dense metric. The per-fold step-size and
+        damping heuristics (Algorithm 3) are otherwise unchanged, except they
+        now whiten by this shared global metric rather than a per-fold one,
+        so they stay consistent with the metric ghmc actually samples with.
+        The rank is clamped to ``num_chains - 1`` (raises ``ValueError`` if
+        this would be < 1). The metric *returned* by ``run()`` is estimated
+        the same way, once more from the final population after the last
+        step.
 
     Returns
     -------
@@ -335,14 +345,13 @@ def meads_adaptation(
                 "momentum-metric support (blackjax#950); the installed ghmc "
                 "module predates it."
             )
-        low_rank_k = min(low_rank_rank, n_per_fold - 1)
+        low_rank_k = min(low_rank_rank, num_chains - 1)
         if low_rank_k < 1:
             raise ValueError(
-                f"low_rank_rank={low_rank_rank} cannot be honored: each fold "
-                f"only has n_per_fold = num_chains // num_folds = {n_per_fold} "
-                "chains, and the per-fold low-rank estimate needs "
-                "n_per_fold - 1 >= 1. Increase num_chains or decrease "
-                "num_folds."
+                f"low_rank_rank={low_rank_rank} cannot be honored: the "
+                f"low-rank metric is estimated from the full population of "
+                f"num_chains={num_chains} chains, and that estimate needs "
+                "num_chains - 1 >= 1. Increase num_chains."
             )
 
     ghmc_kernel = mcmc.ghmc.build_kernel()
@@ -377,27 +386,37 @@ def meads_adaptation(
             folded_scales,
         )
 
-        # MEADS-LRD: each fold additionally estimates its own rank-`low_rank_k`
-        # correlation eigenbasis (sigma, U, lam) from its own n_per_fold
-        # position snapshot, via the same sample-based extractor MCLMC-LRD
-        # uses (`_extract_lrd_from_samples`). This low-rank metric -- not
-        # just its diagonal sigma -- then preconditions the step-size and
-        # damping heuristics below (via `_low_rank_precondition_{grad,pos}`),
-        # so alpha/delta/step_size stay consistent with the metric actually
+        # MEADS-LRD: estimate ONE rank-`low_rank_k` correlation eigenbasis
+        # (sigma, U, lam) per step from the FULL population of all
+        # num_chains chains, via the same sample-based extractor MCLMC-LRD
+        # uses (`_extract_lrd_from_samples`) -- NOT from each fold's own
+        # noisy n_per_fold snapshot. A fold's ensemble is too small (paper
+        # default n_per_fold=16) for its top-k eigenvectors to be stable
+        # step-to-step; the resulting eigenvector jitter destabilizes ghmc's
+        # persistent momentum. The metric is a shared symmetric
+        # preconditioner (unlike step-size/damping, which stay genuinely
+        # per-fold below), so pooling all chains to estimate it needs no
+        # per-fold isolation -- the same practice window adaptation uses for
+        # its diagonal/dense metric. This low-rank metric -- not just its
+        # diagonal sigma -- then preconditions the step-size and damping
+        # heuristics below (via `_low_rank_precondition_{grad,pos}`), so
+        # alpha/delta/step_size stay consistent with the metric actually
         # handed to ghmc for sampling this step.
         if low_rank_rank is not None:
-            flat_folded_pos = jax.vmap(jax.vmap(lambda p: ravel_pytree(p)[0]))(
-                folded_pos
+            flat_all_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(states.position)
+            flat_all_grads = jax.vmap(lambda g: ravel_pytree(g)[0])(
+                states.logdensity_grad
             )
-            flat_folded_grads = jax.vmap(jax.vmap(lambda g: ravel_pytree(g)[0]))(
-                folded_grads
+            d = flat_all_pos.shape[-1]
+            flat_folded_pos = flat_all_pos.reshape((num_folds, n_per_fold, d))
+            flat_folded_grads = flat_all_grads.reshape((num_folds, n_per_fold, d))
+
+            global_sigma, global_U, global_lam, _ = _extract_lrd_from_samples(
+                flat_all_pos, k=low_rank_k
             )
-            fold_sigma, fold_U, fold_lam, _ = jax.vmap(
-                lambda flat: _extract_lrd_from_samples(flat, k=low_rank_k)
-            )(flat_folded_pos)
-            precond_grads_for_step_size = jax.vmap(_low_rank_precondition_grad)(
-                flat_folded_grads, fold_sigma, fold_U, fold_lam
-            )
+            precond_grads_for_step_size = jax.vmap(
+                _low_rank_precondition_grad, in_axes=(0, None, None, None)
+            )(flat_folded_grads, global_sigma, global_U, global_lam)
         else:
             precond_grads_for_step_size = precond_grads
 
@@ -443,14 +462,14 @@ def meads_adaptation(
             folded_scales,
         )
         if low_rank_rank is not None:
-            precond_pos_for_damping = jax.vmap(_low_rank_precondition_pos)(
-                flat_folded_pos, fold_sigma, fold_U, fold_lam
-            )
-            # fold k's momentum metric is fold (k-1)'s low-rank estimate,
-            # mirroring scales_rolled above.
-            low_rank_sigma_rolled = jnp.roll(fold_sigma, 1, axis=0)
-            low_rank_U_rolled = jnp.roll(fold_U, 1, axis=0)
-            low_rank_lam_rolled = jnp.roll(fold_lam, 1, axis=0)
+            # Same shared global (sigma, U, lam) as the step-size block above
+            # -- broadcast across folds (in_axes=None), not rolled: unlike
+            # the per-fold diagonal scale, there is only one metric this
+            # step, so every fold whitens by (and every chain samples with)
+            # the same eigenbasis.
+            precond_pos_for_damping = jax.vmap(
+                _low_rank_precondition_pos, in_axes=(0, None, None, None)
+            )(flat_folded_pos, global_sigma, global_U, global_lam)
         else:
             precond_pos_for_damping = precond_pos
         alphas, deltas = jax.vmap(fold_damping)(
@@ -466,14 +485,15 @@ def meads_adaptation(
         chain_deltas = jnp.repeat(deltas, n_per_fold)
 
         if low_rank_rank is not None:
-            # Feed ghmc a per-chain LowRankInverseMassMatrix instead of the
-            # diagonal chain_scales; blackjax#950 lets ghmc's
-            # momentum_inverse_scale accept this directly (no elementwise
-            # squaring, unlike the legacy diagonal path).
+            # Feed ghmc the SAME global LowRankInverseMassMatrix for every
+            # chain (no per-fold rolling -- there is only one metric this
+            # step); blackjax#950 lets ghmc's momentum_inverse_scale accept
+            # this directly (no elementwise squaring, unlike the legacy
+            # diagonal path).
             chain_momentum_inverse_scale = LowRankInverseMassMatrix(
-                sigma=jnp.repeat(low_rank_sigma_rolled, n_per_fold, axis=0),
-                U=jnp.repeat(low_rank_U_rolled, n_per_fold, axis=0),
-                lam=jnp.repeat(low_rank_lam_rolled, n_per_fold, axis=0),
+                sigma=jnp.repeat(global_sigma[None], num_chains, axis=0),
+                U=jnp.repeat(global_U[None], num_chains, axis=0),
+                lam=jnp.repeat(global_lam[None], num_chains, axis=0),
             )
         else:
             chain_momentum_inverse_scale = chain_scales
@@ -542,20 +562,19 @@ def meads_adaptation(
 
         if low_rank_rank is not None:
             # Re-estimate the metric returned to the caller from the full
-            # final population (num_chains chains), rather than averaging the
-            # per-fold eigenbases used internally during warmup: unlike a
-            # diagonal sigma, per-fold (U, lam) eigenpairs have no canonical
-            # cross-fold alignment, so an elementwise average across folds
-            # would not be meaningful. Using the full population also gives a
-            # richer, less noisy estimate (num_chains samples instead of
-            # n_per_fold), hence the looser clamp (num_chains - 1) than the
-            # per-fold one (n_per_fold - 1) used above during warmup.
+            # final population (num_chains chains, after the last step) --
+            # the same global-population estimator `one_step` already uses
+            # per-step, so this is a fresh draw of the same estimate rather
+            # than a different scheme. `low_rank_k` (== min(low_rank_rank,
+            # num_chains - 1)) is reused unchanged from above.
             flat_final_pos = jax.vmap(lambda p: ravel_pytree(p)[0])(
                 last_states.position
             )
-            final_k = min(low_rank_rank, num_chains - 1)
+            # low_rank_k is set to a non-None int whenever low_rank_rank is
+            # not None (validated above); assert narrows it for mypy.
+            assert low_rank_k is not None
             final_sigma, final_U, final_lam, _ = _extract_lrd_from_samples(
-                flat_final_pos, k=final_k
+                flat_final_pos, k=low_rank_k
             )
             momentum_inverse_scale = LowRankInverseMassMatrix(
                 sigma=final_sigma, U=final_U, lam=final_lam

--- a/tests/adaptation/test_meads.py
+++ b/tests/adaptation/test_meads.py
@@ -7,6 +7,7 @@ import pytest
 
 import blackjax
 from blackjax.adaptation.meads_adaptation import MEADSAdaptationState, base
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.fixtures import BlackJAXTest
 
 
@@ -246,3 +247,130 @@ class TestMEADSAdaptation(BlackJAXTest):
         self.assertEqual(new_states.position.shape, (num_chains, dim))
         # Acceptance rates should be finite
         self.assertTrue(jnp.all(jnp.isfinite(new_states.logdensity)))
+
+
+def make_correlated_pair_logdensity(dim, rho=0.9):
+    """Target with a genuine rank-2 correlation structure: dims 0-1 have
+    correlation ``rho`` (a valid, unit-diagonal correlation matrix), the rest
+    are independent -- exactly the structure a low-rank momentum metric is
+    meant to capture.
+    """
+    C = jnp.eye(dim)
+    C = C.at[0, 1].set(rho)
+    C = C.at[1, 0].set(rho)
+    precision = jnp.linalg.inv(C)
+
+    def logdensity(x):
+        return -0.5 * x @ precision @ x
+
+    return logdensity
+
+
+class TestMEADSLowRank(BlackJAXTest):
+    """Tests for the MEADS-LRD low-rank momentum-metric extension
+    (``low_rank_rank``)."""
+
+    def _make_correlated_problem(self, num_chains=32, dim=6, rho=0.9):
+        logdensity = make_correlated_pair_logdensity(dim, rho)
+        positions = jax.random.normal(self.next_key(), (num_chains, dim))
+        return logdensity, positions
+
+    def test_low_rank_rank_none_matches_diagonal_bit_for_bit(self):
+        """low_rank_rank=None must be numerically identical to omitting it."""
+        num_chains, dim = 16, 3
+        logdensity = make_logdensity(dim)
+        positions = jax.random.normal(self.next_key(), (num_chains, dim))
+        key = self.next_key()
+
+        warmup_default = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=4
+        )
+        warmup_explicit_none = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=4, low_rank_rank=None
+        )
+        (states1, params1), _ = warmup_default.run(key, positions, num_steps=10)
+        (states2, params2), _ = warmup_explicit_none.run(key, positions, num_steps=10)
+
+        np.testing.assert_array_equal(states1.position, states2.position)
+        np.testing.assert_array_equal(
+            params1["momentum_inverse_scale"], params2["momentum_inverse_scale"]
+        )
+        self.assertEqual(params1["step_size"], params2["step_size"])
+
+    def test_low_rank_produces_valid_metric(self):
+        """low_rank_rank=k should return a well-formed LowRankInverseMassMatrix."""
+        num_chains, num_folds, dim = 32, 4, 6
+        logdensity, positions = self._make_correlated_problem(num_chains, dim)
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=3
+        )
+        (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=20)
+
+        mis = params["momentum_inverse_scale"]
+        self.assertIsInstance(mis, LowRankInverseMassMatrix)
+        self.assertEqual(mis.sigma.shape, (dim,))
+        # The FINAL metric is re-estimated from the full num_chains population
+        # (clamp num_chains - 1), richer than the num_folds - 1 clamp used
+        # for the internal per-fold warmup heuristic -- see meads_adaptation's
+        # docstring.
+        expected_k = min(3, num_chains - 1)
+        self.assertEqual(mis.U.shape, (dim, expected_k))
+        self.assertEqual(mis.lam.shape, (expected_k,))
+        self.assertTrue(jnp.all(jnp.isfinite(mis.sigma)))
+        self.assertTrue(jnp.all(jnp.isfinite(mis.U)))
+        self.assertTrue(jnp.all(jnp.isfinite(mis.lam)))
+        self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))
+
+        # U should have (numerically) orthonormal columns.
+        gram = mis.U.T @ mis.U
+        np.testing.assert_allclose(gram, jnp.eye(expected_k), atol=1e-4)
+
+    def test_low_rank_end_to_end_sampling_no_nan(self):
+        """Sampling with the returned low-rank metric should produce finite draws."""
+        num_chains, num_folds, dim = 32, 4, 6
+        logdensity, positions = self._make_correlated_problem(num_chains, dim)
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=3
+        )
+        (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=20)
+
+        ghmc = blackjax.ghmc(logdensity, **params)
+        step = jax.jit(jax.vmap(ghmc.step))
+        keys = jax.random.split(self.next_key(), num_chains)
+        new_states, info = step(keys, last_states)
+
+        self.assertEqual(new_states.position.shape, (num_chains, dim))
+        self.assertTrue(jnp.all(jnp.isfinite(new_states.position)))
+        self.assertTrue(jnp.all(jnp.isfinite(new_states.logdensity)))
+
+    def test_low_rank_rank_clamped_to_n_per_fold_minus_one(self):
+        """n_per_fold - 1 == 1 here; low_rank_rank=1 is exactly reachable and
+        should run without error."""
+        num_chains, num_folds, dim = 8, 4, 3  # n_per_fold = 2
+        logdensity, positions = self._make_correlated_problem(num_chains, dim)
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=1
+        )
+        (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=5)
+        self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))
+
+    def test_low_rank_rank_unreachable_for_folds_raises(self):
+        """n_per_fold=1 (num_chains == num_folds) can't support any per-fold
+        low-rank estimate (n_per_fold - 1 == 0): must raise ValueError."""
+        with pytest.raises(ValueError, match="low_rank_rank"):
+            blackjax.meads_adaptation(
+                make_logdensity(dim=3),
+                num_chains=4,
+                num_folds=4,
+                low_rank_rank=1,
+            )
+
+    def test_low_rank_requires_ghmc_dense_metric_support(self):
+        """Sanity: the module used here does carry blackjax#950's helper (the
+        prerequisite this extension is built on)."""
+        self.assertTrue(
+            hasattr(blackjax.mcmc.ghmc, "_metric_from_momentum_inverse_scale")
+        )

--- a/tests/adaptation/test_meads.py
+++ b/tests/adaptation/test_meads.py
@@ -6,7 +6,13 @@ import numpy as np
 import pytest
 
 import blackjax
-from blackjax.adaptation.meads_adaptation import MEADSAdaptationState, base
+from blackjax.adaptation.meads_adaptation import (
+    _LRD_EIGENVALUE_FLOOR,
+    MEADSAdaptationState,
+    _lrd_accumulator_init,
+    _lrd_accumulator_update,
+    base,
+)
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.fixtures import BlackJAXTest
 
@@ -375,3 +381,118 @@ class TestMEADSLowRank(BlackJAXTest):
         self.assertTrue(
             hasattr(blackjax.mcmc.ghmc, "_metric_from_momentum_inverse_scale")
         )
+
+
+class TestMEADSLowRankHighDimFixes(BlackJAXTest):
+    """Tests for the MEADS-LRD high-dimension (d >> num_chains) fixes: the
+    window-accumulated covariance (FIX 1), the step-size/low-rank-metric
+    decouple (FIX 2), and the eigenvalue floor (FIX 3)."""
+
+    def test_invalid_low_rank_window_fraction(self):
+        """low_rank_window_fraction must be in [0.0, 1.0]."""
+        with pytest.raises(ValueError, match="low_rank_window_fraction"):
+            blackjax.meads_adaptation(
+                make_logdensity(dim=3),
+                num_chains=8,
+                num_folds=4,
+                low_rank_rank=1,
+                low_rank_window_fraction=1.5,
+            )
+        with pytest.raises(ValueError, match="low_rank_window_fraction"):
+            blackjax.meads_adaptation(
+                make_logdensity(dim=3),
+                num_chains=8,
+                num_folds=4,
+                low_rank_rank=1,
+                low_rank_window_fraction=-0.1,
+            )
+
+    def test_accumulator_matches_naive_batch_covariance(self):
+        """FIX 1: the Chan/Welford merge must reproduce the naive covariance
+        of the concatenated batches, with effective n = the sum of the batch
+        sizes -- i.e. num_chains * window_steps once wired into
+        meads_adaptation, rather than a single num_chains-sized snapshot."""
+        key = self.next_key()
+        d, n_b, num_batches = 5, 8, 4
+        batches = jax.random.normal(key, (num_batches, n_b, d))
+
+        acc = _lrd_accumulator_init(d)
+        for b in range(num_batches):
+            acc = _lrd_accumulator_update(acc, batches[b])
+
+        self.assertEqual(float(acc.count), n_b * num_batches)
+        self.assertGreater(float(acc.count), n_b)  # eff n > a single snapshot
+
+        all_samples = batches.reshape(-1, d)
+        naive_cov = jnp.cov(all_samples, rowvar=False)
+        accumulated_cov = acc.m2 / (acc.count - 1.0)
+        np.testing.assert_allclose(accumulated_cov, naive_cov, atol=1e-5, rtol=1e-5)
+
+    def test_step_size_independent_of_low_rank_metric(self):
+        """FIX 2 (ε-decouple): the step size after one warmup step must be
+        bit-for-bit identical whether low_rank_rank is None or set. It is
+        computed purely from the pre-step diagonal-preconditioned gradients
+        (identical in both configs at step 0), never from the low-rank
+        metric."""
+        num_chains, num_folds, dim = 16, 4, 6
+        logdensity = make_correlated_pair_logdensity(dim, rho=0.9)
+        positions = jax.random.normal(self.next_key(), (num_chains, dim))
+        key = self.next_key()
+
+        warmup_diag = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds
+        )
+        warmup_lrd = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=3
+        )
+        (_, params_diag), _ = warmup_diag.run(key, positions, num_steps=1)
+        (_, params_lrd), _ = warmup_lrd.run(key, positions, num_steps=1)
+
+        np.testing.assert_array_equal(params_diag["step_size"], params_lrd["step_size"])
+
+    def test_low_rank_floors_degenerate_eigenvalues_collinear_init(self):
+        """FIX 3: a collinear (rank-1) initial ensemble -- tuningfork's
+        canonical init -- must not produce a degenerate low-rank metric that
+        could self-reinforce into a metric collapse."""
+        num_chains, num_folds, dim = 32, 4, 6
+        logdensity = make_correlated_pair_logdensity(dim, rho=0.9)
+
+        direction = jax.random.normal(self.next_key(), (dim,))
+        direction = direction / jnp.linalg.norm(direction)
+        scalars = jax.random.normal(self.next_key(), (num_chains,))
+        positions = scalars[:, None] * direction[None, :]  # exactly rank-1
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=3
+        )
+        (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=20)
+
+        mis = params["momentum_inverse_scale"]
+        self.assertTrue(jnp.all(mis.lam >= _LRD_EIGENVALUE_FLOOR))
+        self.assertTrue(jnp.all(jnp.isfinite(mis.lam)))
+        self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))
+
+    def test_low_rank_higher_dim_no_step_size_collapse(self):
+        """Regression guard at d larger than num_chains: window accumulation
+        (FIX 1) plus the ε-decouple (FIX 2) must keep the step size in a
+        sane, non-collapsed range -- this is the failure mode a single,
+        p >> n snapshot caused (measured on the real radon model: ~20x
+        collapse). A smaller synthetic analogue here for test speed."""
+        num_chains, num_folds, dim = 32, 4, 40
+        direction = jax.random.normal(jax.random.key(0), (dim,))
+        direction = direction / jnp.linalg.norm(direction)
+
+        def logdensity(x):
+            proj = x @ direction
+            return -0.5 * jnp.sum(x**2) - 0.5 * 24.0 * proj**2
+
+        positions = jax.random.normal(self.next_key(), (num_chains, dim))
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=10
+        )
+        (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=60)
+
+        self.assertGreater(float(params["step_size"]), 1e-2)
+        self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))
+        self.assertTrue(jnp.all(jnp.isfinite(params["momentum_inverse_scale"].lam)))

--- a/tests/adaptation/test_meads.py
+++ b/tests/adaptation/test_meads.py
@@ -496,3 +496,52 @@ class TestMEADSLowRankHighDimFixes(BlackJAXTest):
         self.assertGreater(float(params["step_size"]), 1e-2)
         self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))
         self.assertTrue(jnp.all(jnp.isfinite(params["momentum_inverse_scale"].lam)))
+
+    def test_low_rank_metric_captures_correlated_subspace(self):
+        """Deterministic guard: the low-rank metric's leading eigenvector must
+        capture the correlated subspace. This test guards the feature's value
+        proposition -- a metric silently degraded to uninformative passes all
+        other tests. On the make_correlated_pair_logdensity fixture (correlated
+        pair lives in span{e0, e1}), the leading eigenvector's energy in the
+        correlated subspace must be substantial."""
+        num_chains, num_folds, dim = 32, 4, 6
+        logdensity = make_correlated_pair_logdensity(dim, rho=0.9)
+        # Use a fixed seed for determinism
+        positions = jax.random.normal(jax.random.key(42), (num_chains, dim))
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=2
+        )
+        (last_states, params), _ = warmup.run(
+            jax.random.key(42), positions, num_steps=40
+        )
+
+        mis = params["momentum_inverse_scale"]
+        # The leading eigenvector is column 0 of U (if columns are sorted by |lam - 1|).
+        # Compute energy in the correlated subspace: sqrt(U[0,0]^2 + U[1,0]^2).
+        energy_in_correlated_subspace = jnp.sqrt(mis.U[0, 0] ** 2 + mis.U[1, 0] ** 2)
+        self.assertGreater(
+            float(energy_in_correlated_subspace),
+            0.5,
+            "Leading eigenvector does not capture the correlated subspace",
+        )
+
+    def test_low_rank_rank_clamped_to_dimension(self):
+        """Regression test: low_rank_rank > d must be clamped to d to prevent
+        shape disagreements in jax.lax.cond branches. With low_rank_rank=7
+        on a d=6 target with num_chains=32, the metric must run without error
+        and yield U with min(k, d)=6 columns."""
+        num_chains, num_folds, dim = 32, 4, 6
+        logdensity = make_correlated_pair_logdensity(dim, rho=0.9)
+        positions = jax.random.normal(self.next_key(), (num_chains, dim))
+
+        warmup = blackjax.meads_adaptation(
+            logdensity, num_chains=num_chains, num_folds=num_folds, low_rank_rank=7
+        )
+        (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=20)
+
+        mis = params["momentum_inverse_scale"]
+        # Rank should be clamped to min(7, num_chains-1, d) = min(7, 31, 6) = 6
+        expected_k = min(7, num_chains - 1, dim)
+        self.assertEqual(mis.U.shape, (dim, expected_k))
+        self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))

--- a/tests/adaptation/test_meads.py
+++ b/tests/adaptation/test_meads.py
@@ -310,10 +310,9 @@ class TestMEADSLowRank(BlackJAXTest):
         mis = params["momentum_inverse_scale"]
         self.assertIsInstance(mis, LowRankInverseMassMatrix)
         self.assertEqual(mis.sigma.shape, (dim,))
-        # The FINAL metric is re-estimated from the full num_chains population
-        # (clamp num_chains - 1), richer than the num_folds - 1 clamp used
-        # for the internal per-fold warmup heuristic -- see meads_adaptation's
-        # docstring.
+        # Both the per-step warmup metric and the FINAL metric are estimated
+        # from the full num_chains population (clamp num_chains - 1) -- see
+        # meads_adaptation's docstring.
         expected_k = min(3, num_chains - 1)
         self.assertEqual(mis.U.shape, (dim, expected_k))
         self.assertEqual(mis.lam.shape, (expected_k,))
@@ -345,10 +344,11 @@ class TestMEADSLowRank(BlackJAXTest):
         self.assertTrue(jnp.all(jnp.isfinite(new_states.position)))
         self.assertTrue(jnp.all(jnp.isfinite(new_states.logdensity)))
 
-    def test_low_rank_rank_clamped_to_n_per_fold_minus_one(self):
-        """n_per_fold - 1 == 1 here; low_rank_rank=1 is exactly reachable and
-        should run without error."""
-        num_chains, num_folds, dim = 8, 4, 3  # n_per_fold = 2
+    def test_low_rank_rank_clamped_to_num_chains_minus_one(self):
+        """The metric is estimated from the full population, so the clamp is
+        num_chains - 1 (not n_per_fold - 1): low_rank_rank=1 is reachable
+        even with a small per-fold ensemble (n_per_fold=2 here)."""
+        num_chains, num_folds, dim = 8, 4, 3  # n_per_fold = 2, num_chains - 1 = 7
         logdensity, positions = self._make_correlated_problem(num_chains, dim)
 
         warmup = blackjax.meads_adaptation(
@@ -357,14 +357,15 @@ class TestMEADSLowRank(BlackJAXTest):
         (last_states, params), _ = warmup.run(self.next_key(), positions, num_steps=5)
         self.assertTrue(jnp.all(jnp.isfinite(last_states.position)))
 
-    def test_low_rank_rank_unreachable_for_folds_raises(self):
-        """n_per_fold=1 (num_chains == num_folds) can't support any per-fold
-        low-rank estimate (n_per_fold - 1 == 0): must raise ValueError."""
+    def test_low_rank_rank_unreachable_for_single_chain_raises(self):
+        """The low-rank metric is estimated from the full num_chains
+        population, so it's unreachable only when num_chains - 1 < 1, i.e.
+        num_chains == 1: must raise ValueError."""
         with pytest.raises(ValueError, match="low_rank_rank"):
             blackjax.meads_adaptation(
                 make_logdensity(dim=3),
-                num_chains=4,
-                num_folds=4,
+                num_chains=1,
+                num_folds=1,
                 low_rank_rank=1,
             )
 


### PR DESCRIPTION
## What

**MEADS-LRD**: an opt-in low-rank momentum metric for `meads_adaptation` — `low_rank_rank: int | None = None`. When set, MEADS estimates a rank-k `LowRankInverseMassMatrix` from its chain population (via a windowed Welford covariance) and drives ghmc with it, instead of the diagonal `momentum_inverse_scale`. `None` (default) is the existing diagonal behavior, **bit-for-bit** (verified against the merge-base through the public API, float32 and x64; all 13 pre-existing MEADS tests unchanged).

Builds on #950 (ghmc accepts dense/low-rank metrics). The generalized-HMC analog of the MCLMC-LRD warmup: extract a low-rank metric from the sampler's own ensemble, using sample-covariance estimation (NOT the gradient/Fisher estimator).

## Why

Single-step ghmc's mixing is bottlenecked by metric conditioning in a way NUTS is not: NUTS's long adaptive trajectories absorb residual anisotropy that a diagonal metric leaves behind; a single leapfrog step cannot. An isolation study (offline {diagonal, low-rank, dense} metrics from ground-truth draws, two independent statistician runs) showed a good low-rank metric at k≪d matches dense and rescues correlated targets where MEADS's diagonal catastrophically fails — and that low-rank can *beat* dense at high d (dense over-fits finite-sample covariance noise).

## Design (validated component-by-component)

1. **Windowed population covariance** — the metric is estimated from a Welford running covariance over the *late* half of warmup (`low_rank_window_fraction=0.5`), pooling all `num_chains` chains × window steps. Below `2·d` accumulated support it falls back to pure-diagonal (lam=1, identical to `low_rank_rank=None` dynamics) — a single-step ensemble snapshot at `n_chains < d` is noise-dominated and *worse* than diagonal (measured; this gating is load-bearing for high-d quality).
2. **Step-size decoupling** — the ε heuristic (Algorithm 3 line 8) always whitens by the per-fold *diagonal* scale, never the low-rank metric. Coupling the low-rank metric into `maximum_eigenvalue` collapses ε at d≫n_chains (measured 20.6× collapse on a d=390 target). Unconditionally bias-free (GHMC's MH correction); empirically conservative on every cell run.
3. **Eigenvalue floor** (`max(lam, 1e-6)`) — clamps near-zero and float32-`eigh`-negative eigenvalues. **The floor and the step-size decoupling are two redundant guards on the same NaN path**: a degenerate (e.g. collinear rank-1) initial ensemble produces the σ-frozen collapse (`rhat=inf`, NaN step) only if *both* guards are defeated — verified by a 4-config isolation in the adversarial review.
4. **Rank clamp** — `k = min(low_rank_rank, num_chains−1, d)`; the d-clamp is lossless (a rank-d correction is already the full metric) and removes a trace-time shape error for `rank > d`.

## Validation (end-to-end on real posteriors, canonical seeds, gate = R̂/ESS/divergences/mean-z-vs-ground-truth)

- **Correlated low-d (Lotka-Volterra ODE posterior, d=7):** diagonal MEADS FAILs (min-ESS ≈ 32); MEADS-LRD k=5–6 **PASSes** (min-ESS ≈ 410–450, unbiased) — ~13× ESS. *Provenance note: measured with GT-initialized ensembles on the pre-hardening commit (the fixes are opt-in-path refinements that do not touch that configuration); post-hardening low-d confirmation is synthetic (d=15: 3.65× min-ESS).*
- **High-d (radon, d=390):** with `num_chains=256`, k=40: LRD ≥ diagonal on every metric (R̂ 1.079 vs 1.175, min-ESS 37 vs 18, mean-z 3.31 vs 3.55, z within the reference band). The windowed estimate de-biases as designed (nc=128 → z-biased; nc=256, eff-n ≫ 2d → unbiased). Remaining under-mixing traces to warmup length / single-step trajectory budget — orthogonal to the metric (a *perfect* dense metric from 20k GT draws doesn't clear the gate there either).
- **Funnels (irt_2pl):** still FAILs, by design expectation — no constant metric whitens position-dependent curvature. Out of scope.
- **Tests: 26 pass** (13 pre-existing + 13 new), including a **deterministic metric-subspace-alignment guard** for the feature's value proposition (a metric silently degraded to uninformative directions fails it; alignment ≥0.92 pristine vs ≤0.12 mutated across seeds) and a `rank>d` regression test.

## Review

Adversarially reviewed pre-merge (planted-bug protocol on the test suite, claim-vs-data audit, degenerate-input attacks) + two are-you-sure challenge rounds. Verdict: merge-with-changes, nothing biasing inference; all requested changes applied (`0095fa39`, `6a9c56b0`): rank d-clamp, subspace-alignment test (an ESS-ratio test was considered and rejected as seed-flaky — measured overlap across 5 seeds), collinear-init doc guardrail, dead-code removal.

## Operational guardrails (documented in the docstring)

- **`num_chains ≳ 2·d`** for the windowed estimate to de-bias at high d (else the diagonal fallback engages — safe, not harmful).
- **Use a dispersed, full-rank initial ensemble.** A collinear/near-collinear init (e.g. all chains on a 1-D offset line) does not crash — the redundant guards prevent the NaN collapse — but expect severe under-mixing (measured R̂≈5 on a rank-1 init).
- **k budget should trace to target geometry** (k≈40 for ill-conditioned d≈50–400 class; k≈d−1 when d is small).

## Scope honesty

This makes MEADS competitive on correlated low/moderate-d posteriors and *safe* (never worse than diagonal) at high d — it does **not** make single-step ghmc a NUTS replacement on sharply-curved hierarchies (funnels need reparameterization or multi-step kernels), and full high-d gate-passes additionally need longer warmup budgets. The negative results are documented alongside the wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
