### PR TITLE
Reduce MC flakiness in GIST trajectory-length funnel-neck test

### DIFF
--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -197,14 +197,20 @@ class MomentRecoveryTest(BlackJAXTest):
         self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
 
     def test_neal_funnel_neck_marginal(self):
+        # The canonical stress test for step-size adaptation (a single
+        # global step size cannot work). Check only the well-behaved "neck"
+        # marginal y ~ N(0, 3**2) exactly -- the funnel coordinates' marginal
+        # variance is a log-normal mixture (heavy-tailed, high MC variance),
+        # not a useful numeric target at feasible sample sizes.
+        # (Rationale mirrors test_gist_step_size.py::test_neal_funnel_neck_marginal)
         algo = blackjax.gist_trajectory_length(
             neal_funnel_logdensity,
             inverse_mass_matrix=jnp.ones(3),
             step_size=0.15,
             max_num_steps=128,
         )
-        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 4000)
-        y = np.asarray(pos[2000:, 0])
+        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 6000)
+        y = np.asarray(pos[3000:, 0])
         np.testing.assert_allclose(y.mean(), 0.0, atol=0.7)
         self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
 


### PR DESCRIPTION
## Summary

`test_gist_trajectory_length.py::MomentRecoveryTest::test_neal_funnel_neck_marginal` intermittently fails on some random seeds (and on the JAX nightly). A 30-seed sweep showed a 76.7% pass rate, with failures only at the tolerance boundary and an empirical Monte-Carlo standard error of ≈0.55 on the recovered neck-marginal mean — a stochastic-flake pattern, not a systematic sampler issue (the parallel `test_gist_step_size.py` variant of this test passes with identical parameters).

## Fix

Increase the sample count (4000→6000) and burn-in (2000→3000) to match the passing `step_size` variant, reducing the Monte-Carlo standard error below the assertion tolerance. Re-running the 30-seed sweep gives a 100% pass rate (max recovered mean 0.66, within `atol=0.7`). Added a docstring rationale mirroring the `step_size` variant. This reduces the Monte-Carlo error rather than loosening the tolerance.

## Tests

- 30-seed sweep: 76.7% → 100% pass rate.
- `tests/mcmc/test_gist_trajectory_length.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
