### PR TITLE
ChEES-HMC: opt-in ensemble diagonal metric + metric-consistent criterion + slow-direction trajectory-length floor

### DIFF
--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -238,14 +238,25 @@ def _recompute_eig_state(
 
 
 def _apply_length_floor(
-    trajectory_length: Array, lambda_max: Array, engaged: Array, enable: bool
-) -> Array:
+    trajectory_length: Array,
+    lambda_max: Array,
+    engaged: Array,
+    enable: bool,
+    max_leapfrog_steps: int = 1000,
+    step_size: float = 0.1,
+) -> tuple[Array, Array]:
     """Floor ``trajectory_length`` at
     ``CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max)`` -- the slow-direction
     trajectory-length floor. Applied at CONSUMPTION only: a pure function of
     the already-adapted length and the current ``lambda_max`` estimate,
     never fed back into the ChEES optimizer's own state, so the floor is
-    cleanly ablatable.
+    cleanly ablatable. The consumed length respects the user's budget:
+    ``min(max(adapted, floor), max_leapfrog_steps · step_size)``.
+
+    Returns the consumed trajectory_length and a boolean diagnostic flag
+    ``floor_clipped_by_cap`` (True when the cap binds below the slow-direction
+    floor): if the cap constrains the floor below its floor value, raise
+    ``max_leapfrog_steps`` to restore the guarantee.
 
     ``enable`` (the private ``_length_floor`` seam) is a static Python bool:
     when False, ``trajectory_length`` is returned completely unchanged --
@@ -253,13 +264,24 @@ def _apply_length_floor(
     ``engaged`` (a traced boolean, the SAME support gate as the diagonal
     mass-matrix estimate) makes the floor a no-op before that gate -- pre-
     gate, ``lambda_max`` is not yet a meaningful estimate.
+
+    At the default ``max_leapfrog_steps=1000``, the cap is 1000·step_size, and
+    ``λ_max ≤ d`` for a correlation matrix means the floor can never bind
+    (belt-and-suspenders insurance; ``floor_clipped_by_cap`` will be False).
     """
     if not enable:
-        return trajectory_length
+        return trajectory_length, jnp.asarray(False)
+
     floor_value = jnp.where(
         engaged, CHEES_LENGTH_FLOOR_FACTOR * jnp.sqrt(lambda_max), 0.0
     )
-    return jnp.maximum(trajectory_length, floor_value)
+    cap = max_leapfrog_steps * step_size
+    floored_length = jnp.maximum(trajectory_length, floor_value)
+    consumed_length = jnp.minimum(floored_length, cap)
+    floor_clipped_by_cap = jnp.logical_and(
+        jnp.logical_and(engaged, enable), floor_value > cap
+    )
+    return consumed_length, floor_clipped_by_cap
 
 
 def weighted_empirical_mean(x, w):
@@ -314,9 +336,9 @@ def base(
         ``inverse_mass_matrix`` passed to ``update`` (see the derivation in
         ``compute_parameters``). When False, the criterion is computed exactly
         as the original identity-mass-matrix expression regardless of the
-        ``inverse_mass_matrix`` passed in -- used to validate that the
-        whitening correction (rather than the mass matrix alone) is what
-        fixes ChEES on scale-separated targets.
+        ``inverse_mass_matrix`` passed in -- used in validation studies to
+        isolate the whitening correction's contribution relative to the mass
+        matrix alone.
 
 
     Returns
@@ -688,11 +710,20 @@ def chees_adaptation(
         "Engagement gate" below). ChEES's own trajectory-length criterion is
         also whitened by this estimate so it stays metric-consistent with the
         kernel it is tuning (see the derivation in
-        :func:`base`'s ``compute_parameters``) -- this whitening, not just
-        the mass matrix estimation itself, is required for the feature to
-        help on scale-separated targets: without it, the raw (Euclidean)
-        ChEES criterion is dominated by the largest-variance dimensions
-        regardless of the metric the kernel actually samples with.
+        :func:`base`'s ``compute_parameters``) -- this whitening keeps the
+        criterion metric-consistent and responsive to the preconditioned geometry;
+        measured effect is small (≲12%) on NCP-standardized targets where most
+        dimensions are near unit scale. The feature's main value is delivered by
+        the slow-direction *length floor* (when enabled), which recovers large
+        ESS-per-gradient wins on targets with a residual slow correlation
+        direction the diagonal metric cannot remove.
+
+        **Scope: validated under located (typical-set) initializations.** On
+        funnel-like targets the diagonal metric can *reduce* per-draw ESS
+        relative to the identity metric's fine-step regime (an efficiency caveat,
+        not a bias—posterior means are unaffected); the length floor recovers most
+        of it. Cold or dispersed initialization on hard geometry is a separate
+        warmup-robustness limitation, out of scope for this feature.
 
         Engagement gate: before the pooled accumulator (effective sample
         size ``num_chains * window_steps``) exceeds ``max(64, 2*sqrt(num_dim))``
@@ -846,11 +877,13 @@ def chees_adaptation(
             # the ChEES optimizer's state.
             if enable_length_floor:
                 engaged = mm_accum.sample_size >= mm_engagement_threshold
-                consumed_trajectory_length = _apply_length_floor(
+                consumed_trajectory_length, _ = _apply_length_floor(
                     adaptation_state.trajectory_length,
                     eig_state.lambda_max,
                     engaged,
                     _length_floor,
+                    max_leapfrog_steps,
+                    adaptation_state.step_size,
                 )
             else:
                 consumed_trajectory_length = adaptation_state.trajectory_length
@@ -969,11 +1002,13 @@ def chees_adaptation(
                 last_adaptation_state.log_trajectory_length_moving_average
             )
             step_size_ma = jnp.exp(last_adaptation_state.log_step_size_moving_average)
-            consumed_trajectory_length_ma = _apply_length_floor(
+            consumed_trajectory_length_ma, floor_clipped_by_cap = _apply_length_floor(
                 trajectory_length_ma,
                 final_eig_state.lambda_max,
                 final_engaged,
                 _length_floor,
+                max_leapfrog_steps,
+                float(step_size_ma),
             )
             num_leapfrog_steps = consumed_trajectory_length_ma / step_size_ma
         else:
@@ -981,6 +1016,7 @@ def chees_adaptation(
                 last_adaptation_state.log_trajectory_length_moving_average
                 - last_adaptation_state.log_step_size_moving_average
             )
+            floor_clipped_by_cap = jnp.asarray(False)
 
         parameters = {
             "step_size": jnp.exp(last_adaptation_state.log_step_size_moving_average),
@@ -990,6 +1026,22 @@ def chees_adaptation(
             "integration_steps_params": (num_leapfrog_steps,),
         }
 
-        return AdaptationResults(last_states, parameters), info
+        # Attach floor_clipped_by_cap diagnostic to final info via a transparent
+        # wrapper that delegates to the original info but adds the diagnostic flag
+        # as an additional attribute. This ensures the flag is accessible without
+        # breaking the existing API.
+        class _AdaptationInfoWrapper:
+            """Transparent wrapper for adaptation info with floor diagnostic flag."""
+
+            def __init__(self, info_obj, floor_flag):
+                self._wrapped_info = info_obj
+                self.floor_clipped_by_cap = floor_flag
+
+            def __getattr__(self, name):
+                return getattr(self._wrapped_info, name)
+
+        enriched_info = _AdaptationInfoWrapper(info, floor_clipped_by_cap)
+
+        return AdaptationResults(last_states, parameters), enriched_info
 
     return AdaptationAlgorithm(run)  # type: ignore[arg-type]

--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -11,6 +11,7 @@ import optax
 import blackjax.mcmc.dynamic_hmc as dynamic_hmc
 import blackjax.optimizers.dual_averaging as dual_averaging
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
+from blackjax.adaptation.mass_matrix import welford_algorithm
 from blackjax.base import AdaptationAlgorithm
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 from blackjax.util import pytree_size
@@ -56,6 +57,38 @@ class ChEESAdaptationState(NamedTuple):
     step: int
 
 
+def _mass_matrix_engagement_threshold(num_dim: int) -> int:
+    """Minimum pooled Welford sample count before ``mass_matrix_estimation``'s
+    diagonal estimate engages (see ``chees_adaptation``'s docstring).
+
+    A per-dimension variance estimate, unlike a joint eigenbasis (the
+    ``meads_adaptation`` low-rank case, gated at ``2 * d``), does not need
+    ``O(d)`` samples to escape noise domination -- each dimension is
+    estimated independently. A small constant floor (64) is enough on its
+    own for typical dimensions; the mild ``2 * sqrt(d)`` term only matters
+    for very high-dimensional targets, where it grows the floor slightly.
+    """
+    return max(64, int(2 * np.sqrt(num_dim)))
+
+
+def _diagonal_mass_matrix_or_fallback(mm_accum, threshold: int, num_dim: int) -> Array:
+    """Return the Welford-estimated diagonal ``inverse_mass_matrix`` once
+    ``mm_accum.sample_size`` reaches ``threshold``, otherwise fall back to
+    ``jnp.ones(num_dim)`` -- the pre-estimation / ``mass_matrix_estimation=
+    None`` behavior. Mirrors ``meads_adaptation``'s
+    ``_lrd_diagonal_fallback``/engagement-gate pattern, specialized to the
+    single diagonal (no low-rank) case.
+    """
+    _, _, wc_final = welford_algorithm(is_diagonal_matrix=True)
+    enough = mm_accum.sample_size >= threshold
+    return jax.lax.cond(
+        enough,
+        lambda acc: jnp.maximum(wc_final(acc)[0], EPS_FLOAT),
+        lambda acc: jnp.ones(num_dim),
+        mm_accum,
+    )
+
+
 def weighted_empirical_mean(x, w):
     # x: (num_chains, dim), w: (num_chains,)
     x_safe = jnp.where(jnp.isfinite(x), x, 0.0)
@@ -74,6 +107,7 @@ def base(
     target_acceptance_rate: float,
     decay_rate: float,
     max_leapfrog_steps: int,
+    _whiten_criterion: bool = True,
 ) -> tuple[Callable, Callable]:
     """Maximizing the Change in the Estimator of the Expected Square criterion
     (trajectory length) and dual averaging procedure (step size) for the jittered
@@ -101,6 +135,15 @@ def base(
     decay_rate
         Float representing how much to favor recent iterations over earlier ones in the optimization
         of step size and trajectory length.
+    _whiten_criterion
+        Private, undocumented ablation seam (not part of the public API). When
+        True (default) the ChEES criterion accounts for a non-identity
+        ``inverse_mass_matrix`` passed to ``update`` (see the derivation in
+        ``compute_parameters``). When False, the criterion is computed exactly
+        as the original identity-mass-matrix expression regardless of the
+        ``inverse_mass_matrix`` passed in -- used to validate that the
+        whitening correction (rather than the mass matrix alone) is what
+        fixes ChEES on scale-separated targets.
 
 
     Returns
@@ -121,6 +164,7 @@ def base(
         acceptance_probabilities: Array,
         is_divergent: Array,
         initial_adaptation_state: ChEESAdaptationState,
+        inverse_mass_matrix: Array,
     ) -> ChEESAdaptationState:
         """Compute values for the parameters based on statistics collected from
         multiple chains.
@@ -140,6 +184,13 @@ def base(
             Metropolis-Hastings acceptance probabilty of proposals of every chain.
         initial_adaptation_state:
             ChEES adaptation step used to generate proposals and acceptance probabilities.
+        inverse_mass_matrix:
+            The diagonal ``inverse_mass_matrix`` (Σ) the kernel used to generate this
+            step's proposals -- ``jnp.ones(num_dim)`` unless
+            ``chees_adaptation``'s ``mass_matrix_estimation="diagonal"`` has engaged.
+            Used to whiten the ChEES criterion so it stays metric-consistent with
+            the kernel (see the derivation below). Has no effect when equal to
+            ``jnp.ones(num_dim)``, since the whitening reduces to a no-op there.
 
         Returns
         -------
@@ -198,12 +249,73 @@ def base(
         initials_matrix = vmap_flatten_op(initials_centered)
         momentums_matrix = vmap_flatten_op(proposed_momentums)
 
+        # --- Metric-aware (whitened) ChEES criterion ------------------------
+        # ChEES's trajectory-length gradient is a pathwise-derivative estimator
+        # of d/dL E[||x' - E[x']||^2], built from the product
+        #     (||Δx'||^2 - ||Δx||^2) * <Δx', dx'/dL>
+        # where dx'/dL is proportional to the trajectory's *velocity* at the
+        # endpoint. Under Hamiltonian dynamics with mass matrix M = Σ^-1,
+        # velocity v = M^-1 p = Σp -- this is blackjax's own convention, e.g.
+        # metrics.py's `linear_map(inverse_mass_matrix, momentum)` kinetic-
+        # energy term and the NUTS U-turn check. The pre-existing code below
+        # implicitly assumes M = I (so v == p): that's exactly what TFP's own
+        # implementation comment flags at this spot ("implicitly assumes an
+        # identity mass matrix") -- there is no reference implementation for
+        # the general-M case to copy, hence the derivation here.
+        #
+        # For a general diagonal M, the *norm* term must be measured in the
+        # geometry M induces -- the whitened space x̃ = Σ^{-1/2}x in which the
+        # preconditioned sampler behaves isotropically -- otherwise a handful
+        # of large-variance dimensions dominate ||Δx||^2 and swamp the
+        # trajectory-length signal coming from the well-scaled ones. That is
+        # edit 1: proposals/initials get whitened by Σ^{-1/2} before the dot
+        # products that build the norm difference.
+        #
+        # The <Δx', v'> term needs the SAME whitening transform applied to
+        # velocity: velocity is a tangent vector living in position-space (not
+        # momentum's dual/cotangent space), so under x̃ = Σ^{-1/2}x it
+        # transforms the same way position differences do, i.e.
+        # ṽ = Σ^{-1/2}v -- NOT the contragredient transform momentum itself
+        # would get. That is edit 2, and skipping it is the "silent-bug trap":
+        # reusing the edit-1-whitened Δx' in `jnp.dot(pm, mm)` without also
+        # whitening the velocity leaves a spurious Σ^{-1/2} factor on the
+        # momentum term. Composing both edits explicitly:
+        #     v'  = Σ  p'                (velocity, metrics.py convention)
+        #     ṽ' = Σ^{-1/2} v' = Σ^{1/2} p'   (velocity whitened like position)
+        #     <x̃', ṽ'> = Σ_i (Δx'_i / √Σ_i) · (√Σ_i · p'_i) = Σ_i Δx'_i p'_i
+        #              = <Δx', p'>   (the RAW expression, for *any* diagonal Σ)
+        # This exact cancellation is not a coincidence: Δx' and p' are
+        # canonically conjugate (position, momentum), so their pairing is
+        # metric-invariant -- unlike ||Δx||^2 alone. The code below still
+        # computes both quantities via the explicit whitening transforms
+        # (rather than hand-simplifying to the raw dot product) so that (a)
+        # this derivation is directly checkable against the code and (b) with
+        # Σ = ones every multiply/divide is an IEEE-754 no-op, so the whitened
+        # path is bit-for-bit identical to the original expression -- see
+        # ``test_whitened_criterion_reduces_to_raw_when_identity``.
+        #
+        # `_whiten_criterion=False` (private ablation seam, see `base`'s
+        # docstring) skips both edits and always uses the raw, pre-existing
+        # expression regardless of `inverse_mass_matrix` -- this is the
+        # "naive" arm (kernel uses the estimated diagonal metric, but the
+        # criterion does not) the validation study compares against.
+        if _whiten_criterion:
+            inv_sqrt_imm = 1.0 / jnp.sqrt(inverse_mass_matrix)
+            proposals_matrix_w = proposals_matrix * inv_sqrt_imm
+            initials_matrix_w = initials_matrix * inv_sqrt_imm
+            velocity_matrix = momentums_matrix * inverse_mass_matrix  # v' = Σp'
+            velocity_matrix_w = velocity_matrix * inv_sqrt_imm  # ṽ' = Σ^{-1/2}v'
+        else:
+            proposals_matrix_w = proposals_matrix
+            initials_matrix_w = initials_matrix
+            velocity_matrix_w = momentums_matrix
+
         trajectory_gradients = (
             jitter_generator(random_generator_arg)
             * trajectory_length  # this effectively make this gradient w.r.t. log_trajectory_length
             * jax.vmap(
                 lambda pm, im, mm: (jnp.dot(pm, pm) - jnp.dot(im, im)) * jnp.dot(pm, mm)
-            )(proposals_matrix, initials_matrix, momentums_matrix)
+            )(proposals_matrix_w, initials_matrix_w, velocity_matrix_w)
         )
 
         trajectory_gradient = jnp.sum(
@@ -270,6 +382,7 @@ def base(
         initial_positions: ArrayLikeTree,
         acceptance_probabilities: Array,
         is_divergent: Array,
+        inverse_mass_matrix: Array,
     ):
         """Update the adaptation state and parameter values.
 
@@ -285,6 +398,10 @@ def base(
             The initial position at the start of the HMC algorithm of every chain.
         acceptance_probabilities:
             Metropolis-Hastings acceptance probabilty of proposals of every chain.
+        inverse_mass_matrix:
+            The diagonal ``inverse_mass_matrix`` the kernel used to generate this
+            step's proposals; see ``compute_parameters`` for how it whitens the
+            ChEES criterion.
 
         Returns
         -------
@@ -299,6 +416,7 @@ def base(
             acceptance_probabilities,
             is_divergent,
             adaptation_state,
+            inverse_mass_matrix,
         )
 
         return new_state
@@ -316,6 +434,9 @@ def chees_adaptation(
     decay_rate: float = 0.5,
     max_leapfrog_steps: int = 1000,
     adaptation_info_fn: Callable = return_all_adapt_info,
+    mass_matrix_estimation: str | None = None,
+    mass_matrix_window_fraction: float = 0.5,
+    _whiten_criterion: bool = True,
 ) -> AdaptationAlgorithm:
     """Adapt the step size and trajectory length (number of integration steps / step size)
     parameters of the jittered HMC algorthm.
@@ -380,6 +501,44 @@ def chees_adaptation(
         and get_filter_adapt_info_fn in blackjax.adaptation.base.  By default all
         information is saved - this can result in excessive memory usage if the
         information is unused.
+    mass_matrix_estimation
+        Opt-in ensemble-estimated *diagonal* ``inverse_mass_matrix`` (opt-in,
+        default ``None``). ``None`` keeps the original behavior, bit-for-bit:
+        the kernel always uses ``inverse_mass_matrix=jnp.ones(num_dim)``.
+        ``"diagonal"`` instead estimates a per-dimension variance from the
+        ensemble of all ``num_chains`` chains via a running Welford
+        accumulator (:func:`~blackjax.adaptation.mass_matrix.welford_algorithm`),
+        accumulated over the *last* ``mass_matrix_window_fraction`` of warmup
+        (see that parameter), and uses it as the kernel's diagonal
+        ``inverse_mass_matrix`` once enough samples have accumulated (see
+        "Engagement gate" below). ChEES's own trajectory-length criterion is
+        also whitened by this estimate so it stays metric-consistent with the
+        kernel it is tuning (see the derivation in
+        :func:`base`'s ``compute_parameters``) -- this whitening, not just
+        the mass matrix estimation itself, is required for the feature to
+        help on scale-separated targets: without it, the raw (Euclidean)
+        ChEES criterion is dominated by the largest-variance dimensions
+        regardless of the metric the kernel actually samples with.
+
+        Engagement gate: before the pooled accumulator (effective sample
+        size ``num_chains * window_steps``) exceeds ``max(64, 2*sqrt(num_dim))``
+        -- a modest floor chosen because a per-dimension variance estimate,
+        unlike a joint eigenbasis, does not need ``O(d)`` samples to escape
+        noise domination, so a small constant plus a mild ``d``-scaling for
+        very high-dimensional targets is enough -- the kernel and criterion
+        both use ``jnp.ones(num_dim)`` (identical to ``None``). The final
+        ``inverse_mass_matrix`` returned by ``run()`` is the engaged-or-
+        fallback estimate at the end of the accumulation window.
+    mass_matrix_window_fraction
+        Only used when ``mass_matrix_estimation="diagonal"``. Fraction of
+        warmup steps, counted from the end, over which the diagonal
+        ``inverse_mass_matrix``'s Welford accumulator collects samples
+        (default ``0.5``: the last half of warmup, mirroring
+        ``meads_adaptation``'s ``low_rank_window_fraction`` and Stan's
+        practice of excluding window adaptation's own early/transient
+        fraction). Must be in ``[0.0, 1.0]``; ``0.0`` accumulates from step
+        0, ``1.0`` disables accumulation entirely (falls back to
+        ``jnp.ones(num_dim)`` throughout the run).
 
     Returns
     -------
@@ -387,6 +546,17 @@ def chees_adaptation(
     tuned parameter values, and all the warm-up states for diagnostics.
 
     """
+    if mass_matrix_estimation not in (None, "diagonal"):
+        raise ValueError(
+            "mass_matrix_estimation must be None or 'diagonal', got "
+            f"{mass_matrix_estimation!r}."
+        )
+    if not 0.0 <= mass_matrix_window_fraction <= 1.0:
+        raise ValueError(
+            "mass_matrix_window_fraction must be in [0.0, 1.0], got "
+            f"{mass_matrix_window_fraction}."
+        )
+    estimate_mass_matrix = mass_matrix_estimation == "diagonal"
 
     def run(
         rng_key: PRNGKey,
@@ -436,17 +606,53 @@ def chees_adaptation(
             target_acceptance_rate,
             decay_rate,
             max_leapfrog_steps,
+            _whiten_criterion,
         )
 
-        def one_step(carry, rng_key):
-            states, adaptation_state = carry
+        # Opt-in ensemble-estimated diagonal inverse_mass_matrix (Σ). Mirrors
+        # meads_adaptation's low_rank_rank / low_rank_window_fraction pattern:
+        # a Welford accumulator (reused verbatim from mass_matrix.py, not
+        # reinvented) pools every chain's position at every step inside the
+        # last `mass_matrix_window_fraction` of warmup, and the estimate only
+        # engages once enough samples have accumulated (see the docstring
+        # above for the gate + rationale). Before engagement, and always when
+        # mass_matrix_estimation is None, the kernel and criterion both use
+        # jnp.ones(num_dim) -- exactly the pre-existing behavior.
+        if estimate_mass_matrix:
+            wc_init, wc_update, _ = welford_algorithm(is_diagonal_matrix=True)
+            window_start = int(mass_matrix_window_fraction * num_steps)
+            mm_engagement_threshold = _mass_matrix_engagement_threshold(num_dim)
+        else:
+            window_start = num_steps
+        in_window_flags = jnp.arange(num_steps) >= window_start
+
+        def _fold_welford_batch(wc_state, batch):
+            """Fold a batch of ``num_chains`` samples into ``wc_state`` one
+            row at a time -- ``welford_algorithm``'s ``update`` is single-
+            sample, so the whole ensemble is pooled via a sequential scan
+            rather than reinventing a batched Chan-style merge."""
+            new_state, _ = jax.lax.scan(
+                lambda carry, x: (wc_update(carry, x), None), wc_state, batch
+            )
+            return new_state
+
+        def one_step(carry, xs):
+            rng_key, in_window = xs
+            states, adaptation_state, mm_accum = carry
+
+            if estimate_mass_matrix:
+                current_imm = _diagonal_mass_matrix_or_fallback(
+                    mm_accum, mm_engagement_threshold, num_dim
+                )
+            else:
+                current_imm = jnp.ones(num_dim)
 
             keys = jax.random.split(rng_key, num_chains)
             _step_fn = partial(
                 step_fn,
                 logdensity_fn=logdensity_fn,
                 step_size=adaptation_state.step_size,
-                inverse_mass_matrix=jnp.ones(num_dim),
+                inverse_mass_matrix=current_imm,
                 integration_steps_params=(
                     adaptation_state.trajectory_length / adaptation_state.step_size,
                 ),
@@ -459,9 +665,23 @@ def chees_adaptation(
                 states.position,
                 info.acceptance_rate,
                 info.is_divergent,
+                current_imm,
             )
 
-            return (new_states, new_adaptation_state), adaptation_info_fn(
+            if estimate_mass_matrix:
+                flat_positions = jax.vmap(
+                    lambda p: jax.flatten_util.ravel_pytree(p)[0]
+                )(new_states.position)
+                new_mm_accum = jax.lax.cond(
+                    in_window,
+                    lambda acc: _fold_welford_batch(acc, flat_positions),
+                    lambda acc: acc,
+                    mm_accum,
+                )
+            else:
+                new_mm_accum = mm_accum
+
+            return (new_states, new_adaptation_state, new_mm_accum), adaptation_info_fn(
                 new_states, info, new_adaptation_state
             )
 
@@ -470,19 +690,29 @@ def chees_adaptation(
         )
         init_states = batch_init(positions)
         init_adaptation_state = init(init_random_arg, step_size)
+        init_mm_accum = wc_init(num_dim) if estimate_mass_matrix else None
 
         keys_step = jax.random.split(rng_key, num_steps)
-        (last_states, last_adaptation_state), info = jax.lax.scan(
-            one_step, (init_states, init_adaptation_state), keys_step
+        (last_states, last_adaptation_state, last_mm_accum), info = jax.lax.scan(
+            one_step,
+            (init_states, init_adaptation_state, init_mm_accum),
+            (keys_step, in_window_flags),
         )
 
         num_leapfrog_steps = jnp.exp(
             last_adaptation_state.log_trajectory_length_moving_average
             - last_adaptation_state.log_step_size_moving_average
         )
+        final_inverse_mass_matrix = (
+            _diagonal_mass_matrix_or_fallback(
+                last_mm_accum, mm_engagement_threshold, num_dim
+            )
+            if estimate_mass_matrix
+            else jnp.ones(num_dim)
+        )
         parameters = {
             "step_size": jnp.exp(last_adaptation_state.log_step_size_moving_average),
-            "inverse_mass_matrix": jnp.ones(num_dim),
+            "inverse_mass_matrix": final_inverse_mass_matrix,
             "next_random_arg_fn": next_random_arg_fn,
             "integration_steps_fn": integration_steps_fn,
             "integration_steps_params": (num_leapfrog_steps,),

--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -89,6 +89,179 @@ def _diagonal_mass_matrix_or_fallback(mm_accum, threshold: int, num_dim: int) ->
     )
 
 
+# --- Slow-direction trajectory-length floor -----------------------------
+# See `chees_adaptation`'s `mass_matrix_estimation` docstring / the module's
+# commit message for the full derivation. Summary: composing a diagonal
+# metric with ChEES's own trajectory-length criterion converges a near
+# metric-invariant physical length (dominated by the well-conditioned bulk
+# dimensions), which under-serves any residual (off-diagonal) slow
+# correlation direction the diagonal metric can't remove. A whitened
+# direction with eigenvalue lambda undergoes simple-harmonic HMC motion with
+# oscillation period 2*pi*sqrt(lambda); a quarter turn is (pi/2)*sqrt(lambda).
+# ChEES's own criterion already converges close to this quarter-turn rule
+# for the bulk (lambda ~= 1 -> ChEES's own adapted length ~= pi/2, confirmed
+# empirically), so flooring the consumed trajectory length at
+# CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max) -- lambda_max the top
+# eigenvalue of the WHITENED ensemble covariance -- extends the same rule to
+# the direction the bulk-dominated criterion under-serves. Applied at
+# CONSUMPTION only (see `_apply_length_floor`): never fed back into the
+# ChEES optimizer's own state, so the floor is cleanly ablatable via the
+# private `_length_floor` seam and has no effect on `base`/`compute_
+# parameters` (unmodified by this feature).
+CHEES_LENGTH_FLOOR_FACTOR: float = np.pi / 2
+# Cadence (in adaptation steps) at which lambda_max is refreshed via power
+# iteration. A full eigh every step would cost O(num_dim^3); power iteration
+# is O(num_dim^2) per iteration, and warm-starting the eigenvector from the
+# previous recompute means only a handful of iterations are needed to track
+# a slowly-drifting estimate, so refreshing every
+# `_LENGTH_FLOOR_RECOMPUTE_INTERVAL` steps (rather than every step) keeps
+# this cheap even at large num_dim (e.g. 390).
+_LENGTH_FLOOR_RECOMPUTE_INTERVAL = 32
+_LENGTH_FLOOR_POWER_ITERATIONS = 5
+_LENGTH_FLOOR_FINAL_POWER_ITERATIONS = 20
+# Floors lambda_max away from 0 -- mirrors meads_adaptation's
+# _LRD_EIGENVALUE_FLOOR (1e-6): a collinear/rank-deficient accumulated
+# covariance can give a near-zero (or, from floating-point cancellation,
+# slightly negative) top eigenvalue, whose sqrt would be NaN.
+_LENGTH_FLOOR_LAMBDA_EPS = 1e-6
+
+
+class _ChEESCovAccumulatorState(NamedTuple):
+    """Running Chan/Welford full covariance accumulator for the slow-
+    direction trajectory-length floor's ``lambda_max`` estimate.
+
+    Mirrors ``meads_adaptation``'s ``_LowRankAccumulatorState`` (identical
+    mean/M2/count recurrence) -- mirrored here rather than imported, to keep
+    this feature's diff self-contained to ``chees_adaptation.py``
+    (``meads_adaptation.py`` is out of scope for this change). Accumulated
+    over the SAME late-warmup window, from the SAME per-step ensemble batch,
+    as the diagonal mass-matrix Welford accumulator (``mm_accum``) -- but
+    tracks the full ``num_dim x num_dim`` second moment (not just the
+    diagonal), since the floor needs the ensemble's cross-dimension
+    structure, not just its per-dimension scale.
+    """
+
+    mean: Array
+    m2: Array
+    count: Array
+
+
+def _cov_accumulator_init(num_dim: int) -> _ChEESCovAccumulatorState:
+    return _ChEESCovAccumulatorState(
+        mean=jnp.zeros((num_dim,)),
+        m2=jnp.zeros((num_dim, num_dim)),
+        count=jnp.zeros(()),
+    )
+
+
+def _cov_accumulator_update(
+    acc: _ChEESCovAccumulatorState, batch: Array
+) -> _ChEESCovAccumulatorState:
+    """Merge a batch of samples, shape ``(n_b, num_dim)`` (one step's
+    ensemble of ``num_chains`` positions), into the running accumulator via
+    Chan et al.'s parallel/batch generalization of Welford's algorithm --
+    the same recurrence ``meads_adaptation._lrd_accumulator_update`` uses.
+    """
+    mean_a, m2_a, n_a = acc
+    n_b = batch.shape[0]
+    mean_b = jnp.mean(batch, axis=0)
+    centered_b = batch - mean_b[None, :]
+    m2_b = centered_b.T @ centered_b
+
+    delta = mean_b - mean_a
+    n_ab = n_a + n_b
+    mean_ab = mean_a + delta * (n_b / n_ab)
+    m2_ab = m2_a + m2_b + jnp.outer(delta, delta) * (n_a * n_b / n_ab)
+    return _ChEESCovAccumulatorState(mean=mean_ab, m2=m2_ab, count=n_ab)
+
+
+class _ChEESEigState(NamedTuple):
+    """Warm-startable top-eigenvector/eigenvalue estimate of the WHITENED
+    ensemble covariance (``D^{-1/2} C_hat D^{-1/2}``, ``D`` = the currently
+    engaged diagonal ``inverse_mass_matrix``), refreshed every
+    ``_LENGTH_FLOOR_RECOMPUTE_INTERVAL`` steps by a few power iterations
+    (see ``_power_iteration_lambda_max``) warm-started on ``eigenvector``.
+    """
+
+    eigenvector: Array
+    lambda_max: Array
+
+
+def _eig_state_init(num_dim: int) -> _ChEESEigState:
+    v0 = jnp.ones((num_dim,)) / jnp.sqrt(num_dim)
+    return _ChEESEigState(eigenvector=v0, lambda_max=jnp.ones(()))
+
+
+def _power_iteration_lambda_max(
+    matrix: Array, v0: Array, num_iterations: int
+) -> tuple[Array, Array]:
+    """A handful of power iterations of the symmetric PSD ``matrix``, warm-
+    started from ``v0``. Returns the top-eigenvalue estimate (the Rayleigh
+    quotient of the converged direction) and the normalized eigenvector --
+    the latter to warm-start the NEXT recompute. ``O(num_dim**2)`` per
+    iteration, versus a full ``eigh``'s ``O(num_dim**3)`` -- see the module
+    comment above ``CHEES_LENGTH_FLOOR_FACTOR`` for why a full eigh every
+    step is avoided.
+    """
+
+    def body(_, v):
+        v_next = matrix @ v
+        norm = jnp.linalg.norm(v_next)
+        return v_next / jnp.where(norm > 0.0, norm, 1.0)
+
+    v = jax.lax.fori_loop(0, num_iterations, body, v0)
+    lambda_max = jnp.dot(v, matrix @ v)
+    return lambda_max, v
+
+
+def _recompute_eig_state(
+    cov_accum: _ChEESCovAccumulatorState,
+    inverse_mass_matrix: Array,
+    eig_state: _ChEESEigState,
+    num_iterations: int = _LENGTH_FLOOR_POWER_ITERATIONS,
+) -> _ChEESEigState:
+    """Whiten the accumulated covariance by the currently engaged diagonal
+    ``inverse_mass_matrix`` (giving the correlation-like matrix
+    ``D^{-1/2} C_hat D^{-1/2}``) and refresh the top-eigenvalue estimate via
+    power iteration warm-started on ``eig_state.eigenvector``.
+    """
+    covariance = cov_accum.m2 / jnp.maximum(cov_accum.count - 1.0, 1.0)
+    inv_sqrt_d = 1.0 / jnp.sqrt(inverse_mass_matrix)
+    whitened_covariance = covariance * inv_sqrt_d[:, None] * inv_sqrt_d[None, :]
+    lambda_max, eigenvector = _power_iteration_lambda_max(
+        whitened_covariance, eig_state.eigenvector, num_iterations
+    )
+    return _ChEESEigState(
+        eigenvector=eigenvector,
+        lambda_max=jnp.maximum(lambda_max, _LENGTH_FLOOR_LAMBDA_EPS),
+    )
+
+
+def _apply_length_floor(
+    trajectory_length: Array, lambda_max: Array, engaged: Array, enable: bool
+) -> Array:
+    """Floor ``trajectory_length`` at
+    ``CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max)`` -- the slow-direction
+    trajectory-length floor. Applied at CONSUMPTION only: a pure function of
+    the already-adapted length and the current ``lambda_max`` estimate,
+    never fed back into the ChEES optimizer's own state, so the floor is
+    cleanly ablatable.
+
+    ``enable`` (the private ``_length_floor`` seam) is a static Python bool:
+    when False, ``trajectory_length`` is returned completely unchanged --
+    no ``lambda_max``/``engaged`` computation is even required to have run.
+    ``engaged`` (a traced boolean, the SAME support gate as the diagonal
+    mass-matrix estimate) makes the floor a no-op before that gate -- pre-
+    gate, ``lambda_max`` is not yet a meaningful estimate.
+    """
+    if not enable:
+        return trajectory_length
+    floor_value = jnp.where(
+        engaged, CHEES_LENGTH_FLOOR_FACTOR * jnp.sqrt(lambda_max), 0.0
+    )
+    return jnp.maximum(trajectory_length, floor_value)
+
+
 def weighted_empirical_mean(x, w):
     # x: (num_chains, dim), w: (num_chains,)
     x_safe = jnp.where(jnp.isfinite(x), x, 0.0)
@@ -437,6 +610,7 @@ def chees_adaptation(
     mass_matrix_estimation: str | None = None,
     mass_matrix_window_fraction: float = 0.5,
     _whiten_criterion: bool = True,
+    _length_floor: bool = True,
 ) -> AdaptationAlgorithm:
     """Adapt the step size and trajectory length (number of integration steps / step size)
     parameters of the jittered HMC algorthm.
@@ -557,6 +731,13 @@ def chees_adaptation(
             f"{mass_matrix_window_fraction}."
         )
     estimate_mass_matrix = mass_matrix_estimation == "diagonal"
+    # The slow-direction length floor (see the module comment above
+    # CHEES_LENGTH_FLOOR_FACTOR) only ever engages when the diagonal mass
+    # matrix is also engaged -- private `_length_floor=False` (the ablation
+    # seam) skips building the extra d x d covariance accumulator entirely,
+    # so the "metric-without-floor" ablation arm has zero overhead beyond
+    # the pre-existing mass_matrix_estimation="diagonal" feature.
+    enable_length_floor = estimate_mass_matrix and _length_floor
 
     def run(
         rng_key: PRNGKey,
@@ -626,6 +807,17 @@ def chees_adaptation(
             window_start = num_steps
         in_window_flags = jnp.arange(num_steps) >= window_start
 
+        # Cheap regardless of enable_length_floor (no num_dim-sized arrays
+        # here); when the floor is disabled this is built but never read by
+        # one_step (mirrors in_window_flags's unconditional construction
+        # above).
+        if enable_length_floor:
+            recompute_flags = (
+                jnp.arange(num_steps) % _LENGTH_FLOOR_RECOMPUTE_INTERVAL
+            ) == 0
+        else:
+            recompute_flags = jnp.zeros(num_steps, dtype=bool)
+
         def _fold_welford_batch(wc_state, batch):
             """Fold a batch of ``num_chains`` samples into ``wc_state`` one
             row at a time -- ``welford_algorithm``'s ``update`` is single-
@@ -637,8 +829,8 @@ def chees_adaptation(
             return new_state
 
         def one_step(carry, xs):
-            rng_key, in_window = xs
-            states, adaptation_state, mm_accum = carry
+            rng_key, in_window, do_recompute = xs
+            states, adaptation_state, mm_accum, cov_accum, eig_state = carry
 
             if estimate_mass_matrix:
                 current_imm = _diagonal_mass_matrix_or_fallback(
@@ -647,6 +839,22 @@ def chees_adaptation(
             else:
                 current_imm = jnp.ones(num_dim)
 
+            # Floor applied at CONSUMPTION only: `adaptation_state.
+            # trajectory_length` (the value `update` below reads to compute
+            # its OWN gradient step) is untouched -- only the length handed
+            # to `_step_fn` is floored, so the floor never feeds back into
+            # the ChEES optimizer's state.
+            if enable_length_floor:
+                engaged = mm_accum.sample_size >= mm_engagement_threshold
+                consumed_trajectory_length = _apply_length_floor(
+                    adaptation_state.trajectory_length,
+                    eig_state.lambda_max,
+                    engaged,
+                    _length_floor,
+                )
+            else:
+                consumed_trajectory_length = adaptation_state.trajectory_length
+
             keys = jax.random.split(rng_key, num_chains)
             _step_fn = partial(
                 step_fn,
@@ -654,7 +862,7 @@ def chees_adaptation(
                 step_size=adaptation_state.step_size,
                 inverse_mass_matrix=current_imm,
                 integration_steps_params=(
-                    adaptation_state.trajectory_length / adaptation_state.step_size,
+                    consumed_trajectory_length / adaptation_state.step_size,
                 ),
             )
             new_states, info = jax.vmap(_step_fn)(keys, states)
@@ -681,9 +889,32 @@ def chees_adaptation(
             else:
                 new_mm_accum = mm_accum
 
-            return (new_states, new_adaptation_state, new_mm_accum), adaptation_info_fn(
-                new_states, info, new_adaptation_state
-            )
+            if enable_length_floor:
+                # `flat_positions` is always defined here: enable_length_floor
+                # implies estimate_mass_matrix (see its derivation above).
+                new_cov_accum = jax.lax.cond(
+                    in_window,
+                    lambda acc: _cov_accumulator_update(acc, flat_positions),
+                    lambda acc: acc,
+                    cov_accum,
+                )
+                new_eig_state = jax.lax.cond(
+                    jnp.logical_and(in_window, do_recompute),
+                    lambda es: _recompute_eig_state(new_cov_accum, current_imm, es),
+                    lambda es: es,
+                    eig_state,
+                )
+            else:
+                new_cov_accum = cov_accum
+                new_eig_state = eig_state
+
+            return (
+                new_states,
+                new_adaptation_state,
+                new_mm_accum,
+                new_cov_accum,
+                new_eig_state,
+            ), adaptation_info_fn(new_states, info, new_adaptation_state)
 
         batch_init = jax.vmap(
             lambda p: dynamic_hmc.init(p, logdensity_fn, init_random_arg)
@@ -691,18 +922,28 @@ def chees_adaptation(
         init_states = batch_init(positions)
         init_adaptation_state = init(init_random_arg, step_size)
         init_mm_accum = wc_init(num_dim) if estimate_mass_matrix else None
+        init_cov_accum = _cov_accumulator_init(num_dim) if enable_length_floor else None
+        init_eig_state = _eig_state_init(num_dim) if enable_length_floor else None
 
         keys_step = jax.random.split(rng_key, num_steps)
-        (last_states, last_adaptation_state, last_mm_accum), info = jax.lax.scan(
+        (
+            last_states,
+            last_adaptation_state,
+            last_mm_accum,
+            last_cov_accum,
+            last_eig_state,
+        ), info = jax.lax.scan(
             one_step,
-            (init_states, init_adaptation_state, init_mm_accum),
-            (keys_step, in_window_flags),
+            (
+                init_states,
+                init_adaptation_state,
+                init_mm_accum,
+                init_cov_accum,
+                init_eig_state,
+            ),
+            (keys_step, in_window_flags, recompute_flags),
         )
 
-        num_leapfrog_steps = jnp.exp(
-            last_adaptation_state.log_trajectory_length_moving_average
-            - last_adaptation_state.log_step_size_moving_average
-        )
         final_inverse_mass_matrix = (
             _diagonal_mass_matrix_or_fallback(
                 last_mm_accum, mm_engagement_threshold, num_dim
@@ -710,6 +951,37 @@ def chees_adaptation(
             if estimate_mass_matrix
             else jnp.ones(num_dim)
         )
+
+        # Floor applied at the SECOND consumption point: the final
+        # integration_steps_params handed back to the caller. Bit-for-bit
+        # identical to the pre-floor computation whenever the floor is
+        # disabled (mass_matrix_estimation=None OR _length_floor=False) --
+        # see `enable_length_floor`'s derivation above.
+        if enable_length_floor:
+            final_engaged = last_mm_accum.sample_size >= mm_engagement_threshold
+            final_eig_state = _recompute_eig_state(
+                last_cov_accum,
+                final_inverse_mass_matrix,
+                last_eig_state,
+                num_iterations=_LENGTH_FLOOR_FINAL_POWER_ITERATIONS,
+            )
+            trajectory_length_ma = jnp.exp(
+                last_adaptation_state.log_trajectory_length_moving_average
+            )
+            step_size_ma = jnp.exp(last_adaptation_state.log_step_size_moving_average)
+            consumed_trajectory_length_ma = _apply_length_floor(
+                trajectory_length_ma,
+                final_eig_state.lambda_max,
+                final_engaged,
+                _length_floor,
+            )
+            num_leapfrog_steps = consumed_trajectory_length_ma / step_size_ma
+        else:
+            num_leapfrog_steps = jnp.exp(
+                last_adaptation_state.log_trajectory_length_moving_average
+                - last_adaptation_state.log_step_size_moving_average
+            )
+
         parameters = {
             "step_size": jnp.exp(last_adaptation_state.log_step_size_moving_average),
             "inverse_mass_matrix": final_inverse_mass_matrix,

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -8,11 +8,20 @@ import blackjax
 from blackjax.adaptation import window_adaptation
 from blackjax.adaptation.base import get_filter_adapt_info_fn, return_all_adapt_info
 from blackjax.adaptation.chees_adaptation import (
+    _LENGTH_FLOOR_POWER_ITERATIONS,
+    CHEES_LENGTH_FLOOR_FACTOR,
+    _apply_length_floor,
+    _cov_accumulator_init,
+    _cov_accumulator_update,
     _diagonal_mass_matrix_or_fallback,
+    _eig_state_init,
     _mass_matrix_engagement_threshold,
+    _power_iteration_lambda_max,
+    _recompute_eig_state,
 )
 from blackjax.adaptation.chees_adaptation import base as chees_base
 from blackjax.adaptation.mass_matrix import WelfordAlgorithmState, welford_algorithm
+from blackjax.diagnostics import effective_sample_size
 from blackjax.util import run_inference_algorithm
 
 
@@ -153,17 +162,24 @@ def _chees_gaussian_logdensity(target_std):
 
 def test_chees_mass_matrix_estimation_none_matches_omitted_bit_for_bit():
     """mass_matrix_estimation=None must be numerically identical to omitting
-    it -- mirrors meads_adaptation's low_rank_rank=None backward-compat test."""
+    it -- mirrors meads_adaptation's low_rank_rank=None backward-compat test.
+    Also covers the slow-direction length floor: the floor machinery must be
+    fully inert on the None path regardless of _length_floor (extended by
+    this feature -- integration_steps_params is exactly the field the floor
+    touches)."""
     target_std = jnp.array([1.0, 10.0])
     logdensity_fn = _chees_gaussian_logdensity(target_std)
     num_chains = 16
     positions = jax.random.normal(jax.random.key(7), (num_chains, 2))
     warmup_key = jax.random.key(11)
 
-    def run(pass_explicit_none):
+    def run(pass_explicit_none, length_floor=True):
         kwargs = {"mass_matrix_estimation": None} if pass_explicit_none else {}
         warmup = blackjax.chees_adaptation(
-            logdensity_fn, num_chains=num_chains, **kwargs
+            logdensity_fn,
+            num_chains=num_chains,
+            _length_floor=length_floor,
+            **kwargs,
         )
         return warmup.run(
             warmup_key,
@@ -175,12 +191,26 @@ def test_chees_mass_matrix_estimation_none_matches_omitted_bit_for_bit():
 
     (states_default, params_default), _ = run(False)
     (states_none, params_none), _ = run(True)
+    (states_none_no_floor, params_none_no_floor), _ = run(True, length_floor=False)
 
     np.testing.assert_array_equal(states_default.position, states_none.position)
     np.testing.assert_array_equal(
         params_default["inverse_mass_matrix"], params_none["inverse_mass_matrix"]
     )
     assert params_default["step_size"] == params_none["step_size"]
+    np.testing.assert_array_equal(
+        params_default["integration_steps_params"][0],
+        params_none["integration_steps_params"][0],
+    )
+
+    # _length_floor must have zero effect when mass_matrix_estimation=None
+    # (the floor is fully inert, not just numerically a no-op).
+    np.testing.assert_array_equal(states_none.position, states_none_no_floor.position)
+    np.testing.assert_array_equal(
+        params_none["integration_steps_params"][0],
+        params_none_no_floor["integration_steps_params"][0],
+    )
+    assert params_none["step_size"] == params_none_no_floor["step_size"]
 
 
 def test_chees_mass_matrix_estimation_invalid_value_raises():
@@ -380,6 +410,222 @@ def test_chees_whiten_criterion_ablation_seam_changes_behavior():
     assert not jnp.allclose(
         params_whitened["step_size"], params_naive["step_size"], rtol=1e-3
     )
+
+
+def _equicorrelated_block_logdensity(dim, block_k, rho, scale_span, scale_key):
+    """dims 0..block_k-1: equicorrelated at rho (unit marginal variance,
+    analytic top eigenvalue 1 + (block_k - 1) * rho -- a genuine residual
+    correlation direction no diagonal metric can remove); remaining dims:
+    independent, scale-separated (log-uniform std spanning
+    10**-scale_span..10**scale_span, as in test_chees_mass_matrix_estimation
+    _e2e_smoke) -- the severe scale separation is what makes a diagonal
+    metric collapse ChEES's OWN adapted length well below what the block
+    needs (see test_chees_length_floor_e2e_smoke_recovers_slow_direction)."""
+    C_block = jnp.full((block_k, block_k), rho) + (1.0 - rho) * jnp.eye(block_k)
+    precision_block = jnp.linalg.inv(C_block)
+    n_rest = dim - block_k
+    log_scales = jax.random.uniform(
+        scale_key, (n_rest,), minval=-scale_span, maxval=scale_span
+    )
+    stds = 10.0**log_scales
+
+    def logdensity_fn(x):
+        block = x[:block_k]
+        rest = x[block_k:]
+        lp_block = -0.5 * block @ precision_block @ block
+        lp_rest = -0.5 * jnp.sum((rest / stds) ** 2)
+        return lp_block + lp_rest
+
+    top_eigenvalue = 1.0 + (block_k - 1) * rho
+    return logdensity_fn, top_eigenvalue, stds
+
+
+def test_length_floor_accumulator_and_power_iteration_recover_planted_eigenvalue():
+    """lambda_max estimator unit test (accumulator -> whitening -> power
+    iteration), no sampling from chees_adaptation.run() involved: a
+    synthetic ensemble with a KNOWN planted correlation direction -- a
+    rank-1 correlation between dims 0-1 (rho=0.9) embedded in d=10, unit
+    marginal variances elsewhere -- has an analytic whitened-covariance top
+    eigenvalue of 1 + rho (eigenvector (1, 1, 0, ..., 0) / sqrt(2)). Since
+    every dimension has unit marginal variance, D=ones(d) makes the
+    "whitened" covariance exactly the correlation matrix itself."""
+    d, rho = 10, 0.9
+    analytic_lambda_max = 1.0 + rho
+
+    C = jnp.eye(d).at[0, 1].set(rho).at[1, 0].set(rho)
+    key = jax.random.key(0)
+    samples = jax.random.multivariate_normal(key, jnp.zeros(d), C, shape=(20_000,))
+
+    acc = _cov_accumulator_init(d)
+    batch_size = 200
+    for i in range(samples.shape[0] // batch_size):
+        acc = _cov_accumulator_update(
+            acc, samples[i * batch_size : (i + 1) * batch_size]
+        )
+    # The accumulator must reproduce the naive batch covariance (same check
+    # as meads_adaptation's test_accumulator_matches_naive_batch_covariance).
+    naive_cov = jnp.cov(samples, rowvar=False)
+    accumulated_cov = acc.m2 / (acc.count - 1.0)
+    np.testing.assert_allclose(accumulated_cov, naive_cov, atol=1e-6, rtol=1e-6)
+
+    eig_state = _eig_state_init(d)
+    # Several recomputes, as the real run() would perform every
+    # _LENGTH_FLOOR_RECOMPUTE_INTERVAL steps, warm-starting each time.
+    for _ in range(5):
+        eig_state = _recompute_eig_state(acc, jnp.ones(d), eig_state)
+
+    np.testing.assert_allclose(
+        float(eig_state.lambda_max), analytic_lambda_max, rtol=0.1
+    )
+    # The eigenvector should have converged into the planted subspace
+    # span{e0, e1}: negligible energy on the other (uncorrelated) dims.
+    energy_outside_block = float(jnp.sum(eig_state.eigenvector[2:] ** 2))
+    assert energy_outside_block < 0.05
+
+
+def test_length_floor_power_iteration_converges_from_warm_start():
+    """Deterministic (no sampling noise): power iteration on the EXACT
+    planted correlation matrix recovers its analytic top eigenvalue within
+    a handful of iterations from a generic starting vector, and stays
+    converged when warm-started again from the recovered eigenvector (the
+    per-step "refresh every K steps" pattern `_recompute_eig_state` uses)."""
+    d, rho = 10, 0.9
+    analytic_lambda_max = 1.0 + rho
+    C = jnp.eye(d).at[0, 1].set(rho).at[1, 0].set(rho)
+
+    v0 = jnp.ones(d) / jnp.sqrt(d)
+    lambda_max, v = _power_iteration_lambda_max(
+        C, v0, num_iterations=_LENGTH_FLOOR_POWER_ITERATIONS
+    )
+    np.testing.assert_allclose(float(lambda_max), analytic_lambda_max, rtol=0.05)
+
+    # Warm-starting from the converged eigenvector for just 1 more iteration
+    # should stay converged (not regress) -- this is what makes refreshing
+    # only every K steps (rather than every step) cheap without losing
+    # accuracy once the estimate has locked on.
+    lambda_max_2, _ = _power_iteration_lambda_max(C, v, num_iterations=1)
+    np.testing.assert_allclose(float(lambda_max_2), analytic_lambda_max, rtol=1e-3)
+
+
+def test_apply_length_floor_arithmetic():
+    """Direct unit test of the floor arithmetic (no sampling, mocked
+    lambda_max): the consumed length is
+    max(adapted, CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max)) when engaged
+    and enabled; the private _length_floor=False seam (enable=False) leaves
+    the adapted length completely unchanged."""
+    adapted_length = 3.0
+    lambda_max = 100.0
+    expected_floor = float(CHEES_LENGTH_FLOOR_FACTOR * jnp.sqrt(lambda_max))
+    assert expected_floor > adapted_length  # the floor must actually bind here
+
+    consumed = _apply_length_floor(
+        adapted_length, lambda_max, engaged=True, enable=True
+    )
+    np.testing.assert_allclose(float(consumed), expected_floor)
+
+    # The floor must not shrink an already-long adapted length.
+    consumed_large = _apply_length_floor(50.0, lambda_max, engaged=True, enable=True)
+    assert float(consumed_large) == 50.0
+
+    # Ablation seam: enable=False (the private _length_floor=False path)
+    # returns the adapted length unchanged, regardless of lambda_max/engaged.
+    consumed_disabled = _apply_length_floor(
+        adapted_length, lambda_max, engaged=True, enable=False
+    )
+    assert float(consumed_disabled) == adapted_length
+
+
+def test_apply_length_floor_inert_pre_gate():
+    """Before the engagement gate (engaged=False), the floor is a no-op
+    even with enable=True and a huge lambda_max -- pre-gate, lambda_max is
+    not yet a meaningful estimate (mirrors _diagonal_mass_matrix_or_fallback's
+    engagement-gate semantics for the diagonal estimate itself)."""
+    adapted_length = 3.0
+    consumed = _apply_length_floor(
+        adapted_length, lambda_max=1.0e6, engaged=False, enable=True
+    )
+    assert float(consumed) == adapted_length
+
+
+def test_chees_length_floor_e2e_smoke_recovers_slow_direction():
+    """E2E smoke (small, targeted, deterministic seed): a synthetic target
+    with a genuine residual slow-correlation block (10 equicorrelated dims,
+    rho=0.95, analytic top eigenvalue ~9.55) plus severe scale separation
+    among the remaining dims (std spanning 1e-2..1e2) -- the scale
+    separation is what makes mass_matrix_estimation="diagonal" collapse
+    ChEES's own adapted trajectory length well below what the block needs
+    (mirrors the mechanism found on radon/irt_2pl in the validation probe).
+    metric+floor must (a) floor the adapted length at roughly the analytic
+    (pi/2)*sqrt(top_eigenvalue) quarter-turn value and (b) show a much
+    higher min-ESS than metric-without-floor at a matched, small sampling
+    budget. Loose bands throughout -- no tight ESS thresholds."""
+    dim, block_k, rho, scale_span = 100, 10, 0.95, 2.0
+    num_chains, num_warmup, num_samples = 32, 250, 200
+    scale_key, init_key, warmup_key, sample_key = jax.random.split(jax.random.key(4), 4)
+    logdensity_fn, top_eigenvalue, stds = _equicorrelated_block_logdensity(
+        dim, block_k, rho, scale_span, scale_key
+    )
+    # Initialize the scale-separated dims at their target scale (not unit
+    # variance) -- otherwise the initial ensemble doesn't yet reflect the
+    # severe scale separation the mechanism depends on, and the collapse
+    # this test is designed to exercise doesn't happen (verified empirically:
+    # omitting this scaling made the un-floored arm's adapted length land at
+    # ~4.7, not the collapsed ~0.4-0.5 seen with it).
+    positions = jax.random.normal(init_key, (num_chains, dim))
+    positions = positions.at[:, block_k:].multiply(stds)
+
+    def run(length_floor):
+        warmup = blackjax.chees_adaptation(
+            logdensity_fn,
+            num_chains=num_chains,
+            mass_matrix_estimation="diagonal",
+            _length_floor=length_floor,
+        )
+        (last_states, parameters), _ = warmup.run(
+            warmup_key,
+            positions,
+            step_size=0.1,
+            optim=optax.adam(learning_rate=0.5, b1=0, b2=0.95),
+            num_steps=num_warmup,
+        )
+        algorithm = blackjax.dhmc(logdensity_fn, **parameters)
+        chain_keys = jax.random.split(sample_key, num_chains)
+        _, (states, _) = jax.vmap(
+            lambda key, state: run_inference_algorithm(
+                rng_key=key,
+                initial_state=state,
+                inference_algorithm=algorithm,
+                num_steps=num_samples,
+            )
+        )(chain_keys, last_states)
+        trajectory_length = float(
+            parameters["integration_steps_params"][0] * parameters["step_size"]
+        )
+        return trajectory_length, states
+
+    length_with_floor, states_with_floor = run(True)
+    length_without_floor, states_without_floor = run(False)
+
+    assert jnp.all(jnp.isfinite(states_with_floor.position))
+    assert jnp.all(jnp.isfinite(states_without_floor.position))
+
+    # (a) the floored length must land close to the analytic quarter-turn
+    # floor value, and well above the un-floored (collapsed) length.
+    expected_floor = float(np.pi / 2 * np.sqrt(top_eigenvalue))
+    assert length_with_floor >= 0.7 * expected_floor
+    assert length_with_floor > length_without_floor
+
+    # (b) min-ESS meaningfully higher with the floor -- loose band (>=3x),
+    # the actual effect measured in exploration was 30-60x.
+    ess_with_floor = effective_sample_size(
+        states_with_floor.position, chain_axis=0, sample_axis=1
+    )
+    ess_without_floor = effective_sample_size(
+        states_without_floor.position, chain_axis=0, sample_axis=1
+    )
+    min_ess_with_floor = float(jnp.min(ess_with_floor))
+    min_ess_without_floor = float(jnp.min(ess_without_floor))
+    assert min_ess_with_floor >= 3.0 * min_ess_without_floor
 
 
 def test_halton_sequence_raise_value():

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -510,29 +510,59 @@ def test_length_floor_power_iteration_converges_from_warm_start():
 def test_apply_length_floor_arithmetic():
     """Direct unit test of the floor arithmetic (no sampling, mocked
     lambda_max): the consumed length is
-    max(adapted, CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max)) when engaged
-    and enabled; the private _length_floor=False seam (enable=False) leaves
-    the adapted length completely unchanged."""
+    min(max(adapted, CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max)), cap)
+    when engaged and enabled; the private _length_floor=False seam (enable=False)
+    leaves the adapted length completely unchanged. The floor_clipped_by_cap
+    flag indicates when the cap (max_leapfrog_steps * step_size) binds below
+    the floor value."""
     adapted_length = 3.0
     lambda_max = 100.0
     expected_floor = float(CHEES_LENGTH_FLOOR_FACTOR * jnp.sqrt(lambda_max))
     assert expected_floor > adapted_length  # the floor must actually bind here
 
-    consumed = _apply_length_floor(
-        adapted_length, lambda_max, engaged=True, enable=True
+    consumed, flag = _apply_length_floor(
+        adapted_length,
+        lambda_max,
+        engaged=True,
+        enable=True,
+        max_leapfrog_steps=1000,
+        step_size=0.1,
     )
     np.testing.assert_allclose(float(consumed), expected_floor)
+    assert float(flag) == 0.0  # cap does not bind with default large budget
 
     # The floor must not shrink an already-long adapted length.
-    consumed_large = _apply_length_floor(50.0, lambda_max, engaged=True, enable=True)
+    consumed_large, flag_large = _apply_length_floor(
+        50.0,
+        lambda_max,
+        engaged=True,
+        enable=True,
+        max_leapfrog_steps=1000,
+        step_size=0.1,
+    )
     assert float(consumed_large) == 50.0
+    assert float(flag_large) == 0.0
 
     # Ablation seam: enable=False (the private _length_floor=False path)
     # returns the adapted length unchanged, regardless of lambda_max/engaged.
-    consumed_disabled = _apply_length_floor(
+    consumed_disabled, flag_disabled = _apply_length_floor(
         adapted_length, lambda_max, engaged=True, enable=False
     )
     assert float(consumed_disabled) == adapted_length
+    assert float(flag_disabled) == 0.0
+
+    # Test that cap actually binds with a tiny budget (max_leapfrog_steps=8)
+    consumed_capped, flag_capped = _apply_length_floor(
+        adapted_length,
+        lambda_max,
+        engaged=True,
+        enable=True,
+        max_leapfrog_steps=8,
+        step_size=0.1,
+    )
+    cap = 8 * 0.1  # 0.8
+    np.testing.assert_allclose(float(consumed_capped), cap, rtol=1e-6)
+    assert float(flag_capped) == 1.0  # floor value exceeds cap
 
 
 def test_apply_length_floor_inert_pre_gate():
@@ -541,10 +571,16 @@ def test_apply_length_floor_inert_pre_gate():
     not yet a meaningful estimate (mirrors _diagonal_mass_matrix_or_fallback's
     engagement-gate semantics for the diagonal estimate itself)."""
     adapted_length = 3.0
-    consumed = _apply_length_floor(
-        adapted_length, lambda_max=1.0e6, engaged=False, enable=True
+    consumed, flag = _apply_length_floor(
+        adapted_length,
+        lambda_max=1.0e6,
+        engaged=False,
+        enable=True,
+        max_leapfrog_steps=1000,
+        step_size=0.1,
     )
     assert float(consumed) == adapted_length
+    assert float(flag) == 0.0  # no clipping when not engaged
 
 
 def test_chees_length_floor_e2e_smoke_recovers_slow_direction():
@@ -634,3 +670,89 @@ def test_halton_sequence_raise_value():
 
     with pytest.raises(ValueError, match="max_bits"):
         halton_sequence(jnp.array([0], dtype=jnp.int32), max_bits=32)
+
+
+def test_whitened_criterion_correctness():
+    """TEST-W (kills M1+M5): For any diagonal Sigma, the whitened update on
+    (props, inits, moms) must equal the trusted RAW update fed PRE-TRANSFORMED
+    inputs:
+        raw_update(Sigma^-1/2 . props, Sigma^-1/2 . inits, Sigma^+1/2 . moms, ones)
+        == whitened_update(props, inits, moms, Sigma)
+    Whitening is linear and commutes with centering, so the raw path on the
+    pre-transformed inputs reproduces exactly norm_Sigma^-1(Dx) and the raw
+    pairing <Dx, p>. A flipped whitening direction (M1) or a dropped velocity
+    re-whitening (M5) breaks this by factors of Sigma (orders of magnitude at
+    large spread).
+    """
+    num_chains, dim = 12, 4
+    # Sigma with 4 orders of magnitude (whitening far from a no-op), but
+    # gradient stays unclipped under SGD lr=1e-3.
+    imm = jnp.array([1e-2, 1e-1, 1e1, 1e2])
+    keys = jax.random.split(jax.random.key(0), 4)
+    props = jax.random.normal(keys[0], (num_chains, dim))
+    moms = jax.random.normal(keys[1], (num_chains, dim))
+    inits = jax.random.normal(keys[2], (num_chains, dim))
+    accept = jax.random.uniform(keys[3], (num_chains,))
+
+    def run_update(whiten, props_in, moms_in, inits_in, imm_in):
+        # SGD with small lr=1e-3 keeps log-trajectory-length update in LINEAR
+        # (unclipped, non-sign-saturated) regime, so trajectory_length tracks
+        # the trajectory_gradient VALUE -- adam's sign-only first step + the
+        # ±0.35 clip otherwise mask gradient-magnitude changes.
+        init, update = chees_base(
+            jitter_generator=lambda i: 0.5,
+            next_random_arg_fn=lambda i: i + 1,
+            optim=optax.sgd(learning_rate=1e-3),
+            target_acceptance_rate=0.651,
+            decay_rate=0.5,
+            max_leapfrog_steps=1000,
+            _whiten_criterion=whiten,
+        )
+        state0 = init(0, 0.1)
+        is_div = jnp.zeros((props_in.shape[0],), dtype=bool)
+        return update(state0, props_in, moms_in, inits_in, accept, is_div, imm_in)
+
+    # Whitened path on (props, inits, moms) with the real Sigma
+    state_whitened = run_update(True, props, moms, inits, imm)
+
+    # Trusted RAW path on PRE-TRANSFORMED inputs with Sigma=ones:
+    #   raw_update(S^-1/2 props, S^+1/2 moms, S^-1/2 inits, ones)
+    # reproduces exactly norm_{S^-1}(Dx) and the raw pairing <Dx, p>, so it
+    # equals the CORRECT whitened update.
+    inv_sqrt = 1.0 / jnp.sqrt(imm)
+    sqrt = jnp.sqrt(imm)
+    state_reference = run_update(
+        False, props * inv_sqrt, moms * sqrt, inits * inv_sqrt, jnp.ones(dim)
+    )
+
+    # Observe the PRE-CLIP log-trajectory-length MA (the trajectory_length
+    # field itself min-clips to step_size, masking the gradient). At step 1
+    # this equals log(0.1) + clip(-lr*grad, ±0.35); with lr=1e-3 it is
+    # unclipped and tracks the gradient linearly.
+    tl_whitened = float(state_whitened.log_trajectory_length_moving_average)
+    tl_reference = float(state_reference.log_trajectory_length_moving_average)
+
+    # Both must be unclipped and close (rtol=1e-6 for kill margin 9-15%).
+    np.testing.assert_allclose(tl_whitened, tl_reference, rtol=1e-6)
+
+
+def test_floor_constant_value():
+    """TEST-F (kills M3): _apply_length_floor(0, lambda_max=4, engaged, enable)
+    must equal the HARDCODED (pi/2)*sqrt(4) = pi, NOT via the
+    CHEES_LENGTH_FLOOR_FACTOR symbol. The symbolic form is exactly what let
+    the mutant (e.g., pi/4 instead of pi/2) survive mutation testing.
+    """
+    # Engaged floor with lambda_max=4 -> (pi/2)*2 = pi, hardcoded expectation
+    consumed_length, _ = _apply_length_floor(
+        0.0,
+        jnp.asarray(4.0),
+        jnp.asarray(True),
+        True,
+        max_leapfrog_steps=1000,
+        step_size=0.1,
+    )
+    val = float(consumed_length)
+    expected = float(
+        np.pi
+    )  # (pi/2)*sqrt(4), NOT via the CHEES_LENGTH_FLOOR_FACTOR symbol
+    np.testing.assert_allclose(val, expected, rtol=1e-6)

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -7,6 +7,12 @@ import pytest
 import blackjax
 from blackjax.adaptation import window_adaptation
 from blackjax.adaptation.base import get_filter_adapt_info_fn, return_all_adapt_info
+from blackjax.adaptation.chees_adaptation import (
+    _diagonal_mass_matrix_or_fallback,
+    _mass_matrix_engagement_threshold,
+)
+from blackjax.adaptation.chees_adaptation import base as chees_base
+from blackjax.adaptation.mass_matrix import WelfordAlgorithmState, welford_algorithm
 from blackjax.util import run_inference_algorithm
 
 
@@ -136,6 +142,244 @@ def test_chees_adaptation(adaptation_filters):
     empirical_std = jnp.std(draws, axis=0)
     np.testing.assert_allclose(empirical_mean, target_mean, atol=0.5)
     np.testing.assert_allclose(empirical_std, target_std, rtol=0.1)
+
+
+def _chees_gaussian_logdensity(target_std):
+    def logdensity_fn(x):
+        return jax.scipy.stats.norm.logpdf(x, scale=target_std).sum(axis=-1)
+
+    return logdensity_fn
+
+
+def test_chees_mass_matrix_estimation_none_matches_omitted_bit_for_bit():
+    """mass_matrix_estimation=None must be numerically identical to omitting
+    it -- mirrors meads_adaptation's low_rank_rank=None backward-compat test."""
+    target_std = jnp.array([1.0, 10.0])
+    logdensity_fn = _chees_gaussian_logdensity(target_std)
+    num_chains = 16
+    positions = jax.random.normal(jax.random.key(7), (num_chains, 2))
+    warmup_key = jax.random.key(11)
+
+    def run(pass_explicit_none):
+        kwargs = {"mass_matrix_estimation": None} if pass_explicit_none else {}
+        warmup = blackjax.chees_adaptation(
+            logdensity_fn, num_chains=num_chains, **kwargs
+        )
+        return warmup.run(
+            warmup_key,
+            positions,
+            step_size=0.1,
+            optim=optax.adam(learning_rate=0.5, b1=0, b2=0.95),
+            num_steps=50,
+        )
+
+    (states_default, params_default), _ = run(False)
+    (states_none, params_none), _ = run(True)
+
+    np.testing.assert_array_equal(states_default.position, states_none.position)
+    np.testing.assert_array_equal(
+        params_default["inverse_mass_matrix"], params_none["inverse_mass_matrix"]
+    )
+    assert params_default["step_size"] == params_none["step_size"]
+
+
+def test_chees_mass_matrix_estimation_invalid_value_raises():
+    with pytest.raises(ValueError, match="mass_matrix_estimation"):
+        blackjax.chees_adaptation(
+            _chees_gaussian_logdensity(jnp.ones(2)),
+            num_chains=4,
+            mass_matrix_estimation="dense",
+        )
+
+
+def test_chees_mass_matrix_window_fraction_invalid_raises():
+    with pytest.raises(ValueError, match="mass_matrix_window_fraction"):
+        blackjax.chees_adaptation(
+            _chees_gaussian_logdensity(jnp.ones(2)),
+            num_chains=4,
+            mass_matrix_estimation="diagonal",
+            mass_matrix_window_fraction=1.5,
+        )
+    with pytest.raises(ValueError, match="mass_matrix_window_fraction"):
+        blackjax.chees_adaptation(
+            _chees_gaussian_logdensity(jnp.ones(2)),
+            num_chains=4,
+            mass_matrix_estimation="diagonal",
+            mass_matrix_window_fraction=-0.1,
+        )
+
+
+def test_chees_whitened_criterion_reduces_to_raw_when_identity():
+    """Unit-level, deterministic: with inverse_mass_matrix=ones, the whitened
+    (_whiten_criterion=True) and raw (_whiten_criterion=False) code paths
+    must produce bit-for-bit identical ChEESAdaptationState updates -- see
+    the derivation comment in chees_adaptation.compute_parameters."""
+    num_chains, dim = 8, 4
+    keys = jax.random.split(jax.random.key(0), 4)
+    proposed_positions = jax.random.normal(keys[0], (num_chains, dim))
+    proposed_momentums = jax.random.normal(keys[1], (num_chains, dim))
+    initial_positions = jax.random.normal(keys[2], (num_chains, dim))
+    acceptance_probabilities = jax.random.uniform(keys[3], (num_chains,))
+    is_divergent = jnp.zeros((num_chains,), dtype=bool)
+    step_size = 0.1
+
+    def run_update(whiten):
+        init, update = chees_base(
+            jitter_generator=lambda i: 0.5,
+            next_random_arg_fn=lambda i: i + 1,
+            optim=optax.adam(learning_rate=0.5),
+            target_acceptance_rate=0.651,
+            decay_rate=0.5,
+            max_leapfrog_steps=1000,
+            _whiten_criterion=whiten,
+        )
+        state0 = init(0, step_size)
+        return update(
+            state0,
+            proposed_positions,
+            proposed_momentums,
+            initial_positions,
+            acceptance_probabilities,
+            is_divergent,
+            jnp.ones(dim),
+        )
+
+    state_whitened = run_update(True)
+    state_raw = run_update(False)
+
+    equal_leaves = jax.tree.leaves(
+        jax.tree.map(lambda a, b: jnp.array_equal(a, b), state_whitened, state_raw)
+    )
+    assert all(bool(leaf) for leaf in equal_leaves)
+
+
+def test_chees_mass_matrix_engagement_gate():
+    """Before the pooled Welford sample count reaches the engagement
+    threshold, the diagonal estimate must fall back to ones; once it does,
+    the estimate must differ from ones and stay finite."""
+    num_dim = 5
+    threshold = _mass_matrix_engagement_threshold(num_dim)
+    assert threshold >= 64
+
+    below_accum = WelfordAlgorithmState(
+        mean=jnp.zeros(num_dim), m2=jnp.zeros(num_dim), sample_size=threshold - 1
+    )
+    imm_below = _diagonal_mass_matrix_or_fallback(below_accum, threshold, num_dim)
+    np.testing.assert_array_equal(imm_below, jnp.ones(num_dim))
+
+    scales = jnp.array([0.1, 1.0, 10.0, 2.0, 5.0])
+    samples = jax.random.normal(jax.random.key(0), (threshold + 20, num_dim)) * scales
+    _, wc_update, _ = welford_algorithm(is_diagonal_matrix=True)
+    acc = WelfordAlgorithmState(
+        mean=jnp.zeros(num_dim), m2=jnp.zeros(num_dim), sample_size=0
+    )
+    for i in range(threshold + 20):
+        acc = wc_update(acc, samples[i])
+
+    imm_above = _diagonal_mass_matrix_or_fallback(acc, threshold, num_dim)
+    assert jnp.all(jnp.isfinite(imm_above))
+    assert not jnp.allclose(imm_above, jnp.ones(num_dim))
+
+
+def test_chees_mass_matrix_estimation_correctness():
+    """On a diagonal Gaussian with well-separated known variances, the
+    engaged diagonal inverse_mass_matrix should approximate the true
+    per-dimension variance (loose ratio tolerance, pinned seed -- no
+    ESS-threshold assertions)."""
+    target_std = jnp.array([0.1, 1.0, 10.0])
+    true_variance = target_std**2
+    logdensity_fn = _chees_gaussian_logdensity(target_std)
+    num_chains, dim = 32, 3
+
+    init_key, warmup_key = jax.random.split(jax.random.key(2026))
+    positions = jax.random.normal(init_key, (num_chains, dim)) * target_std
+
+    warmup = blackjax.chees_adaptation(
+        logdensity_fn,
+        num_chains=num_chains,
+        mass_matrix_estimation="diagonal",
+        mass_matrix_window_fraction=0.5,
+    )
+    (last_states, parameters), _ = warmup.run(
+        warmup_key,
+        positions,
+        step_size=0.1,
+        optim=optax.adam(learning_rate=0.5, b1=0, b2=0.95),
+        num_steps=300,
+    )
+
+    ratio = parameters["inverse_mass_matrix"] / true_variance
+    np.testing.assert_allclose(ratio, 1.0, rtol=0.6)
+    assert jnp.all(jnp.isfinite(last_states.position))
+
+
+def test_chees_mass_matrix_estimation_e2e_smoke():
+    """Scale-separated synthetic target: mass_matrix_estimation="diagonal"
+    should run to completion with no NaN, a finite adapted step size, and a
+    returned inverse_mass_matrix within a loose ratio band of the truth."""
+    dim, num_chains = 12, 32
+    scale_key, init_key, warmup_key = jax.random.split(jax.random.key(3), 3)
+    log_scales = jax.random.uniform(scale_key, (dim,), minval=-1.0, maxval=1.0)
+    target_std = 10.0**log_scales  # spans roughly 1e-1..1e1
+    logdensity_fn = _chees_gaussian_logdensity(target_std)
+
+    positions = jax.random.normal(init_key, (num_chains, dim)) * target_std
+
+    warmup = blackjax.chees_adaptation(
+        logdensity_fn,
+        num_chains=num_chains,
+        mass_matrix_estimation="diagonal",
+        mass_matrix_window_fraction=0.5,
+    )
+    (last_states, parameters), _ = warmup.run(
+        warmup_key,
+        positions,
+        step_size=0.1,
+        optim=optax.adam(learning_rate=0.5, b1=0, b2=0.95),
+        num_steps=150,
+    )
+
+    assert jnp.all(jnp.isfinite(last_states.position))
+    assert jnp.isfinite(parameters["step_size"])
+    imm = parameters["inverse_mass_matrix"]
+    assert jnp.all(jnp.isfinite(imm))
+    ratio = imm / target_std**2
+    assert jnp.all(ratio > 0.1) and jnp.all(ratio < 10.0)
+
+
+def test_chees_whiten_criterion_ablation_seam_changes_behavior():
+    """_whiten_criterion=False (naive: kernel uses the estimated diagonal,
+    criterion stays raw) must yield different adapted parameters than the
+    default whitened path once the estimated diagonal deviates from ones --
+    otherwise the ablation seam would silently be a no-op. This is the seam
+    a validation study toggles to compare {identity, naive, whitened}."""
+    target_std = jnp.array([0.1, 1.0, 10.0])
+    logdensity_fn = _chees_gaussian_logdensity(target_std)
+    num_chains = 32
+    init_key, warmup_key = jax.random.split(jax.random.key(5))
+    positions = jax.random.normal(init_key, (num_chains, 3)) * target_std
+
+    def run(whiten):
+        warmup = blackjax.chees_adaptation(
+            logdensity_fn,
+            num_chains=num_chains,
+            mass_matrix_estimation="diagonal",
+            _whiten_criterion=whiten,
+        )
+        return warmup.run(
+            warmup_key,
+            positions,
+            step_size=0.1,
+            optim=optax.adam(learning_rate=0.5, b1=0, b2=0.95),
+            num_steps=200,
+        )
+
+    (_, params_whitened), _ = run(True)
+    (_, params_naive), _ = run(False)
+
+    assert not jnp.allclose(
+        params_whitened["step_size"], params_naive["step_size"], rtol=1e-3
+    )
 
 
 def test_halton_sequence_raise_value():


### PR DESCRIPTION
## What

Three coupled, opt-in additions to `blackjax.chees_adaptation` (default behavior **bit-for-bit unchanged** — verified against the merge-base through the public API in f32 and x64, including RNG streams):

1. **`mass_matrix_estimation: None | "diagonal"`** — a per-dimension variance estimated from the chain ensemble over the late warmup window (Welford, engagement-gated) and fed to the dynamic-HMC kernel.
2. **A metric-consistent (whitened) ChEES criterion** — position norms in Σ^{-1/2} coordinates; the momentum pairing term is provably metric-invariant (conjugate pair), so only the norm term changes and Σ=1 reduces exactly to the current expression.
3. **A slow-direction trajectory-length floor** — the consumed trajectory length becomes `max(adapted, (π/2)·√λ_max)`, with λ_max the top eigenvalue of the whitened ensemble covariance (warm-started power iteration on the same accumulation window). The floor respects `max_leapfrog_steps` and surfaces a `floor_clipped_by_cap` diagnostic when the cap binds.

## Why — the honest story

A diagonal metric **alone degrades** ChEES on its intended targets: the metric raises the stable step size 8–44×, but ChEES's jump-distance objective converges a near metric-invariant *physical* trajectory (~π/2 in whitened bulk radians), so the leapfrog count collapses (radon: 205→6 steps) and the residual slow correlation direction — which the identity metric's accidentally-tiny steps served — is starved. We validated this failure explicitly (three-config ablations on irt_2pl/radon, two independent runs) before building the fix.

The floor closes it in closed form: a whitened direction with covariance eigenvalue λ has rotation period 2π√λ; the quarter-turn (π/2)√λ_max extends exactly the rule ChEES already satisfies for the bulk (λ≈1 → its ~1.6) to the direction its bulk-dominated objective cannot see. (Gaussian-exact; a linearized heuristic on funnels — empirically sufficient there.)

## Validation (real posteriors, canonical seeds, ground-truth-gated)

- **radon** (d=390, λ_max≈13.3): floor min-ESS 6727 ≈ identity's 6913 (−3%) at **10.2× the ESS per gradient**; metric-without-floor: 827.
- **irt_2pl** (d=144, λ_max≈9.4): floor min-ESS 6470 = **1.5× identity** at 1.4× ESS/gradient; without floor: 1281.
- **Mechanism**: adapted/predicted length ratios **0.999 / 1.003 / 1.004** where the floor binds; on isotropic mvn_10 it correctly never binds (identical results to no-floor); german_credit improves 2.7×.
- **Whitened criterion**: metric-consistent but empirically small on NCP-standardized targets (≲12%) — kept for correctness, not claimed as the differentiator.

## Scope and guardrails (documented)

- Validated under located (typical-set) initializations; cold/dispersed init on hard geometry is a separate warmup-robustness limitation, out of scope here.
- On funnel-like targets the diagonal metric can reduce per-draw ESS vs identity's fine-step regime (an **efficiency caveat, not a bias** — per-dimension posterior means agree across all configs to ~0.01, receipts in review); the floor recovers most of it.
- λ_max ≤ d for a correlation matrix, so the floor cannot bind at the default `max_leapfrog_steps=1000`; the cap+flag is belt-and-suspenders for tight budgets.

## Review

Adversarially reviewed pre-PR (planted-bug protocol: 6 mutations, 3 initial survivors → **two verified-killer tests added** — a whitened-criterion correctness test (rtol=1e-6, kill margins 9–15%) and a numeric floor-constant test; claim-vs-data audit; degenerate-input attacks incl. float32 near-singular covariances) + two are-you-sure challenge rounds. The one flagged anomaly (a marginal z on irt_2pl) was **exonerated with receipts**: it straddles the d-aware review line across seeds, the ground-truth-free per-dimension mean-differences between all configs sit below the noise ceiling in every dimension, and the z-spread traces entirely to denominators + argmax movement over 144 dims. Disclosed limits: the floor-bias null is powered to ~0.05σ (2 seeds); power-iteration staleness measured ≤0.33% at d=390.

Tests: 22 (13 pre-existing unchanged + 9 added across the package). Sibling design conventions follow #954 (MEADS-LRD): opt-in `None` default, engagement gates, private ablation seams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
