### PR TITLE
docs: verified-frontends line in the progress_bar howto

### DIFF
--- a/docs/examples/howto_progress_bar.md
+++ b/docs/examples/howto_progress_bar.md
@@ -346,6 +346,8 @@ print("Scan is restored:", "progress_bar" not in jax.lax.scan.__module__)
 
 By default, the progress bar displays as a **rich widget** in Jupyter (requires `ipywidgets` >= 7.0, installed separately). Without it, you get a text-based bar on stderr. Both work identically; the widget is simply prettier in notebooks.
 
+Verified frontends: **terminal**, **JupyterLab** (widget and text modes), **VS Code's notebook interface** (including Remote-SSH), and **marimo** (console-path text bar; for long marimo runs the `output_file=` + reader pattern above is a good alternative).
+
 To use the rich widget:
 
 ```bash


### PR DESCRIPTION
One-line follow-up to #965: documents the maintainer-verified frontend matrix for `blackjax.progress_bar()` — terminal, JupyterLab (widget + text modes), VS Code notebook interface (incl. Remote-SSH), and marimo. This is the first question users ask about a display feature; now the howto answers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JsMap6KJUCBNadh5M1FsX