### PR TITLE
Auto-provision >=2 devices for multi-device tests via conftest

### DIFF
--- a/.github/workflows/test_multidevice.yml
+++ b/.github/workflows/test_multidevice.yml
@@ -22,8 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - style
-    env:
-      XLA_FLAGS: "--xla_force_host_platform_device_count=2"
     steps:
       - uses: actions/checkout@v3
       - name: Set up uv

--- a/tests/test_multidevice/conftest.py
+++ b/tests/test_multidevice/conftest.py
@@ -1,0 +1,62 @@
+# Copyright 2024- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Auto-provision >=2 JAX devices for the multi-device tests.
+
+These tests require at least 2 devices. The right way to obtain them depends on
+the machine, and the choice must be made *before* JAX is imported — so it lives
+here in ``conftest.py``, whose module-level code runs at collection time, ahead
+of the test modules' ``import jax``.
+
+Precedence:
+  1. An explicit user-set ``XLA_FLAGS`` is respected (never overridden).
+  2. If >=2 real GPUs are visible, do nothing — the tests run on the real
+     multi-GPU mesh (``jax.devices()`` already returns them).
+  3. Otherwise, simulate 2 CPU devices via
+     ``--xla_force_host_platform_device_count=2`` so the tests still run on a
+     single-device machine (typical CI / laptop).
+
+Effect: ``pytest tests/test_multidevice/`` does the right thing everywhere with
+no flag to remember — real GPUs where present, simulated CPU otherwise — and the
+CI workflow no longer needs to set ``XLA_FLAGS`` explicitly.
+
+Limitation: a machine with >=2 physical GPUs but a CPU-only ``jaxlib`` install is
+not auto-handled (nvidia-smi reports the GPUs, yet JAX exposes 1 CPU device, so
+the tests skip). Install a CUDA ``jaxlib`` or set ``XLA_FLAGS`` explicitly.
+"""
+import os
+import subprocess
+
+
+def _has_multi_gpu() -> bool:
+    """Return True if >=2 GPUs are visible, without importing JAX.
+
+    Importing JAX to count devices would lock in the device set before we could
+    request host-platform simulation, so we probe ``nvidia-smi`` instead.
+    """
+    try:
+        result = subprocess.run(
+            ["nvidia-smi", "-L"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if result.returncode != 0:
+        return False
+    return sum(line.startswith("GPU ") for line in result.stdout.splitlines()) >= 2
+
+
+if "XLA_FLAGS" not in os.environ and not _has_multi_gpu():
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=2"


### PR DESCRIPTION
## Problem

The `tests/test_multidevice/` tests need >=2 JAX devices, but the *way* to get them differs by machine:
a real >=2-GPU box exposes them directly, while a single-device CI runner must use XLA host-platform
simulation (`--xla_force_host_platform_device_count=2`) — which has to be requested **before** `jax` is
imported. Today that flag is hard-coded only in `test_multidevice.yml`, so `pytest tests/test_multidevice/`
runs on a 2-GPU box only if you remember to set `XLA_FLAGS`, and real-vs-simulated is a manual, CI-only call.

## Fix

A `tests/test_multidevice/conftest.py` whose module-level code runs at collection time (before the test
modules `import jax`) and sets the simulation flag **only when** an explicit `XLA_FLAGS` is absent **and**
`<2` real GPUs are detected (probed via `nvidia-smi`, so JAX isn't imported prematurely). The tests were
already device-agnostic (mesh from `jax.devices()[:2]`, skip if `<2`), so nothing else changes.

Result: `pytest tests/test_multidevice/` does the right thing everywhere with no flag to remember — **real
GPUs where present, simulated 2×CPU otherwise** — and the workflow drops the now-redundant `XLA_FLAGS` env.

Limitation (documented in the conftest): a machine with >=2 physical GPUs but a CPU-only `jaxlib` install is
not auto-handled (nvidia-smi reports GPUs, JAX exposes 1 CPU device → tests skip); set `XLA_FLAGS` explicitly.

## Testing

- **Local / CPU (single device), no `XLA_FLAGS` set:** conftest simulates 2 CPU devices → **4/4 pass**.
- **Real 2× RTX 5090:** the 4 tests pass on the physical 2-GPU mesh (`jax.devices() = [CudaDevice(0),
  CudaDevice(1)]`) run without the flag — which is exactly the conftest's multi-GPU path (nvidia-smi detects
  2 GPUs → sets nothing → identical to the no-flag run). This validates #961/#962 on real hardware for the
  first time (CI has only ever exercised the simulated path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)