### PR TITLE
Replace progress-bar mechanism with a scan-instrumenting context manager

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -41,6 +41,7 @@ from .mcmc.random_walk import (
 )
 from .ns import nss as _nss
 from .optimizers import dual_averaging, lbfgs
+from .progress_bar import progress_bar
 from .sgmcmc import csgld as _csgld
 from .sgmcmc import sghmc as _sghmc
 from .sgmcmc import sgld as _sgld
@@ -308,4 +309,5 @@ __all__ = [
     "rhat",
     "SamplingAlgorithm",  # base
     "VIAlgorithm",
+    "progress_bar",  # progress bar context manager
 ]

--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -100,7 +100,6 @@ from blackjax.adaptation.step_size import (
 from blackjax.adaptation.window_adaptation import build_schedule
 from blackjax.base import AdaptationAlgorithm
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix, gaussian_euclidean_low_rank
-from blackjax.progress_bar import gen_scan_fn
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 from blackjax.util import pytree_size
 
@@ -1033,7 +1032,6 @@ def window_adaptation_low_rank(
     target_acceptance_rate: float = 0.80,
     gamma: float = 1e-5,
     cutoff: float = 2.0,
-    progress_bar: bool = False,
     adaptation_info_fn: Callable = _default_low_rank_adaptation_info_fn,
     integrator=mcmc.integrators.velocity_verlet,
     gradient_based_init: bool = False,
@@ -1072,8 +1070,6 @@ def window_adaptation_low_rank(
     cutoff
         Eigenvectors with eigenvalue in ``[1/cutoff, cutoff]`` are masked.
         Default ``2.0`` matches nutpie's ``c=2``.
-    progress_bar
-        Show a progress bar during warmup.
     adaptation_info_fn
         Controls what adaptation info is retained; see
         ``blackjax.adaptation.base``. Default
@@ -1128,6 +1124,11 @@ def window_adaptation_low_rank(
     production sampling.  The last chain state from warmup is available as
     ``warmup_info[-1].state``, and μ* as
     ``warmup_info[-1].adaptation_state.mu_star``.
+
+    Notes
+    -----
+    Wrap ``warmup.run(...)`` in :func:`blackjax.progress_bar` to display a
+    progress bar, e.g. ``with blackjax.progress_bar(): warmup.run(...)``.
     """
     if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
         mcmc_kernel = algorithm.build_kernel(integrator)
@@ -1202,11 +1203,8 @@ def window_adaptation_low_rank(
             buffer_size,
         )
 
-        if progress_bar:
-            print("Running low-rank window adaptation")
-        scan_fn = gen_scan_fn(num_steps, progress_bar=progress_bar)
         keys = jax.random.split(rng_key, num_steps)
-        last_state, info = scan_fn(
+        last_state, info = jax.lax.scan(
             one_step,
             (init_state, init_adaptation_state),
             (jnp.arange(num_steps), keys, schedule),

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -29,7 +29,6 @@ from blackjax.adaptation.step_size import (
     dual_averaging_adaptation,
 )
 from blackjax.base import AdaptationAlgorithm
-from blackjax.progress_bar import gen_scan_fn
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 from blackjax.util import pytree_size
 
@@ -263,7 +262,6 @@ def window_adaptation(
     imm_shrinkage_to_previous: float = 0.0,
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,
-    progress_bar: bool = False,
     adaptation_info_fn: Callable = return_all_adapt_info,
     integrator=mcmc.integrators.velocity_verlet,
     **extra_parameters,
@@ -335,8 +333,6 @@ def window_adaptation(
         The initial step size used in the algorithm.
     target_acceptance_rate
         The acceptance rate that we target during step size adaptation.
-    progress_bar
-        Whether we should display a progress bar.
     adaptation_info_fn
         Function to select the adaptation info returned. See return_all_adapt_info
         and get_filter_adapt_info_fn in blackjax.adaptation.base.  By default all
@@ -349,6 +345,11 @@ def window_adaptation(
     Returns
     -------
     A function that runs the adaptation and returns an `AdaptationResult` object.
+
+    Notes
+    -----
+    Wrap ``warmup.run(...)`` in :func:`blackjax.progress_bar` to display a
+    progress bar, e.g. ``with blackjax.progress_bar(): warmup.run(...)``.
 
     """
     # Validate initial_inverse_mass_matrix shape against is_mass_matrix_diagonal.
@@ -416,13 +417,10 @@ def window_adaptation(
         init_state = algorithm.init(position, logdensity_fn)
         init_adaptation_state = adapt_init(position, initial_step_size)
 
-        if progress_bar:
-            print("Running window adaptation")
-        scan_fn = gen_scan_fn(num_steps, progress_bar=progress_bar)
         start_state = (init_state, init_adaptation_state)
         keys = jax.random.split(rng_key, num_steps)
         schedule = build_schedule(num_steps)
-        last_state, info = scan_fn(
+        last_state, info = jax.lax.scan(
             one_step,
             start_state,
             (jnp.arange(num_steps), keys, schedule),

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -25,6 +25,7 @@ import os
 import threading
 import time
 import uuid
+import warnings
 from contextlib import contextmanager
 
 import jax
@@ -36,6 +37,27 @@ _original_scan = jax.lax.scan
 _scan_depth = threading.local()
 _progress_registry: dict = {}  # uuid -> ProgressState
 
+# The scan implementation captured on the empty->non-empty registry
+# transition (i.e. whatever `jax.lax.scan` pointed to when the FIRST
+# concurrently-active progress_bar() context was entered). This may be a
+# third-party monkeypatch rather than `_original_scan` -- capturing and
+# restoring THIS value (instead of unconditionally restoring the import-time
+# original) avoids clobbering a foreign patch that predates or outlives our
+# own. `None` means no session is currently open.
+_session_scan = None
+
+
+def _underlying_scan():
+    """The scan implementation to delegate to for anything we do not
+    instrument (nested scans, no active context, etc).
+
+    Falls back to a captured foreign patch if one was installed before our
+    session started, so a pre-existing third-party `jax.lax.scan` patch
+    keeps functioning for calls made *inside* our context instead of being
+    silently bypassed -- true chaining, not just non-clobbering on exit.
+    """
+    return _session_scan if _session_scan is not None else _original_scan
+
 
 def _patched_scan(f, init, xs=None, length=None, **kwargs):
     """Drop-in replacement for ``jax.lax.scan`` installed while a
@@ -43,24 +65,39 @@ def _patched_scan(f, init, xs=None, length=None, **kwargs):
 
     Only the *outermost* ``lax.scan`` encountered at trace time is
     instrumented -- nested scans (e.g. a thinning inner loop) fall through to
-    the original ``lax.scan`` unmodified. Outermost-ness is tracked with a
+    the underlying ``lax.scan`` unmodified. Outermost-ness is tracked with a
     thread-local depth counter that increments for the duration of tracing
-    ``f`` (which happens synchronously inside the call to the original
+    ``f`` (which happens synchronously inside the call to the underlying
     ``lax.scan`` below), so any ``lax.scan`` call made from within ``f`` sees
     a depth > 0 and is left alone.
+
+    Attribution when multiple ``progress_bar()`` contexts are simultaneously
+    active (e.g. one per thread): with exactly one context active, ANY
+    calling thread is attributed to it (this is what makes "enter the
+    context on the main thread, run the scan on a worker thread" work). Once
+    a second context is active, attribution requires an exact match between
+    the calling thread and the context's *owner* thread (the thread that
+    called ``__enter__``); a scan from any other thread -- including a
+    genuine bystander or another context's own delegate -- falls through
+    with no bar rather than risk guessing wrong. See the module docstring
+    Notes for the fully disclosed decision table.
     """
     depth = getattr(_scan_depth, "value", 0)
     _scan_depth.value = depth + 1
     try:
         active = list(_progress_registry.values())
         if depth == 0 and active:
-            # Innermost-active-context wins when progress_bar() contexts are
-            # nested (rare, but well-defined: latest entered = latest in the
-            # registry's insertion order).
-            state = active[-1]
+            if len(active) >= 2:
+                here = threading.get_ident()
+                owned = [s for s in active if s.owner_thread == here]
+                if not owned:
+                    return _underlying_scan()(f, init, xs=xs, length=length, **kwargs)
+                state = owned[-1]
+            else:
+                state = active[-1]
             return _inject_progress(f, init, xs, length, state, **kwargs)
         else:
-            return _original_scan(f, init, xs=xs, length=length, **kwargs)
+            return _underlying_scan()(f, init, xs=xs, length=length, **kwargs)
     finally:
         _scan_depth.value = depth
 
@@ -70,25 +107,43 @@ def _inject_progress(f, init, xs, length, state, **kwargs):
     carry) and fire a callback on every step."""
     if length is not None:
         n = length
+        if xs is not None:
+            leaves = jax.tree.leaves(xs)
+            if leaves and leaves[0].shape[0] != n:
+                # length disagrees with xs's own leading dimension -- let
+                # the underlying scan raise its own actionable error
+                # ("scan got `length` argument of ... which disagrees
+                # with ...") instead of us augmenting xs and having JAX
+                # blame an error on our internally-built pytree.
+                return _underlying_scan()(f, init, xs=xs, length=length, **kwargs)
     elif xs is not None:
         leaves = jax.tree.leaves(xs)
         if not leaves:
-            return _original_scan(f, init, xs=xs, length=length, **kwargs)
+            return _underlying_scan()(f, init, xs=xs, length=length, **kwargs)
         n = leaves[0].shape[0]
     else:
-        return _original_scan(f, init, xs=xs, length=length, **kwargs)
+        return _underlying_scan()(f, init, xs=xs, length=length, **kwargs)
 
     state.n_steps = n
+    reverse = kwargs.get("reverse", False)
     indices = jnp.arange(n)
 
     def f_wrapped(carry, augmented_x):
         original_x, idx = augmented_x
-        # debug.callback returns None -> no result_shape_dtypes -> no shape
-        # mismatch under vmap (unlike io_callback with a scalar result).
-        jax.debug.callback(state._step_callback, idx, ordered=False)
+        # `display_idx` is a pure function of the static `n` and the
+        # unbatched `idx` (jnp.arange(n)) -- it never touches the batched
+        # axis under vmap, which is what makes the callback fire exactly
+        # once per real step regardless of chain count (see
+        # _step_callback's docstring and the module Notes). If a future
+        # change ever passes a value here that DOES depend on the vmapped
+        # input, JAX's vmap batching rule will unroll it into one call per
+        # batch element per step, silently breaking that guarantee --
+        # re-validate vmap behavior before adding any batched argument.
+        display_idx = (n - 1 - idx) if reverse else idx
+        jax.debug.callback(state._step_callback, display_idx, ordered=False)
         return f(carry, original_x)
 
-    return _original_scan(f_wrapped, init, xs=(xs, indices), length=None, **kwargs)
+    return _underlying_scan()(f_wrapped, init, xs=(xs, indices), length=None, **kwargs)
 
 
 class ProgressState:
@@ -104,6 +159,10 @@ class ProgressState:
         self.print_rate = print_rate  # None -> resolved lazily
         self.output_file = output_file
         self.current_step = 0
+        self.owner_thread = threading.get_ident()
+        self.closed = False
+        self._output_file_warned = False
+        self._callback_warned = False
         self._bar = None
         self._tqdm_cls = None
         self._stop_event = threading.Event()
@@ -115,25 +174,66 @@ class ProgressState:
         return max(1, self.n_steps // 20)
 
     def _step_callback(self, idx):
-        """Runs on the host once per scan step (outermost scan only)."""
-        step = int(idx)
-        rate = self._resolved_print_rate()
-        if step % rate == 0 or step == self.n_steps - 1:
-            # Track the max seen so the bar stays monotone even if steps
-            # arrive out of order (e.g. under some future scheduling).
-            # `step == 0` is an unconditional reset: on a multi-phase run
-            # (e.g. mclmc_find_L_and_step_size's ~5 sequential warmup scans),
-            # this is what tells _render_loop a new phase has started even
-            # when the new phase happens to have the same length as the
-            # previous one (so `n_steps` alone would not change) -- see
-            # _render_loop's `cur < last` check.
-            if step > self.current_step or step == 0:
-                self.current_step = step
-            if self.output_file:
-                tmp = self.output_file + ".tmp"
-                with open(tmp, "w") as fh:
-                    fh.write(f"{step} {self.n_steps}")
-                os.replace(tmp, self.output_file)  # atomic
+        """Runs on the host once per scan step (outermost scan only).
+
+        INVARIANT: this function must never raise. It executes inside a
+        ``jax.debug.callback``; an exception here crosses back into the XLA
+        runtime as a fatal ``JaxRuntimeError`` and kills the ENTIRE traced
+        computation, not just the progress display -- e.g. an
+        ``output_file`` write failure (a permission change, a full disk, an
+        NFS hiccup) must never be allowed to crash an in-progress sampling
+        run. The outer ``except Exception`` is intentionally broad: the
+        invariant is unconditional and the specific ways a host callback can
+        fail cannot be enumerated in advance. The inner ``except OSError``
+        handles the one recurring, retryable-looking failure (the
+        ``output_file`` write) so we stop paying a doomed write on every
+        remaining step instead of relying on the outer catch every time.
+        """
+        if self.closed:
+            return
+        try:
+            step = int(idx)
+            rate = self._resolved_print_rate()
+            if rate <= 0:  # print_rate=0 is an innocent typo, not a crash
+                rate = 1
+            if step % rate == 0 or step == self.n_steps - 1:
+                # Track the max seen so the bar stays monotone even if steps
+                # arrive out of order (e.g. under some future scheduling).
+                # `step == 0` is an unconditional reset: on a multi-phase
+                # run (e.g. mclmc_find_L_and_step_size's ~5 sequential
+                # warmup scans), this is what tells _render_loop a new
+                # phase has started even when the new phase happens to have
+                # the same length as the previous one (so `n_steps` alone
+                # would not change) -- see _render_loop's `cur < last`
+                # check.
+                if step > self.current_step or step == 0:
+                    self.current_step = step
+                if self.output_file:
+                    try:
+                        tmp = self.output_file + ".tmp"
+                        with open(tmp, "w") as fh:
+                            fh.write(f"{step} {self.n_steps}")
+                        os.replace(tmp, self.output_file)  # atomic
+                    except OSError as e:
+                        if not self._output_file_warned:
+                            warnings.warn(
+                                "blackjax.progress_bar: disabling "
+                                f"output_file after a write failure ({e!r}) "
+                                "-- the progress bar itself is unaffected.",
+                                stacklevel=2,
+                            )
+                            self._output_file_warned = True
+                        self.output_file = None
+        except Exception as e:  # noqa: BLE001 -- see invariant above
+            if not self._callback_warned:
+                warnings.warn(
+                    "blackjax.progress_bar: internal callback error "
+                    f"({e!r}) -- further progress updates for this context "
+                    "are disabled, but the underlying computation is "
+                    "unaffected.",
+                    stacklevel=2,
+                )
+                self._callback_warned = True
 
     def _start_display(self):
         from tqdm.auto import tqdm
@@ -208,16 +308,59 @@ def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
 
     Notes
     -----
-    Works under ``jax.vmap`` -- the bar shows the maximum step seen across
-    chains instead of crashing (fixes #927).
+    Works under ``jax.vmap`` -- the injected step index is a compile-time
+    constant (``jnp.arange(n)``) that never depends on the batched axis, so
+    it stays unbatched and the callback fires exactly once per real scan
+    step regardless of chain count, instead of the shape-mismatch crash the
+    old ``io_callback``-based mechanism had (fixes #927).
 
     Only the outermost ``jax.lax.scan`` traced *while this context is
-    active* is instrumented. Because ``jax.jit`` caches compiled functions, a
-    function traced once outside this context (and cached) will not show a
-    bar even if later called from inside it -- and conversely a function
-    traced inside this context keeps its callback baked in even after the
-    context exits. Force a retrace (e.g. by clearing the JIT cache, or by not
-    pre-jitting) if you need the bar to reliably appear.
+    active* is instrumented. The retrace boundary that actually matters is
+    repeated calls to an already-traced/jit'd/checkpointed function across
+    DIFFERENT ``progress_bar()`` contexts -- a fresh ``jax.jit(fn)`` wrapper
+    is NOT itself a retrace boundary (JAX's jit cache is keyed by function
+    identity, not by whether a progress_bar context happens to be active),
+    so calling the SAME compiled function again inside a *later* context
+    reuses the cached trace and its callback stays baked in from whichever
+    context (if any) was active the FIRST time it was traced. Safe pattern:
+    keep ONE ``progress_bar()`` context open across all repeated calls to
+    the same compiled function. Workaround if you must re-enter: force a
+    retrace with ``jax.clear_caches()`` before the next call. A stale
+    baked-in callback also has a small phantom cost (~32us/step of host
+    dispatch) on every future execution into an already-closed, inert
+    state.
+
+    Under ``jax.checkpoint`` combined with differentiation, the wrapped scan
+    body -- including the injected callback -- runs twice per logical step
+    (primal pass + backward-pass recompute), so the displayed step
+    count/rate appear roughly doubled; computed values and gradients are
+    unaffected.
+
+    **Process-global patch -- scope and boundaries.** This context manager
+    monkeypatches ``jax.lax.scan`` for its duration, which has consequences
+    beyond the ``with`` block itself:
+
+    * Only use the ``with`` form. A manually ``__enter__``ed context (e.g.
+      in an interactive session) that is never ``__exit__``ed leaves
+      ``jax.lax.scan`` patched for the rest of the process/kernel session.
+    * With exactly one context active, ANY calling thread's top-level scan
+      is attributed to it -- this is what makes "enter the context on the
+      main thread, run sampling on a worker thread/executor" work, but it
+      also means a genuinely unrelated bystander scan on another thread is
+      indistinguishable from that pattern and gets the same bar. With two
+      or more contexts simultaneously active, attribution instead requires
+      an exact owner-thread match (the thread that called ``__enter__``); a
+      scan from any other thread -- including a legitimate delegate of one
+      of the active contexts -- falls through with no bar rather than risk
+      misattributing it to the wrong context.
+    * Under ``jax.shard_map``/multi-device execution the callback fires
+      once per device per step (``N`` times the host-callback overhead);
+      the bar can reach 100% while a slower shard is still running.
+    * A ``functools.partial(jax.lax.scan, ...)`` captured before the
+      context is entered keeps a reference to the un-patched function and
+      silently bypasses the bar entirely (no error, no bar).
+    * If two contexts share the same ``output_file`` path, their writes
+      interleave and corrupt the file -- use a unique path per context.
 
     Examples
     --------
@@ -228,20 +371,32 @@ def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
                 blackjax.nuts, logdensity_fn
             ).run(rng_key, initial_position, 1000)
     """
+    global _session_scan
+
     key = str(uuid.uuid4())
     state = ProgressState(label=label, print_rate=print_rate, output_file=output_file)
+    if not _progress_registry:  # empty -> non-empty: this is the session opener
+        _session_scan = (
+            jax.lax.scan
+        )  # capture whatever is installed now (foreign or original)
     _progress_registry[key] = state
     jax.lax.scan = _patched_scan
     state._start_display()
     try:
         yield state
     finally:
+        state.closed = True
         state._stop_event.set()
         if state._display_thread is not None:
             state._display_thread.join(timeout=2.0)
         del _progress_registry[key]
-        if not _progress_registry:
-            jax.lax.scan = _original_scan
+        if not _progress_registry:  # non-empty -> empty: this is the session closer
+            if jax.lax.scan is _patched_scan:
+                jax.lax.scan = _session_scan
+            # Else: something else replaced jax.lax.scan while we were
+            # active -- leave it alone rather than clobbering a foreign
+            # patch installed during our session.
+            _session_scan = None
         # Clear before removing: a jit-cached function traced inside this
         # context keeps its callback baked in after exit (see the docstring
         # Notes), and a post-exit call would otherwise resurrect the file
@@ -249,3 +404,16 @@ def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
         state.output_file = None
         if output_file and os.path.exists(output_file):
             os.remove(output_file)
+        if state.n_steps == 0:
+            warnings.warn(
+                "blackjax.progress_bar: no scan step was ever observed "
+                "inside this context. Either the wrapped code never called "
+                "jax.lax.scan, or the function was already "
+                "jit-compiled/traced before this context was entered "
+                "(jax.jit's cache is keyed by function identity, so a "
+                "cache hit skips retracing and the injected callback never "
+                "gets baked in). Keep ONE progress_bar() context open "
+                "across repeated calls to the same compiled function, or "
+                "force a retrace with jax.clear_caches().",
+                stacklevel=2,
+            )

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -11,108 +11,206 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Progress bar decorators for use with step functions.
-Adapted from Jeremie Coullon's blog post :cite:p:`progress_bar`.
+"""A ``jax.lax.scan``-monkeypatching progress bar for BlackJAX.
+
+Supersedes the old ``gen_scan_fn``/``progress_bar_scan`` mechanism (which
+augmented the scan *carry* with a ``chain_id`` and broke under ``jax.vmap``
+with a shape mismatch in its ``io_callback`` result -- see issue #927). This
+module instead augments the scan ``xs`` with a step index and fires a
+``jax.debug.callback`` (which returns ``None``, so there is no result shape to
+mismatch under ``vmap``); the carry is never touched, so it composes cleanly
+with any transformation that batches or otherwise rewrites the carry.
 """
-from threading import Lock
+import os
+import threading
+import time
+import uuid
+from contextlib import contextmanager
 
-from jax import lax
-from jax.experimental import io_callback
-from jax.numpy import array
+import jax
+import jax.numpy as jnp
+
+__all__ = ["progress_bar"]
+
+_original_scan = jax.lax.scan
+_scan_depth = threading.local()
+_progress_registry: dict = {}  # uuid -> ProgressState
 
 
-def progress_bar_scan(num_samples, print_rate=None):
-    "Progress bar for a JAX scan"
-    progress_bars = {}
-    idx_counter = 0
-    lock = Lock()
+def _patched_scan(f, init, xs=None, length=None, **kwargs):
+    """Drop-in replacement for ``jax.lax.scan`` installed while a
+    :func:`progress_bar` context is active.
 
-    if print_rate is None:
-        if num_samples > 20:
-            print_rate = int(num_samples / 20)
+    Only the *outermost* ``lax.scan`` encountered at trace time is
+    instrumented -- nested scans (e.g. a thinning inner loop) fall through to
+    the original ``lax.scan`` unmodified. Outermost-ness is tracked with a
+    thread-local depth counter that increments for the duration of tracing
+    ``f`` (which happens synchronously inside the call to the original
+    ``lax.scan`` below), so any ``lax.scan`` call made from within ``f`` sees
+    a depth > 0 and is left alone.
+    """
+    depth = getattr(_scan_depth, "value", 0)
+    _scan_depth.value = depth + 1
+    try:
+        active = list(_progress_registry.values())
+        if depth == 0 and active:
+            # Innermost-active-context wins when progress_bar() contexts are
+            # nested (rare, but well-defined: latest entered = latest in the
+            # registry's insertion order).
+            state = active[-1]
+            return _inject_progress(f, init, xs, length, state, **kwargs)
         else:
-            print_rate = 1  # if you run the sampler for less than 20 iterations
-
-    def _calc_chain_idx(iter_num):
-        nonlocal idx_counter
-        with lock:
-            idx = idx_counter
-            idx_counter += 1
-        return idx
-
-    def _update_bar(arg, chain_id):
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            try:
-                from fastprogress.fastprogress import progress_bar
-            except ImportError as e:
-                raise ImportError(
-                    "fastprogress is required to use progress bars. "
-                    "Install it with: pip install fastprogress"
-                ) from e
-        chain_id = int(chain_id)
-        if arg == 0:
-            chain_id = _calc_chain_idx(arg)
-            progress_bars[chain_id] = progress_bar(range(num_samples))
-            progress_bars[chain_id].update(0)
-
-        progress_bars[chain_id].update_bar(arg + 1)
-        return chain_id
-
-    def _close_bar(arg, chain_id):
-        progress_bars[int(chain_id)].on_iter_end()
-
-    def _update_progress_bar(iter_num, chain_id):
-        "Updates progress bar of a JAX scan or loop"
-
-        chain_id = lax.cond(
-            # update every multiple of `print_rate` except at the end
-            (iter_num % print_rate == 0) | (iter_num == (num_samples - 1)),
-            lambda: io_callback(_update_bar, array(0), iter_num, chain_id),
-            lambda: chain_id,
-        )
-
-        _ = lax.cond(
-            iter_num == num_samples - 1,
-            lambda: io_callback(_close_bar, None, iter_num + 1, chain_id),
-            lambda: None,
-        )
-        return chain_id
-
-    def _progress_bar_scan(func):
-        """Decorator that adds a progress bar to `body_fun` used in `lax.scan`.
-        Note that `body_fun` must either be looping over `np.arange(num_samples)`,
-        or be looping over a tuple who's first element is `np.arange(num_samples)`
-        This means that `iter_num` is the current iteration number
-        """
-
-        def wrapper_progress_bar(carry, x):
-            if type(x) is tuple:
-                iter_num, *_ = x
-            else:
-                iter_num = x
-            subcarry, chain_id = carry
-            chain_id = _update_progress_bar(iter_num, chain_id)
-            subcarry, y = func(subcarry, x)
-
-            return (subcarry, chain_id), y
-
-        return wrapper_progress_bar
-
-    return _progress_bar_scan
+            return _original_scan(f, init, xs=xs, length=length, **kwargs)
+    finally:
+        _scan_depth.value = depth
 
 
-def gen_scan_fn(num_samples, progress_bar, print_rate=None):
-    if progress_bar:
-
-        def scan_wrap(f, init, *args, **kwargs):
-            func = progress_bar_scan(num_samples, print_rate)(f)
-            carry = (init, -1)
-            (last_state, _), output = lax.scan(func, carry, *args, **kwargs)
-            return last_state, output
-
-        return scan_wrap
+def _inject_progress(f, init, xs, length, state, **kwargs):
+    """Wrap ``f`` so a step index is threaded through ``xs`` (never the
+    carry) and fire a callback on every step."""
+    if length is not None:
+        n = length
+    elif xs is not None:
+        leaves = jax.tree.leaves(xs)
+        if not leaves:
+            return _original_scan(f, init, xs=xs, length=length, **kwargs)
+        n = leaves[0].shape[0]
     else:
-        return lax.scan
+        return _original_scan(f, init, xs=xs, length=length, **kwargs)
+
+    state.n_steps = n
+    indices = jnp.arange(n)
+
+    def f_wrapped(carry, augmented_x):
+        original_x, idx = augmented_x
+        # debug.callback returns None -> no result_shape_dtypes -> no shape
+        # mismatch under vmap (unlike io_callback with a scalar result).
+        jax.debug.callback(state._step_callback, idx, ordered=False)
+        return f(carry, original_x)
+
+    return _original_scan(f_wrapped, init, xs=(xs, indices), length=None, **kwargs)
+
+
+class ProgressState:
+    """Mutable, shared state for one active :func:`progress_bar` context.
+
+    A plain Python object closed over by the ``jax.debug.callback`` -- it
+    never enters the traced computation itself, only the step index does.
+    """
+
+    def __init__(self, label, print_rate, output_file):
+        self.label = label
+        self.n_steps = 0
+        self.print_rate = print_rate  # None -> resolved lazily
+        self.output_file = output_file
+        self.current_step = 0
+        self._bar = None
+        self._tqdm_cls = None
+        self._stop_event = threading.Event()
+        self._display_thread = None
+
+    def _resolved_print_rate(self):
+        if self.print_rate is not None:
+            return self.print_rate
+        return max(1, self.n_steps // 20)
+
+    def _step_callback(self, idx):
+        """Runs on the host once per scan step (outermost scan only)."""
+        step = int(idx)
+        rate = self._resolved_print_rate()
+        if step % rate == 0 or step == self.n_steps - 1:
+            # Track the max seen so the bar stays monotone even if steps
+            # arrive out of order (e.g. under some future scheduling).
+            if step > self.current_step or step == 0:
+                self.current_step = step
+            if self.output_file:
+                tmp = self.output_file + ".tmp"
+                with open(tmp, "w") as fh:
+                    fh.write(f"{step} {self.n_steps}")
+                os.replace(tmp, self.output_file)  # atomic
+
+    def _start_display(self):
+        from tqdm.auto import tqdm
+
+        self._tqdm_cls = tqdm
+        self._display_thread = threading.Thread(target=self._render_loop, daemon=True)
+        self._display_thread.start()
+
+    def _render_loop(self):
+        bar = None
+        last = -1
+        while not self._stop_event.is_set():
+            # n_steps is unknown until the outermost scan is traced, so wait
+            # for it before creating the bar.
+            if self.n_steps > 0 and bar is None:
+                bar = self._tqdm_cls(total=self.n_steps, desc=self.label, unit="step")
+            if bar is not None:
+                cur = self.current_step
+                if cur != last:
+                    bar.n = cur + 1
+                    bar.refresh()
+                    last = cur
+            time.sleep(0.1)
+        if bar is not None:
+            bar.n = self.n_steps
+            bar.refresh()
+            bar.close()
+
+
+@contextmanager
+def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
+    """Add a progress bar to any BlackJAX sampling call.
+
+    Automatically detects the outermost ``jax.lax.scan`` in the wrapped code
+    and injects a step counter, without requiring any parameter on the
+    algorithm being run.
+
+    Parameters
+    ----------
+    label
+        Display label for the progress bar.
+    print_rate
+        Update every ``print_rate`` steps. Defaults to ``max(1, num_steps // 20)``.
+    output_file
+        If given, atomically writes ``"<step> <total>"`` to this path on each
+        update. Display it from another terminal with
+        ``python -m blackjax.progress_reader <path>``.
+
+    Notes
+    -----
+    Works under ``jax.vmap`` -- the bar shows the maximum step seen across
+    chains instead of crashing (fixes #927).
+
+    Only the outermost ``jax.lax.scan`` traced *while this context is
+    active* is instrumented. Because ``jax.jit`` caches compiled functions, a
+    function traced once outside this context (and cached) will not show a
+    bar even if later called from inside it -- and conversely a function
+    traced inside this context keeps its callback baked in even after the
+    context exits. Force a retrace (e.g. by clearing the JIT cache, or by not
+    pre-jitting) if you need the bar to reliably appear.
+
+    Examples
+    --------
+    .. code::
+
+        with blackjax.progress_bar(label="NUTS warmup"):
+            (state, params), _ = blackjax.window_adaptation(
+                blackjax.nuts, logdensity_fn
+            ).run(rng_key, initial_position, 1000)
+    """
+    key = str(uuid.uuid4())
+    state = ProgressState(label=label, print_rate=print_rate, output_file=output_file)
+    _progress_registry[key] = state
+    jax.lax.scan = _patched_scan
+    state._start_display()
+    try:
+        yield state
+    finally:
+        state._stop_event.set()
+        if state._display_thread is not None:
+            state._display_thread.join(timeout=2.0)
+        del _progress_registry[key]
+        if not _progress_registry:
+            jax.lax.scan = _original_scan
+        if output_file and os.path.exists(output_file):
+            os.remove(output_file)

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -212,5 +212,10 @@ def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
         del _progress_registry[key]
         if not _progress_registry:
             jax.lax.scan = _original_scan
+        # Clear before removing: a jit-cached function traced inside this
+        # context keeps its callback baked in after exit (see the docstring
+        # Notes), and a post-exit call would otherwise resurrect the file
+        # we are about to delete via that stale _step_callback.
+        state.output_file = None
         if output_file and os.path.exists(output_file):
             os.remove(output_file)

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -121,6 +121,12 @@ class ProgressState:
         if step % rate == 0 or step == self.n_steps - 1:
             # Track the max seen so the bar stays monotone even if steps
             # arrive out of order (e.g. under some future scheduling).
+            # `step == 0` is an unconditional reset: on a multi-phase run
+            # (e.g. mclmc_find_L_and_step_size's ~5 sequential warmup scans),
+            # this is what tells _render_loop a new phase has started even
+            # when the new phase happens to have the same length as the
+            # previous one (so `n_steps` alone would not change) -- see
+            # _render_loop's `cur < last` check.
             if step > self.current_step or step == 0:
                 self.current_step = step
             if self.output_file:
@@ -142,10 +148,34 @@ class ProgressState:
         while not self._stop_event.is_set():
             # n_steps is unknown until the outermost scan is traced, so wait
             # for it before creating the bar.
-            if self.n_steps > 0 and bar is None:
-                bar = self._tqdm_cls(total=self.n_steps, desc=self.label, unit="step")
-            if bar is not None:
+            if self.n_steps > 0:
                 cur = self.current_step
+                # Detect a new phase on a multi-phase run (e.g.
+                # mclmc_find_L_and_step_size's ~5 sequential warmup scans of
+                # different lengths, immediately followed by a sampling
+                # scan): `n_steps` changing is the common case, but two
+                # consecutive phases can share the same length, in which
+                # case `n_steps` alone would not signal the restart -- `cur
+                # < last` catches that (a new phase's step 0 always resets
+                # `current_step`, see _step_callback). Either signal resets
+                # the bar so its total/elapsed-timer/rate stats reflect the
+                # new phase instead of freezing at the first phase's total
+                # (the observed bug) or overflowing into tqdm's unbounded
+                # counter mode once a later phase runs longer than the
+                # first. `n_steps` is written at trace time, strictly
+                # before that phase's first callback can fire, so the only
+                # possible race is a single stale tick where this loop
+                # observes the new `n_steps` before `current_step` has been
+                # reset to 0 by that phase's first callback -- harmless,
+                # self-corrects on the very next 0.1s tick.
+                if bar is None:
+                    bar = self._tqdm_cls(
+                        total=self.n_steps, desc=self.label, unit="step"
+                    )
+                    last = -1
+                elif self.n_steps != bar.total or cur < last:
+                    bar.reset(total=self.n_steps)
+                    last = -1
                 if cur != last:
                     bar.n = cur + 1
                     bar.refresh()

--- a/blackjax/progress_bar.py
+++ b/blackjax/progress_bar.py
@@ -37,6 +37,21 @@ _original_scan = jax.lax.scan
 _scan_depth = threading.local()
 _progress_registry: dict = {}  # uuid -> ProgressState
 
+# Guards the registry empty<->non-empty transitions and the _session_scan
+# capture/restore below (progress_bar() enter/exit only -- NOT held across
+# the `yield`, and NOT touched by _patched_scan/_inject_progress on the
+# scan-tracing hot path). Without this, two threads racing to be the FIRST
+# entrant could both observe an empty registry before either inserts: the
+# second to actually patch `jax.lax.scan` would have the FIRST's bare
+# `_patched_scan` visible as "the current jax.lax.scan" and capture that as
+# `_session_scan`, making `_underlying_scan()` return `_patched_scan` itself
+# -- infinite self-recursion on every subsequent pass-through call. Holding
+# this lock around the narrow enter/exit critical section (a dict insert/del
+# plus one attribute read-or-write) serializes exactly that race at
+# essentially zero cost, since entering/exiting a context is rare compared
+# to the scans that run inside it.
+_registry_lock = threading.Lock()
+
 # The scan implementation captured on the empty->non-empty registry
 # transition (i.e. whatever `jax.lax.scan` pointed to when the FIRST
 # concurrently-active progress_bar() context was entered). This may be a
@@ -188,6 +203,14 @@ class ProgressState:
         handles the one recurring, retryable-looking failure (the
         ``output_file`` write) so we stop paying a doomed write on every
         remaining step instead of relying on the outer catch every time.
+
+        Both handlers mutate state (the warned-once flag, disabling
+        ``output_file``) BEFORE attempting to warn, and wrap the
+        ``warnings.warn`` call itself in its own ``try/except``: if the
+        active warnings filter promotes ``UserWarning`` to an error (this
+        project's own ``pytest.ini`` does), the courtesy warning must not be
+        allowed to become the very exception this function exists to
+        prevent -- the never-raise invariant outranks the warning.
         """
         if self.closed:
             return
@@ -215,25 +238,40 @@ class ProgressState:
                             fh.write(f"{step} {self.n_steps}")
                         os.replace(tmp, self.output_file)  # atomic
                     except OSError as e:
-                        if not self._output_file_warned:
-                            warnings.warn(
-                                "blackjax.progress_bar: disabling "
-                                f"output_file after a write failure ({e!r}) "
-                                "-- the progress bar itself is unaffected.",
-                                stacklevel=2,
-                            )
-                            self._output_file_warned = True
+                        already_warned = self._output_file_warned
+                        self._output_file_warned = True
                         self.output_file = None
+                        if not already_warned:
+                            try:
+                                warnings.warn(
+                                    "blackjax.progress_bar: disabling "
+                                    f"output_file after a write failure "
+                                    f"({e!r}) -- the progress bar itself is "
+                                    "unaffected.",
+                                    stacklevel=2,
+                                )
+                            except Exception:
+                                # warnings can be promoted to errors by the
+                                # active filter; the never-raise invariant
+                                # outranks the courtesy.
+                                pass
         except Exception as e:  # noqa: BLE001 -- see invariant above
-            if not self._callback_warned:
-                warnings.warn(
-                    "blackjax.progress_bar: internal callback error "
-                    f"({e!r}) -- further progress updates for this context "
-                    "are disabled, but the underlying computation is "
-                    "unaffected.",
-                    stacklevel=2,
-                )
-                self._callback_warned = True
+            already_warned = self._callback_warned
+            self._callback_warned = True
+            if not already_warned:
+                try:
+                    warnings.warn(
+                        "blackjax.progress_bar: internal callback error "
+                        f"({e!r}) -- further progress updates for this "
+                        "context are disabled, but the underlying "
+                        "computation is unaffected.",
+                        stacklevel=2,
+                    )
+                except Exception:
+                    # warnings can be promoted to errors by the active
+                    # filter; the never-raise invariant outranks the
+                    # courtesy.
+                    pass
 
     def _start_display(self):
         from tqdm.auto import tqdm
@@ -375,12 +413,21 @@ def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
 
     key = str(uuid.uuid4())
     state = ProgressState(label=label, print_rate=print_rate, output_file=output_file)
-    if not _progress_registry:  # empty -> non-empty: this is the session opener
-        _session_scan = (
-            jax.lax.scan
-        )  # capture whatever is installed now (foreign or original)
-    _progress_registry[key] = state
-    jax.lax.scan = _patched_scan
+    with _registry_lock:
+        if not _progress_registry:  # empty -> non-empty: this is the session opener
+            candidate = jax.lax.scan  # whatever is installed now (foreign or original)
+            # Belt-and-braces: the lock above already prevents the race
+            # that could make this true (two threads both observing an
+            # empty registry before either inserts), but guard the
+            # invariant directly anyway -- capturing our OWN bare patch
+            # here would make _underlying_scan() return _patched_scan
+            # itself, i.e. infinite self-recursion on every pass-through
+            # call. A foreign wrapper installed AROUND _patched_scan is a
+            # different object and would still chain through correctly.
+            if candidate is not _patched_scan:
+                _session_scan = candidate
+        _progress_registry[key] = state
+        jax.lax.scan = _patched_scan
     state._start_display()
     try:
         yield state
@@ -389,14 +436,15 @@ def progress_bar(label="BlackJAX", print_rate=None, output_file=None):
         state._stop_event.set()
         if state._display_thread is not None:
             state._display_thread.join(timeout=2.0)
-        del _progress_registry[key]
-        if not _progress_registry:  # non-empty -> empty: this is the session closer
-            if jax.lax.scan is _patched_scan:
-                jax.lax.scan = _session_scan
-            # Else: something else replaced jax.lax.scan while we were
-            # active -- leave it alone rather than clobbering a foreign
-            # patch installed during our session.
-            _session_scan = None
+        with _registry_lock:
+            del _progress_registry[key]
+            if not _progress_registry:  # non-empty -> empty: session closer
+                if jax.lax.scan is _patched_scan:
+                    jax.lax.scan = _session_scan
+                # Else: something else replaced jax.lax.scan while we were
+                # active -- leave it alone rather than clobbering a foreign
+                # patch installed during our session.
+                _session_scan = None
         # Clear before removing: a jit-cached function traced inside this
         # context keeps its callback baked in after exit (see the docstring
         # Notes), and a post-exit call would otherwise resurrect the file

--- a/blackjax/progress_reader.py
+++ b/blackjax/progress_reader.py
@@ -1,0 +1,71 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Standalone reader for file-based progress output.
+
+Usage: python -m blackjax.progress_reader /tmp/bjx_progress.txt
+"""
+import argparse
+import time
+
+
+def read_progress(path):
+    """Read '<step> <total>' from ``path``.
+
+    Returns
+    -------
+    ``(step, total)`` tuple of ints, or ``None`` if the file does not exist
+    or does not yet contain a parseable ``"<step> <total>"`` payload (e.g. it
+    was read mid-write).
+    """
+    try:
+        with open(path) as fh:
+            parts = fh.read().split()
+        return int(parts[0]), int(parts[1])
+    except (FileNotFoundError, IndexError, ValueError):
+        return None
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("path")
+    p.add_argument("--interval", type=float, default=0.2)
+    args = p.parse_args(argv)
+
+    from tqdm.auto import tqdm
+
+    bar = None
+    last = -1
+    missing_after_start = 0
+    while True:
+        result = read_progress(args.path)
+        if result is not None:
+            step, total = result
+            if bar is None:
+                bar = tqdm(total=total, desc="BlackJAX", unit="step")
+            if step != last:
+                bar.n = step + 1
+                bar.refresh()
+                last = step
+        elif bar is not None:
+            # File deleted after we saw progress -> run finished.
+            missing_after_start += 1
+            if missing_after_start > 3:
+                break
+        time.sleep(args.interval)
+    if bar is not None:
+        bar.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/blackjax/util.py
+++ b/blackjax/util.py
@@ -17,7 +17,6 @@ from blackjax.eca import eca_step as eca_step  # noqa: F401
 from blackjax.eca import ensemble_execute_fn as ensemble_execute_fn  # noqa: F401
 from blackjax.eca import run_eca as run_eca  # noqa: F401
 from blackjax.eca import while_with_info as while_with_info  # noqa: F401
-from blackjax.progress_bar import gen_scan_fn
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
 
@@ -154,7 +153,6 @@ def run_inference_algorithm(
     num_steps: int,
     initial_state: ArrayLikeTree = None,
     initial_position: ArrayLikeTree = None,
-    progress_bar: bool = False,
     transform: Callable = lambda state, info: (state, info),
 ) -> tuple:
     """Wrapper to run an inference algorithm.
@@ -162,6 +160,9 @@ def run_inference_algorithm(
     Note that this utility function does not work for Stochastic Gradient MCMC samplers
     like sghmc, as SG-MCMC samplers require additional control flow for batches of data
     to be passed in during each sample.
+
+    Wrap the call in :func:`blackjax.progress_bar` to display a progress bar,
+    e.g. ``with blackjax.progress_bar(): run_inference_algorithm(...)``.
 
     Parameters
     ----------
@@ -175,8 +176,6 @@ def run_inference_algorithm(
         One of blackjax's sampling algorithms or variational inference algorithms.
     num_steps
         Number of MCMC steps.
-    progress_bar
-        Whether to display a progress bar.
     transform
         A transformation of the trace of states (and info) to be returned. This is useful for
         computing determinstic variables, or returning a subset of the states.
@@ -208,10 +207,8 @@ def run_inference_algorithm(
         state, info = inference_algorithm.step(rng_key, state)
         return state, transform(state, info)
 
-    scan_fn = gen_scan_fn(num_steps, progress_bar)
-
     xs = jnp.arange(num_steps), keys
-    final_state, history = scan_fn(one_step, initial_state, xs)
+    final_state, history = lax.scan(one_step, initial_state, xs)
 
     return final_state, history
 
@@ -257,7 +254,6 @@ def store_only_expectation_values(
              inference_algorithm=memory_efficient_sampling_alg,
              num_steps=num_steps,
              transform=transform,
-             progress_bar=True,
          )
     """
 

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -45,12 +45,6 @@
   url = {https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.finfo.html},
 }
 
-@online{progress_bar,
-  author = {Jeremie Coullon},
-  title = {How to add a progress bar to JAX scans and loops},
-  url = {https://www.jeremiecoullon.com/2021/01/29/jax_progress_bar/},
-}
-
 @online{nuts_uturn,
   url = {https://discourse.mc-stan.org/t/nuts-misses-u-turns-runs-in-circles-until-max-treedepth/9727/46},
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-progress = ["fastprogress>=1.0.0,<1.1"]
+progress = ["tqdm>=4.66"]
 
 [project.urls]
 homepage = "https://github.com/blackjax-devs/blackjax"

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -222,7 +222,6 @@ class LinearRegressionTest(chex.TestCase):
             inference_algorithm=alg,
             num_steps=num_steps,
             transform=lambda state, _: state.position,
-            progress_bar=False,
         )
 
         return out
@@ -282,7 +281,6 @@ class LinearRegressionTest(chex.TestCase):
             inference_algorithm=alg,
             num_steps=num_steps,
             transform=lambda state, _: state.position,
-            progress_bar=False,
         )
 
         return out
@@ -340,7 +338,6 @@ class LinearRegressionTest(chex.TestCase):
             case["algorithm"],
             logposterior_fn,
             is_mass_matrix_diagonal,
-            progress_bar=True,
             adaptation_info_fn=window_adapt_config["filter_fn"],
             **case["parameters"],
         )

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -14,6 +14,7 @@
 """Unit tests for the ``jax.lax.scan``-monkeypatching progress bar."""
 import os
 import stat
+import sys
 import tempfile
 import threading
 import warnings
@@ -25,9 +26,18 @@ import numpy as np
 from absl.testing import absltest
 
 import blackjax
-from blackjax.progress_bar import _original_scan, _patched_scan
+from blackjax.progress_bar import ProgressState, _original_scan, _patched_scan
 from blackjax.progress_reader import read_progress
 from blackjax.util import run_inference_algorithm
+
+# `blackjax/__init__.py` does `from .progress_bar import progress_bar`, which
+# shadows the *submodule* name `blackjax.progress_bar` with the *function* on
+# the `blackjax` package object. `from blackjax.progress_bar import X` above
+# is unaffected (it resolves `X` from sys.modules directly), but reading the
+# module's mutable globals (`_session_scan`, reassigned at runtime, so a
+# `from ... import _session_scan` would only ever see the import-time value)
+# needs the real submodule object -- pull it out of sys.modules explicitly.
+_progress_bar_module = sys.modules["blackjax.progress_bar"]
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
 
@@ -265,6 +275,81 @@ class ProgressBarTest(BlackJAXTest):
             jax.block_until_ready(final)
 
         self.assertEqual(state.current_step, 29)
+
+    def test_step_callback_survives_promoted_warnings(self):
+        """The never-raise invariant must hold even when the active
+        warnings filter promotes ``UserWarning`` to an error (this
+        project's own ``pytest.ini`` does): driving ``_step_callback``
+        directly against an unwritable ``output_file`` must not raise, and
+        ``output_file`` must still end up disabled (TL round-2 finding --
+        the courtesy warning itself was escaping as the very crash item A
+        exists to prevent)."""
+        if os.geteuid() == 0:
+            self.skipTest("running as root bypasses directory permissions")
+
+        tmpdir = tempfile.mkdtemp()
+        readonly_dir = os.path.join(tmpdir, "readonly")
+        os.makedirs(readonly_dir)
+        os.chmod(readonly_dir, stat.S_IREAD | stat.S_IEXEC)
+        bad_path = os.path.join(readonly_dir, "progress.txt")
+
+        try:
+            state = ProgressState(label="direct", print_rate=1, output_file=bad_path)
+            state.n_steps = 10
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                try:
+                    state._step_callback(jnp.array(0))
+                except Exception as e:  # pragma: no cover -- failure path
+                    self.fail(
+                        "_step_callback raised under a promoted warnings "
+                        f"filter: {e!r}"
+                    )
+            self.assertIsNone(state.output_file)
+        finally:
+            os.chmod(readonly_dir, stat.S_IRWXU)
+
+    def test_concurrent_first_enter_no_self_capture(self):
+        """Two threads racing to be the FIRST ``progress_bar()`` entrant
+        must never let one capture the OTHER's freshly-installed
+        ``_patched_scan`` as ``_session_scan`` (which would self-recurse on
+        every pass-through call). Repeated with a ``threading.Barrier`` so
+        both threads hit ``__enter__`` at the same instant (TL round-2
+        finding #2 -- the registry-lock + self-capture guard)."""
+
+        def body(carry, x):
+            return carry + x, carry
+
+        for i in range(50):
+            barrier = threading.Barrier(2)
+            captured = []
+            results = {}
+
+            def worker(label, n):
+                barrier.wait(timeout=5)
+                with blackjax.progress_bar(label=label) as state:
+                    captured.append(_progress_bar_module._session_scan)
+                    f, _ = jax.lax.scan(body, 0.0, jnp.arange(n))
+                    jax.block_until_ready(f)
+                    results[label] = state.n_steps
+
+            t1 = threading.Thread(target=worker, args=("r1", 4))
+            t2 = threading.Thread(target=worker, args=("r2", 5))
+            t1.start()
+            t2.start()
+            t1.join(timeout=10)
+            t2.join(timeout=10)
+
+            self.assertFalse(t1.is_alive(), f"iteration {i}: thread 1 hung")
+            self.assertFalse(t2.is_alive(), f"iteration {i}: thread 2 hung")
+            for c in captured:
+                self.assertIsNot(
+                    c, _patched_scan, f"iteration {i}: captured our own patch"
+                )
+            self.assertEqual(results.get("r1"), 4)
+            self.assertEqual(results.get("r2"), 5)
+
+        self.assertIs(jax.lax.scan, _original_scan)
 
     def test_owner_thread_routing_two_contexts(self):
         """With >=2 simultaneously active contexts, a scan is attributed

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 """Unit tests for the ``jax.lax.scan``-monkeypatching progress bar."""
 import os
+import stat
 import tempfile
+import threading
+import warnings
 
 import chex
 import jax
@@ -22,7 +25,7 @@ import numpy as np
 from absl.testing import absltest
 
 import blackjax
-from blackjax.progress_bar import _original_scan
+from blackjax.progress_bar import _original_scan, _patched_scan
 from blackjax.progress_reader import read_progress
 from blackjax.util import run_inference_algorithm
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
@@ -188,6 +191,242 @@ class ProgressBarTest(BlackJAXTest):
         self.assertEqual(calls[:30], list(range(30)))
         self.assertEqual(calls[30:], list(range(50)))
         self.assertEqual(state.n_steps, 50)
+
+    def test_reverse_display_ascends(self):
+        """``reverse=True`` must show an ascending display sequence ending
+        at ``n - 1``, not a countdown that looks reset-to-zero on
+        completion (adversarial-review finding #A4)."""
+        n = 6
+        seen = []
+
+        def body(carry, x):
+            return carry + x, carry
+
+        with blackjax.progress_bar(label="reverse", print_rate=1) as state:
+            original_callback = state._step_callback
+
+            def recording_callback(idx):
+                seen.append(int(idx))
+                original_callback(idx)
+
+            state._step_callback = recording_callback
+            final, _ = jax.lax.scan(body, 0.0, jnp.arange(float(n)), reverse=True)
+            jax.block_until_ready(final)
+
+        self.assertEqual(seen, list(range(n)))
+        self.assertEqual(state.current_step, n - 1)
+
+    def test_unwritable_output_file_completes_with_one_warning(self):
+        """An ``output_file`` write failure must not crash the run --
+        ``_step_callback`` is a total function -- and must warn exactly
+        once, not once per remaining step (adversarial-review finding #B14,
+        the sole crash path found)."""
+        if os.geteuid() == 0:
+            self.skipTest("running as root bypasses directory permissions")
+
+        tmpdir = tempfile.mkdtemp()
+        readonly_dir = os.path.join(tmpdir, "readonly")
+        os.makedirs(readonly_dir)
+        os.chmod(readonly_dir, stat.S_IREAD | stat.S_IEXEC)
+        bad_path = os.path.join(readonly_dir, "progress.txt")
+
+        def body(carry, x):
+            return carry + x, carry
+
+        try:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                with blackjax.progress_bar(
+                    label="perm", output_file=bad_path, print_rate=1
+                ) as state:
+                    final, _ = jax.lax.scan(body, 0.0, jnp.arange(50))
+                    jax.block_until_ready(final)
+            output_file_warnings = [
+                w
+                for w in caught
+                if issubclass(w.category, UserWarning)
+                and "output_file" in str(w.message)
+            ]
+            self.assertEqual(len(output_file_warnings), 1)
+            self.assertEqual(state.current_step, 49)
+            np.testing.assert_allclose(final, float(jnp.arange(50.0).sum()))
+        finally:
+            os.chmod(readonly_dir, stat.S_IRWXU)
+
+    def test_print_rate_zero_no_crash(self):
+        """``print_rate=0`` (an innocent typo) must not
+        ``ZeroDivisionError`` inside the callback."""
+
+        def body(carry, x):
+            return carry + x, carry
+
+        with blackjax.progress_bar(label="zero-rate", print_rate=0) as state:
+            final, _ = jax.lax.scan(body, 0.0, jnp.arange(30))
+            jax.block_until_ready(final)
+
+        self.assertEqual(state.current_step, 29)
+
+    def test_owner_thread_routing_two_contexts(self):
+        """With >=2 simultaneously active contexts, a scan is attributed
+        only to its OWNER thread (the thread that called ``__enter__``); a
+        true bystander thread owning neither context falls through with no
+        bar rather than being misattributed (adversarial-review finding
+        #B4)."""
+
+        def body(carry, x):
+            return carry + x, carry
+
+        def run_scan(n):
+            f, _ = jax.lax.scan(body, 0.0, jnp.arange(n))
+            jax.block_until_ready(f)
+
+        # -- owner-correct cell: each thread's own scan lands on its own
+        # context, never on the other's. --
+        ready1, ready2, done1 = (
+            threading.Event(),
+            threading.Event(),
+            threading.Event(),
+        )
+        results = {}
+
+        def owner_a():
+            with blackjax.progress_bar(label="A") as sa:
+                results["a"] = sa
+                ready1.set()
+                ready2.wait(timeout=5)
+                run_scan(31)
+                done1.set()
+
+        def owner_b():
+            ready1.wait(timeout=5)
+            with blackjax.progress_bar(label="B") as sb:
+                results["b"] = sb
+                ready2.set()
+                done1.wait(timeout=5)
+                run_scan(32)
+
+        ta, tb = threading.Thread(target=owner_a), threading.Thread(target=owner_b)
+        ta.start()
+        tb.start()
+        ta.join(timeout=10)
+        tb.join(timeout=10)
+
+        self.assertEqual(results["a"].n_steps, 31)
+        self.assertEqual(results["b"].n_steps, 32)
+
+        # -- bystander cell: a genuine third thread owning NEITHER active
+        # context must not be misattributed to either. --
+        ready1.clear()
+        ready2.clear()
+        done1.clear()
+        results2 = {}
+
+        def owner_a2():
+            with blackjax.progress_bar(label="A2") as sa:
+                results2["a"] = sa
+                ready1.set()
+                ready2.wait(timeout=5)
+                bystander = threading.Thread(target=lambda: run_scan(41))
+                bystander.start()
+                bystander.join(timeout=5)
+                done1.set()
+
+        def owner_b2():
+            ready1.wait(timeout=5)
+            with blackjax.progress_bar(label="B2") as sb:
+                results2["b"] = sb
+                ready2.set()
+                done1.wait(timeout=5)
+
+        # Both A2 and B2 legitimately end this cell with zero attributed
+        # steps (that is the point of the test -- the bystander's scan
+        # must land on neither), which by design now also triggers the
+        # zero-step UserWarning on each context's exit; suppress it here
+        # since it's expected, not a signal something went wrong under this
+        # project's filterwarnings=error.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            ta2 = threading.Thread(target=owner_a2)
+            tb2 = threading.Thread(target=owner_b2)
+            ta2.start()
+            tb2.start()
+            ta2.join(timeout=10)
+            tb2.join(timeout=10)
+
+        self.assertEqual(results2["a"].n_steps, 0)
+        self.assertEqual(results2["b"].n_steps, 0)
+
+    def test_foreign_patch_chaining_and_restoration(self):
+        """A third-party ``jax.lax.scan`` patch installed before our context
+        keeps firing for scans run inside it (chaining), and is restored --
+        not clobbered back to the true original -- on exit
+        (adversarial-review finding #B8)."""
+        foreign_calls = []
+        real_original = _original_scan
+
+        def foreign_patch(f, init, xs=None, length=None, **kwargs):
+            foreign_calls.append(1)
+            return real_original(f, init, xs=xs, length=length, **kwargs)
+
+        def body(carry, x):
+            return carry + x, carry
+
+        jax.lax.scan = foreign_patch
+        try:
+            with blackjax.progress_bar(label="chain-test") as state:
+                final, _ = jax.lax.scan(body, 0.0, jnp.arange(15))
+                jax.block_until_ready(final)
+
+            self.assertGreater(len(foreign_calls), 0)
+            self.assertEqual(state.n_steps, 15)
+            # Restored to the FOREIGN patch, not clobbered back to the true
+            # original -- the foreign patch predates our session.
+            self.assertIs(jax.lax.scan, foreign_patch)
+        finally:
+            jax.lax.scan = real_original
+
+    def test_nonlifo_two_context_restore(self):
+        """A enters, B enters, A exits first, B exits last --
+        ``jax.lax.scan`` is restored to the true original once the LAST
+        context exits, regardless of entry/exit order (adversarial-review
+        finding #B8, non-LIFO exit-order case)."""
+
+        def body(carry, x):
+            return carry + x, carry
+
+        cm_a = blackjax.progress_bar(label="A")
+        cm_b = blackjax.progress_bar(label="B")
+        cm_a.__enter__()
+        cm_b.__enter__()
+        try:
+            final, _ = jax.lax.scan(body, 0.0, jnp.arange(9))
+            jax.block_until_ready(final)
+        finally:
+            # Both contexts are owned by this (the main) thread, so the
+            # single scan above is attributed only to B (the most recently
+            # entered of the two, per the owner-tie-break rule) -- A
+            # legitimately sees zero steps and warns on exit; that warning
+            # is expected here; it is not what this test is checking.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                cm_a.__exit__(None, None, None)
+            self.assertIs(jax.lax.scan, _patched_scan)  # B is still active
+            cm_b.__exit__(None, None, None)
+
+        self.assertIs(jax.lax.scan, _original_scan)
+
+    def test_zero_step_warns(self):
+        """A context that never observes a scan step warns once, naming
+        both possible root causes."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            with blackjax.progress_bar(label="no-scan"):
+                pass
+
+        messages = [
+            str(w.message) for w in caught if issubclass(w.category, UserWarning)
+        ]
+        self.assertTrue(any("no scan step was ever observed" in m for m in messages))
 
     def test_kwargs_passthrough(self):
         """``reverse=True`` and ``unroll=2`` are forwarded faithfully and

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -1,0 +1,183 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the ``jax.lax.scan``-monkeypatching progress bar."""
+import os
+import tempfile
+
+import chex
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest
+
+import blackjax
+from blackjax.progress_bar import _original_scan
+from blackjax.progress_reader import read_progress
+from blackjax.util import run_inference_algorithm
+from tests.fixtures import BlackJAXTest, std_normal_logdensity
+
+
+class ProgressBarTest(BlackJAXTest):
+    def test_basic(self):
+        """``run_inference_algorithm`` (NUTS, 100 steps, 2-dim gaussian)
+        completes inside the context manager and the callback fires."""
+        algorithm = blackjax.nuts(
+            std_normal_logdensity, step_size=0.1, inverse_mass_matrix=jnp.eye(2)
+        )
+        with blackjax.progress_bar(label="test") as state:
+            final_state, _ = run_inference_algorithm(
+                rng_key=self.next_key(),
+                inference_algorithm=algorithm,
+                num_steps=100,
+                initial_position=jnp.zeros(2),
+            )
+            jax.block_until_ready(final_state)
+
+        self.assertEqual(state.n_steps, 100)
+        self.assertGreater(state.current_step, 0)
+
+    def test_vmap_no_crash(self):
+        """Regression test for #927: ``jax.vmap`` over 2 chains of a
+        scan-based sampler must not crash inside the context manager."""
+        algorithm = blackjax.hmc(
+            std_normal_logdensity,
+            step_size=0.1,
+            inverse_mass_matrix=jnp.eye(2),
+            num_integration_steps=5,
+        )
+
+        def run(key, position):
+            return run_inference_algorithm(
+                rng_key=key,
+                inference_algorithm=algorithm,
+                num_steps=50,
+                initial_position=position,
+            )
+
+        keys = jax.random.split(self.next_key(), 2)
+        positions = jnp.zeros((2, 2))
+
+        with blackjax.progress_bar(label="vmap") as state:
+            (final_state, _) = jax.vmap(run)(keys, positions)
+            jax.block_until_ready(final_state)
+
+        chex.assert_shape(final_state.position, (2, 2))
+        self.assertEqual(state.n_steps, 50)
+        self.assertGreater(state.current_step, 0)
+
+    def test_outermost_only(self):
+        """Only the outermost scan (10 steps) is instrumented; the inner
+        scan (5 steps, 50 total) must not double-fire the callback."""
+
+        def inner_body(carry, x):
+            return carry + x, carry
+
+        def outer_body(carry, x):
+            inner_final, _ = jax.lax.scan(inner_body, carry, jnp.arange(5))
+            return inner_final, inner_final
+
+        with blackjax.progress_bar(label="nested") as state:
+            calls = []
+            original_callback = state._step_callback
+
+            def counting_callback(idx):
+                calls.append(int(idx))
+                original_callback(idx)
+
+            state._step_callback = counting_callback
+
+            final, _ = jax.lax.scan(outer_body, 0.0, jnp.arange(10))
+            jax.block_until_ready(final)
+
+        self.assertEqual(len(calls), 10)
+        self.assertLessEqual(max(calls), 9)
+
+    def test_output_file(self):
+        """``output_file`` is written atomically during the run and removed
+        on exit."""
+        tmpdir = tempfile.mkdtemp()
+        path = os.path.join(tmpdir, "bjx_progress.txt")
+
+        def body(carry, x):
+            return carry + x, carry
+
+        with blackjax.progress_bar(
+            label="file", output_file=path, print_rate=1
+        ) as state:
+            final, _ = jax.lax.scan(body, 0.0, jnp.arange(20))
+            jax.block_until_ready(final)
+
+            self.assertTrue(os.path.exists(path))
+            step, total = read_progress(path)
+            self.assertEqual(total, state.n_steps)
+            self.assertGreaterEqual(step, 0)
+            self.assertLess(step, total)
+
+        self.assertFalse(os.path.exists(path))
+
+    def test_progress_reader_read_progress(self):
+        """Unit test the standalone parse helper directly (no subprocess)."""
+        tmpdir = tempfile.mkdtemp()
+        path = os.path.join(tmpdir, "progress.txt")
+
+        # Missing file -> None.
+        self.assertIsNone(read_progress(path))
+
+        with open(path, "w") as fh:
+            fh.write("7 42")
+        self.assertEqual(read_progress(path), (7, 42))
+
+        # Malformed content -> None, not an exception.
+        with open(path, "w") as fh:
+            fh.write("not-a-number")
+        self.assertIsNone(read_progress(path))
+
+    def test_restoration(self):
+        """After the context exits, ``jax.lax.scan`` is restored to the
+        original, unpatched function and behaves normally."""
+        with blackjax.progress_bar(label="restore-me"):
+            final, _ = jax.lax.scan(lambda c, x: (c + x, c), 0.0, jnp.arange(5))
+            jax.block_until_ready(final)
+
+        self.assertIs(jax.lax.scan, _original_scan)
+
+        # A plain scan after exit works exactly as jax.lax.scan normally does
+        # -- no progress-bar machinery (and therefore no callback) is
+        # reachable once jax.lax.scan is the unpatched function.
+        final, ys = jax.lax.scan(lambda c, x: (c + x, c), 0.0, jnp.arange(5))
+        np.testing.assert_allclose(final, 10.0)
+        np.testing.assert_allclose(ys, jnp.array([0.0, 0.0, 1.0, 3.0, 6.0]))
+
+    def test_kwargs_passthrough(self):
+        """``reverse=True`` and ``unroll=2`` are forwarded faithfully and
+        still produce correct results."""
+
+        def body(carry, x):
+            return carry + x, carry
+
+        xs = jnp.arange(6, dtype=jnp.float32)
+        expected_final, expected_ys = jax.lax.scan(
+            body, 0.0, xs, reverse=True, unroll=2
+        )
+
+        with blackjax.progress_bar(label="kwargs"):
+            final, ys = jax.lax.scan(body, 0.0, xs, reverse=True, unroll=2)
+            jax.block_until_ready(final)
+
+        np.testing.assert_allclose(final, expected_final)
+        np.testing.assert_allclose(ys, expected_ys)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -159,6 +159,36 @@ class ProgressBarTest(BlackJAXTest):
         np.testing.assert_allclose(final, 10.0)
         np.testing.assert_allclose(ys, jnp.array([0.0, 0.0, 1.0, 3.0, 6.0]))
 
+    def test_sequential_scans_different_lengths(self):
+        """Two sequential outermost scans of different lengths inside one
+        context are each (re-)instrumented -- regression test for the
+        multi-phase display bug (e.g. mclmc_find_L_and_step_size's several
+        sequential warmup scans rendered with the first phase's total
+        frozen for the rest of the run)."""
+        calls = []
+
+        def body(carry, x):
+            return carry + x, carry
+
+        with blackjax.progress_bar(label="sequential", print_rate=1) as state:
+            original_callback = state._step_callback
+
+            def counting_callback(idx):
+                calls.append(int(idx))
+                original_callback(idx)
+
+            state._step_callback = counting_callback
+
+            final1, _ = jax.lax.scan(body, 0.0, jnp.arange(30))
+            final2, _ = jax.lax.scan(body, final1, jnp.arange(50))
+            jax.block_until_ready(final2)
+
+        self.assertEqual(len(calls), 30 + 50)
+        self.assertEqual(calls.count(0), 2)  # both phases fired step 0
+        self.assertEqual(calls[:30], list(range(30)))
+        self.assertEqual(calls[30:], list(range(50)))
+        self.assertEqual(state.n_steps, 50)
+
     def test_kwargs_passthrough(self):
         """``reverse=True`` and ``unroll=2`` are forwarded faithfully and
         still produce correct results."""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import chex
 import numpy as np
-from absl.testing import absltest, parameterized
+from absl.testing import absltest
 from jax import jit
 from jax import numpy as jnp
 from jax import random as jr
@@ -30,17 +30,16 @@ class RunInferenceAlgorithmTest(chex.TestCase):
         )
         self.num_steps = 10
 
-    def check_compatible(self, initial_state, progress_bar):
+    def check_compatible(self, initial_state):
         """
         Runs 10 steps with `run_inference_algorithm` starting with
-        `initial_state` and potentially a progress bar.
+        `initial_state`.
         """
         _ = run_inference_algorithm(
             rng_key=self.key,
             initial_state=initial_state,
             inference_algorithm=self.algorithm,
             num_steps=self.num_steps,
-            progress_bar=progress_bar,
             transform=lambda state, info: state.position,
         )
 
@@ -74,7 +73,6 @@ class RunInferenceAlgorithmTest(chex.TestCase):
             inference_algorithm=sampling_alg,
             num_steps=num_steps,
             transform=lambda state, info: state_transform(state),
-            progress_bar=True,
         )
 
         print("average of steps (slow way):", samples.mean(axis=0))
@@ -91,26 +89,22 @@ class RunInferenceAlgorithmTest(chex.TestCase):
             inference_algorithm=memory_efficient_sampling_alg,
             num_steps=num_steps,
             transform=transform,
-            progress_bar=True,
         )
 
         assert jnp.allclose(trace_at_every_step[0][-1], samples.mean(axis=0))
 
-    @parameterized.parameters([True, False])
-    def test_compatible_with_initial_pos(self, progress_bar):
+    def test_compatible_with_initial_pos(self):
         _ = run_inference_algorithm(
             rng_key=self.key,
             initial_position=jnp.array([1.0, 1.0]),
             inference_algorithm=self.algorithm,
             num_steps=self.num_steps,
-            progress_bar=progress_bar,
             transform=lambda state, info: state.position,
         )
 
-    @parameterized.parameters([True, False])
-    def test_compatible_with_initial_state(self, progress_bar):
+    def test_compatible_with_initial_state(self):
         state = self.algorithm.init(jnp.array([1.0, 1.0]))
-        self.check_compatible(state, progress_bar)
+        self.check_compatible(state)
 
     @staticmethod
     def logdensity_fn(x):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -182,7 +182,6 @@ class ThinInferenceAlgorithmTest(chex.TestCase):
             initial_state=state,
             inference_algorithm=sampler,
             num_steps=num_steps,
-            # progress_bar=True,
         )
         return state, history
 

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ dependencies = [
 
 [package.optional-dependencies]
 progress = [
-    { name = "fastprogress" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -206,12 +206,12 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "fastprogress", marker = "extra == 'progress'", specifier = ">=1.0.0,<1.1" },
     { name = "jax", specifier = ">=0.9.0" },
     { name = "jaxlib", specifier = ">=0.9.0" },
     { name = "numpy", specifier = ">=1.25" },
     { name = "optax", specifier = ">=0.2.3" },
     { name = "scipy", specifier = ">=1.13" },
+    { name = "tqdm", marker = "extra == 'progress'", specifier = ">=4.66" },
     { name = "typing-extensions", specifier = ">=4.4.0" },
 ]
 provides-extras = ["progress"]
@@ -846,15 +846,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
-]
-
-[[package]]
-name = "fastprogress"
-version = "1.0.5"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/f0/e9410610562ab95517230c2438cc80bbc97227b3930c02501d06323a533b/fastprogress-1.0.5.tar.gz", hash = "sha256:58ca16a981f0292804d905f2e0042ad608d788bf6cbe6ab96b71ec4b20453aef", size = 16385, upload-time = "2025-12-27T00:00:43.662Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/9e/2feab862288930fd5e2ced90c3ef3d8e422d228601f2045f0e3a17e4b366/fastprogress-1.0.5-py3-none-any.whl", hash = "sha256:a96b027a832dcf64036d2bd1576a6cbf4bcaf484579253dcb8f3379702c4363c", size = 13891, upload-time = "2025-12-27T00:00:42.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Redesigns the progress-bar mechanism as a **context manager** that instruments the outermost `jax.lax.scan` in whatever it wraps — no per-algorithm parameter threading:

```python
with blackjax.progress_bar(label="NUTS warmup"):
    (state, params), _ = blackjax.window_adaptation(blackjax.nuts, logdensity_fn).run(
        rng_key, initial_position, 1000
    )
```

**Why.** The old `gen_scan_fn` mechanism had three interlocking defects:

1. **vmap crash (#927)** — it augmented the scan *carry* with a scalar `chain_id`; under `jax.vmap` the carry batches while `io_callback(result_shape_dtypes=array(0))` stays scalar → shape mismatch. This is why multi-chain `vmap(warmup.run)` couldn't show a progress bar.
2. **Boilerplate proliferation** — every scan-wrapping algorithm needed a `progress_bar: bool` param + a `gen_scan_fn` call. Applied 3× in-tree; #960 would have been the 4th copy (with 2 extra levels of private-factory threading).
3. **`print_rate` never exposed** — existed internally, hardcoded `None` at every call site.

**How it works.**

- On entry the context patches `jax.lax.scan`; a thread-local depth counter instruments **only the outermost scan** traced while active (nested/inner scans pass through untouched).
- The step index is threaded through **`xs`, never the carry** — the carry pytree is untouched, so it composes with any transformation that batches the carry. **This is what makes it vmap-safe**: under `jax.vmap` the bar shows the max step seen across chains instead of crashing.
- Progress is emitted via `jax.debug.callback` (returns `None` → no result shape to mismatch), rendered by a daemon display thread using **tqdm** (replaces `fastprogress`).
- Optional `output_file=` atomically writes `"<step> <total>"`; the new `python -m blackjax.progress_reader <path>` renders a bar from a separate terminal/process — useful for long-running or distributed jobs.
- On exit the original `lax.scan` is restored (refcounted for nested contexts).

HLO-level injection (inspecting the lowered module and inserting a counter) was investigated and rejected: JAX 0.10 removed `jax.xla_computation` and offers no supported mutate-and-recompile path; ordered-effect token threading through `stablehlo.while` would be hand-built and version-fragile.

## ⚠️ Breaking changes

- `progress_bar` (and the never-exposed `print_rate`) parameters are **removed** from `run_inference_algorithm`, `window_adaptation`, and `window_adaptation_low_rank`. The old mechanism crashed under `vmap`, so no deprecation shim is provided. Migration: delete the argument and wrap the call in `with blackjax.progress_bar(): ...`.
- `blackjax.progress_bar.gen_scan_fn` / `progress_bar_scan` are **deleted**.
- The `progress` optional-dependency extra now installs `tqdm` instead of `fastprogress`.

Known limitation (documented in the docstring): `jax.jit` caches — a function traced *outside* the context won't show a bar when later called inside it (and vice versa); force a retrace if needed.

**Downstream (tracked separately, not in this PR):** sampling-book uses the removed argument at 6 call sites in 3 notebooks (`mclmc.md` ×4, `slice_sampling.md`, `probabilistic_ode_solver_parameter_estimation.md`) — to be migrated when its blackjax pin bumps. tuningfork's recipe emitter passes `progress_bar=` into generated warmup/sampling code and carries a "single-chain-warmup-when-progress-bar" workaround that exists *because of* #927 — the new mechanism makes that workaround removable outright.

## Tests

`tests/test_progress_bar.py` (new, 7 cases): basic NUTS run · **vmap no-crash (#927 regression)** · outermost-scan-only (nested 10×5 scan fires exactly 10 callbacks) · `output_file` write/cleanup · `progress_reader` parsing · `lax.scan` restoration after exit · kwargs passthrough (`reverse=True`, `unroll=2`). Regression: `tests/test_util.py` + `tests/adaptation/` — 239/239 pass.

## Related issues / discussions

Fixes #927. Supersedes #960 (thanks @ the author for the nudge — the context manager provides the progress bar + per-step update cadence for MCLMC adaptation without parameter threading; `print_rate=1` covers the slow-distributed-sampling use case).

## Checklist
- [x] Rebased on latest `main`
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes (7 new cases incl. the #927 regression; 239/239 regression suite)
- [x] Public functions have NumPy-style docstrings; migration pointers added where the old parameter was removed

Reviewed by: TL (design + hardening round), SWE (implementation), Tech Writer (docs QA + citation prune).

---

## Adversarial review (2026-07-08)

At the maintainer's request, the monkeypatch mechanism went through a **2-arm hostile review** (~50 executed attack repros; semantic-rewrite arm + global-state/ecosystem arm), each arm interrogated twice before acceptance. Headline: **no attack produced wrong values, gradients, or samples in any constructible case** — grad, remat, vmap, cond/while nesting, AOT, shard_map, threads, and pytree edge cases are all bitwise-exact.

Defects found and fixed in the hardening commits (`cfa1f8dcc`, `34d706e39`, `1fee46db1`):

- **Crash (BLOCKER)**: an `output_file` write failure mid-run (permissions, full disk) propagated as `JaxRuntimeError` and killed the whole sampling computation. `_step_callback` is now total (never raises into XLA), warn-once + self-disabling — including under `-W error`.
- **Ecosystem**: exiting the context unconditionally restored the import-time `lax.scan`, clobbering any third-party patch. Now: session-capture + restore-only-if-still-installed + chaining through a pre-existing foreign patch.
- **Threading**: two threads each correctly using their own context cross-attributed progress. Now: owner-thread matching when ≥2 contexts are active (single-context worker delegation unchanged); race-free enter/exit via a registry lock.
- **Display**: `reverse=True` counted the bar down and made finished runs look reset (fixed); degraded `length`/`xs`-mismatch error message (fixed).
- **Docs**: the Notes section was rewritten — the vmap sentence was corrected (the injected index stays unbatched → the callback fires exactly once per real step; a refactor-guard comment protects the invariant), the jit-cache caveat now states the precise trigger (fresh context per already-compiled call) with the safe pattern and `jax.clear_caches()` workaround, plus explicit process-global boundaries (with-form only, bystander absorption, shard_map ×N-device fire, `functools.partial` bypass). A `UserWarning` now fires when a context exits having observed zero steps.

Known accepted limitations (documented, no fix exists): `jax.checkpoint`+grad double-fires the callback (display only); shard_map fires once per device per step; a bystander thread's scan is indistinguishable from legitimate delegation when exactly one context is active.

Test suite: 17 cases (8 original + 9 regression tests from the review), plus the MCLMC end-to-end verification (bitwise-identical tuning results with/without the bar).
