### PR TITLE
Expose MCLMC warmup divergence flags as tuning-scan ys (jaxtap-observable) + degenerate-warmup checking docs

### DIFF
--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Algorithms to adapt the MCLMC kernel parameters, namely step size and L."""
 
-import warnings
 from typing import NamedTuple
 
 import jax
@@ -22,66 +21,6 @@ from jax.flatten_util import ravel_pytree
 
 from blackjax.diagnostics import effective_sample_size
 from blackjax.util import generate_unit_vector, incremental_value_update, pytree_size
-
-# ---------------------------------------------------------------------------
-# Diagnostic warning callbacks — safe to call under JIT via jax.debug.callback.
-# Each function must NEVER raise: wrap the body in try/except so that a
-# warnings.simplefilter("error") environment does not corrupt the JAX runtime.
-# ---------------------------------------------------------------------------
-
-
-def _cb_frozen_outcome_warning(step_size, position_std, num_steps):
-    """Warn when the adapted step size cannot traverse the warmup-scale posterior.
-
-    Triggered on mixing infeasibility (step_size * num_steps << warmup position
-    std, or zero position variance from complete divergence).  Scale/budget-
-    relative — no magic absolute constant.  Frozen-vs-healthy separation is
-    ~6 orders of magnitude, so a 3-order margin is highly robust.
-    """
-    try:
-        ss = float(step_size)
-        pos_std = float(position_std)
-        n = int(num_steps)
-        # Two conditions for "frozen":
-        #  (a) pos_std ≈ 0 — all warmup steps diverged, zero position variance.
-        #  (b) step_size * num_steps << pos_std — step too small to traverse.
-        is_zero_scale = pos_std < 1e-10
-        is_step_frozen = (ss * n) < pos_std * 1e-3
-        if is_zero_scale or is_step_frozen:
-            ss_str = format(ss, ".2g")
-            pos_str = format(pos_std, ".2g")
-            warnings.warn(
-                f"MCLMC warmup: adapted step_size {ss_str} cannot traverse "
-                f"the warmup-scale posterior (scale {pos_str}) in {n} "
-                "steps — warmup likely collapsed, check initial step size / "
-                "model support (see blackjax#973).",
-                UserWarning,
-                stacklevel=2,
-            )
-    except Exception:
-        pass
-
-
-def _cb_grad_finiteness_guard(grad_flat):
-    """Warn when the init-state gradient is non-finite.
-
-    Value-finiteness at init is insufficient (e.g. lotka-volterra: finite
-    logdensity but NaN gradient at the ODE solver's stiff regime).  This guard
-    fires once at adaptation start and is nearly free — the gradient was already
-    computed by ``mclmc.init``.
-    """
-    try:
-        if not bool(jnp.all(jnp.isfinite(grad_flat))):
-            warnings.warn(
-                "MCLMC warmup: gradient non-finite at init — this is a "
-                "model/solver/support issue, not a step-size issue. "
-                "Check model code, solver tolerances, and parameter support "
-                "(see blackjax#973).",
-                UserWarning,
-                stacklevel=2,
-            )
-    except Exception:
-        pass
 
 
 class MCLMCAdaptationState(NamedTuple):
@@ -205,17 +144,29 @@ def mclmc_find_L_and_step_size(
         divergence_steps = [
             e.step for e in rec.events if e.kind == "output" and e.value
         ]
+
+    **Checking for degenerate warmup**
+
+    BlackJAX does not emit runtime warnings; checking is the user's
+    responsibility.
+
+    *Before calling* — verify the initial gradient is finite::
+
+        from jax.flatten_util import ravel_pytree
+        ok = jnp.all(jnp.isfinite(ravel_pytree(state.logdensity_grad)[0]))
+        # finite logdensity + non-finite gradient = model/solver/support issue (#973)
+
+    *After calling* — a collapsed warmup leaves ``step_size`` orders of magnitude
+    below the posterior scale; healthy and frozen runs differ by ~6 orders::
+
+        ratio = final_params.step_size * num_steps / final_params.L
+        # ratio ≈ 1 → healthy;  ratio << 1 → likely frozen
     """
     if logdensity_fn is None:
         raise ValueError(
             "logdensity_fn is required. Pass the log-density function of the "
             "target distribution."
         )
-
-    # Guard: check gradient finiteness at init (nearly free — already computed
-    # by mclmc.init; fires once via jax.debug.callback so it works under JIT).
-    flat_grad, _ = ravel_pytree(state.logdensity_grad)
-    jax.debug.callback(_cb_grad_finiteness_guard, flat_grad)
 
     dim = pytree_size(state.position)
     if params is None:
@@ -385,14 +336,11 @@ def make_L_step_size_adaptation(
         )
 
         L = params.L
-        # determine L; track warmup position scale for the frozen-outcome warning
         inverse_mass_matrix = params.inverse_mass_matrix
-        warmup_position_std = jnp.zeros(())  # updated below when data is available
         if num_steps2 > 1:
             x_average, x_squared_average = average[0], average[1]
             variances = x_squared_average - jnp.square(x_average)
-            warmup_position_std = jnp.sqrt(jnp.sum(variances))
-            L = warmup_position_std
+            L = jnp.sqrt(jnp.sum(variances))
 
             if diagonal_preconditioning:
                 inverse_mass_matrix = variances
@@ -405,14 +353,6 @@ def make_L_step_size_adaptation(
                 (state, params, _, _), _ = run_steps(
                     xs=(jnp.ones(steps), keys), state=state, params=params
                 )
-
-        # Emit endpoint diagnostic warnings (safe under JIT via jax.debug.callback)
-        jax.debug.callback(
-            _cb_frozen_outcome_warning,
-            params.step_size,
-            warmup_position_std,
-            jnp.array(num_steps, dtype=jnp.int32),
-        )
 
         return state, MCLMCAdaptationState(L, params.step_size, inverse_mass_matrix)
 

--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -30,23 +30,6 @@ from blackjax.util import generate_unit_vector, incremental_value_update, pytree
 # ---------------------------------------------------------------------------
 
 
-def _cb_divergence_warning(count, step_size):
-    """Warn when warmup divergences occurred.  Fired at end of adaptation."""
-    try:
-        if int(count) > 0:
-            ss_str = format(float(step_size), ".4g")
-            warnings.warn(
-                f"MCLMC warmup: {int(count)} divergent step(s) detected during "
-                f"tuning (final step_size={ss_str}). "
-                "If unexpected, try a smaller initial step size or check model "
-                "support.",
-                UserWarning,
-                stacklevel=2,
-            )
-    except Exception:
-        pass  # never propagate — a raise inside jax.debug.callback corrupts runtime
-
-
 def _cb_frozen_outcome_warning(step_size, position_std, num_steps):
     """Warn when the adapted step size cannot traverse the warmup-scale posterior.
 
@@ -199,6 +182,29 @@ def mclmc_find_L_and_step_size(
             rng_key=tune_key,
             diagonal_preconditioning=preconditioning,
         )
+
+    Notes
+    -----
+    **Live divergence monitoring (jax-tap >= 0.3.0)**
+
+    The internal tuning scan exposes a per-step divergence flag as its ``ys``
+    output (``True`` = divergence on that step).  Users who install
+    ``jax-tap >= 0.3.0`` can observe this stream with no changes to BlackJAX::
+
+        import jaxtap  # pip install "jax-tap>=0.3.0"
+
+        with jaxtap.record(
+            select_ys=lambda ys: ys[0],  # the single divergence-flag leaf
+            alert_ys=lambda e: "divergence" if e.value else None,
+            alert_ys_once=True,  # one stderr line then silence; drop for per-step
+        ) as rec:
+            state, params, _ = blackjax.mclmc_find_L_and_step_size(
+                mclmc_kernel=kernel, num_steps=N, state=init_state,
+                rng_key=key, logdensity_fn=logdensity_fn,
+            )
+        divergence_steps = [
+            e.step for e in rec.events if e.kind == "output" and e.value
+        ]
     """
     if logdensity_fn is None:
         raise ValueError(
@@ -338,7 +344,9 @@ def make_L_step_size_adaptation(
             weight=mask * success * params.step_size,
         )
 
-        # Emit divergence flag (True = divergence occurred this step)
+        # Enabling seam: per-step divergence flag (True = diverged) is the scan ys.
+        # jaxtap y-taps observe it via select_ys=lambda ys: ys[0] — see Notes in
+        # mclmc_find_L_and_step_size.
         return (state, params, adaptive_state, streaming_avg), jnp.logical_not(success)
 
     def run_steps(xs, state, params):
@@ -371,11 +379,10 @@ def make_L_step_size_adaptation(
         # we use the last num_steps2 to compute the diagonal preconditioner
         mask = jnp.concatenate((jnp.zeros(num_steps1), jnp.ones(num_steps2)))
 
-        # run the steps; collect per-step divergence flags for the count warning
-        (state, params, _, (_, average)), div_flags1 = run_steps(
+        # run the steps; ys (per-step divergence flags) available to jaxtap y-taps
+        (state, params, _, (_, average)), _ = run_steps(
             xs=(mask, L_step_size_adaptation_keys), state=state, params=params
         )
-        total_div_count = jnp.sum(div_flags1)
 
         L = params.L
         # determine L; track warmup position scale for the frozen-outcome warning
@@ -395,13 +402,11 @@ def make_L_step_size_adaptation(
                 # readjust the stepsize
                 steps = round(num_steps2 / 3)  # we do some small number of steps
                 keys = jax.random.split(final_key, steps)
-                (state, params, _, _), div_flags_dc = run_steps(
+                (state, params, _, _), _ = run_steps(
                     xs=(jnp.ones(steps), keys), state=state, params=params
                 )
-                total_div_count = total_div_count + jnp.sum(div_flags_dc)
 
-        # Emit diagnostic warnings (safe under JIT via jax.debug.callback)
-        jax.debug.callback(_cb_divergence_warning, total_div_count, params.step_size)
+        # Emit endpoint diagnostic warnings (safe under JIT via jax.debug.callback)
         jax.debug.callback(
             _cb_frozen_outcome_warning,
             params.step_size,

--- a/blackjax/adaptation/mclmc_adaptation.py
+++ b/blackjax/adaptation/mclmc_adaptation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Algorithms to adapt the MCLMC kernel parameters, namely step size and L."""
 
+import warnings
 from typing import NamedTuple
 
 import jax
@@ -21,6 +22,83 @@ from jax.flatten_util import ravel_pytree
 
 from blackjax.diagnostics import effective_sample_size
 from blackjax.util import generate_unit_vector, incremental_value_update, pytree_size
+
+# ---------------------------------------------------------------------------
+# Diagnostic warning callbacks — safe to call under JIT via jax.debug.callback.
+# Each function must NEVER raise: wrap the body in try/except so that a
+# warnings.simplefilter("error") environment does not corrupt the JAX runtime.
+# ---------------------------------------------------------------------------
+
+
+def _cb_divergence_warning(count, step_size):
+    """Warn when warmup divergences occurred.  Fired at end of adaptation."""
+    try:
+        if int(count) > 0:
+            ss_str = format(float(step_size), ".4g")
+            warnings.warn(
+                f"MCLMC warmup: {int(count)} divergent step(s) detected during "
+                f"tuning (final step_size={ss_str}). "
+                "If unexpected, try a smaller initial step size or check model "
+                "support.",
+                UserWarning,
+                stacklevel=2,
+            )
+    except Exception:
+        pass  # never propagate — a raise inside jax.debug.callback corrupts runtime
+
+
+def _cb_frozen_outcome_warning(step_size, position_std, num_steps):
+    """Warn when the adapted step size cannot traverse the warmup-scale posterior.
+
+    Triggered on mixing infeasibility (step_size * num_steps << warmup position
+    std, or zero position variance from complete divergence).  Scale/budget-
+    relative — no magic absolute constant.  Frozen-vs-healthy separation is
+    ~6 orders of magnitude, so a 3-order margin is highly robust.
+    """
+    try:
+        ss = float(step_size)
+        pos_std = float(position_std)
+        n = int(num_steps)
+        # Two conditions for "frozen":
+        #  (a) pos_std ≈ 0 — all warmup steps diverged, zero position variance.
+        #  (b) step_size * num_steps << pos_std — step too small to traverse.
+        is_zero_scale = pos_std < 1e-10
+        is_step_frozen = (ss * n) < pos_std * 1e-3
+        if is_zero_scale or is_step_frozen:
+            ss_str = format(ss, ".2g")
+            pos_str = format(pos_std, ".2g")
+            warnings.warn(
+                f"MCLMC warmup: adapted step_size {ss_str} cannot traverse "
+                f"the warmup-scale posterior (scale {pos_str}) in {n} "
+                "steps — warmup likely collapsed, check initial step size / "
+                "model support (see blackjax#973).",
+                UserWarning,
+                stacklevel=2,
+            )
+    except Exception:
+        pass
+
+
+def _cb_grad_finiteness_guard(grad_flat):
+    """Warn when the init-state gradient is non-finite.
+
+    Value-finiteness at init is insufficient (e.g. lotka-volterra: finite
+    logdensity but NaN gradient at the ODE solver's stiff regime).  This guard
+    fires once at adaptation start and is nearly free — the gradient was already
+    computed by ``mclmc.init``.
+    """
+    try:
+        if not bool(jnp.all(jnp.isfinite(grad_flat))):
+            warnings.warn(
+                "MCLMC warmup: gradient non-finite at init — this is a "
+                "model/solver/support issue, not a step-size issue. "
+                "Check model code, solver tolerances, and parameter support "
+                "(see blackjax#973).",
+                UserWarning,
+                stacklevel=2,
+            )
+    except Exception:
+        pass
 
 
 class MCLMCAdaptationState(NamedTuple):
@@ -127,6 +205,11 @@ def mclmc_find_L_and_step_size(
             "logdensity_fn is required. Pass the log-density function of the "
             "target distribution."
         )
+
+    # Guard: check gradient finiteness at init (nearly free — already computed
+    # by mclmc.init; fires once via jax.debug.callback so it works under JIT).
+    flat_grad, _ = ravel_pytree(state.logdensity_grad)
+    jax.debug.callback(_cb_grad_finiteness_guard, flat_grad)
 
     dim = pytree_size(state.position)
     if params is None:
@@ -255,11 +338,12 @@ def make_L_step_size_adaptation(
             weight=mask * success * params.step_size,
         )
 
-        return (state, params, adaptive_state, streaming_avg), None
+        # Emit divergence flag (True = divergence occurred this step)
+        return (state, params, adaptive_state, streaming_avg), jnp.logical_not(success)
 
     def run_steps(xs, state, params):
-        """Run adaptation steps via scan, returning final carry state."""
-        return jax.lax.scan(
+        """Run adaptation steps via scan; return (final_carry, per_step_div_flags)."""
+        carry, div_flags = jax.lax.scan(
             step,
             init=(
                 state,
@@ -268,7 +352,8 @@ def make_L_step_size_adaptation(
                 (0.0, jnp.array([jnp.zeros(dim), jnp.zeros(dim)])),
             ),
             xs=xs,
-        )[0]
+        )
+        return carry, div_flags
 
     def L_step_size_adaptation(state, params, num_steps, rng_key):
         num_steps1, num_steps2 = round(num_steps * frac_tune1), round(
@@ -286,18 +371,21 @@ def make_L_step_size_adaptation(
         # we use the last num_steps2 to compute the diagonal preconditioner
         mask = jnp.concatenate((jnp.zeros(num_steps1), jnp.ones(num_steps2)))
 
-        # run the steps
-        state, params, _, (_, average) = run_steps(
+        # run the steps; collect per-step divergence flags for the count warning
+        (state, params, _, (_, average)), div_flags1 = run_steps(
             xs=(mask, L_step_size_adaptation_keys), state=state, params=params
         )
+        total_div_count = jnp.sum(div_flags1)
 
         L = params.L
-        # determine L
+        # determine L; track warmup position scale for the frozen-outcome warning
         inverse_mass_matrix = params.inverse_mass_matrix
+        warmup_position_std = jnp.zeros(())  # updated below when data is available
         if num_steps2 > 1:
             x_average, x_squared_average = average[0], average[1]
             variances = x_squared_average - jnp.square(x_average)
-            L = jnp.sqrt(jnp.sum(variances))
+            warmup_position_std = jnp.sqrt(jnp.sum(variances))
+            L = warmup_position_std
 
             if diagonal_preconditioning:
                 inverse_mass_matrix = variances
@@ -307,9 +395,19 @@ def make_L_step_size_adaptation(
                 # readjust the stepsize
                 steps = round(num_steps2 / 3)  # we do some small number of steps
                 keys = jax.random.split(final_key, steps)
-                state, params, _, (_, average) = run_steps(
+                (state, params, _, _), div_flags_dc = run_steps(
                     xs=(jnp.ones(steps), keys), state=state, params=params
                 )
+                total_div_count = total_div_count + jnp.sum(div_flags_dc)
+
+        # Emit diagnostic warnings (safe under JIT via jax.debug.callback)
+        jax.debug.callback(_cb_divergence_warning, total_div_count, params.step_size)
+        jax.debug.callback(
+            _cb_frozen_outcome_warning,
+            params.step_size,
+            warmup_position_std,
+            jnp.array(num_steps, dtype=jnp.int32),
+        )
 
         return state, MCLMCAdaptationState(L, params.step_size, inverse_mass_matrix)
 

--- a/tests/adaptation/test_mclmc_warmup_diagnostics.py
+++ b/tests/adaptation/test_mclmc_warmup_diagnostics.py
@@ -11,22 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the MCLMC warmup diagnostic warnings (blackjax#973 follow-up trio).
+"""Tests for the MCLMC warmup diagnostic warnings (blackjax#973 follow-up).
 
-Three warn-only guards added in feat/mclmc-warmup-diagnostics:
-  1. Persistent-divergence count warning — fires when any warmup steps diverge.
-  2. Frozen-outcome warning — fires when adapted step_size cannot traverse the
-     posterior in the sampling budget (mixing infeasibility check).
-  3. Gradient-finiteness init guard — fires when the init-state gradient is
+Two bespoke endpoint guards added in feat/mclmc-warmup-diagnostics:
+  1. Frozen-outcome warning — fires when adapted step_size cannot traverse
+     the posterior in the sampling budget (mixing infeasibility check).
+  2. Gradient-finiteness init guard — fires when the init-state gradient is
      non-finite (value-finiteness is insufficient, e.g. lotka ODE stiffness).
+
+Per-step divergence monitoring is delegated to jax-tap (>= 0.3.0) via the
+scan ys enabling seam — see Notes in mclmc_find_L_and_step_size docstring.
 
 All warnings are unreachable on healthy runs (zero behavior change).
 """
-import re
 import warnings
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 from blackjax.adaptation.mclmc_adaptation import (
     MCLMCAdaptationState,
@@ -50,15 +52,10 @@ def _cliff_target(x):
     For any |x|^2 > 0 in float32 the factor 1e35 drives the argument below 0,
     so max clips to 0 and log(0)=-inf.  Since jnp.isfinite(-inf)=False, the
     kernel flags nonans=False on every step and reverts — position stays at
-    x=0, warmup_position_std accumulates to 0, triggering both the count warning
-    and the frozen-outcome warning.
+    x=0, warmup_position_std accumulates to 0, triggering the frozen-outcome
+    warning.
     """
     return jnp.log(jnp.maximum(1.0 - jnp.sum(x**2) * 1e35, 0.0))
-
-
-def _bounded_target(x):
-    """Std-normal inside ±5; large init step size causes initial divergences."""
-    return -0.5 * jnp.sum(x**2) + jnp.sum(jnp.log(5.0 - jnp.abs(x)))
 
 
 def _gaussian_target(x):
@@ -102,53 +99,30 @@ def _run_adaptation(target, ss_init, num_steps=200, frac1=0.5, frac2=0.5, frac3=
 # ---------------------------------------------------------------------------
 
 
-def test_cliff_replica_fires_both_warnings():
+def test_cliff_replica_fires_frozen_warning():
     """Cliff target: every kernel step produces ld=-inf, so pos_std stays 0.
 
-    Expected: divergence-count warning (with count in message) + frozen-outcome
-    warning (pos_std < 1e-10 condition).
+    Expected: frozen-outcome warning (pos_std < 1e-10 condition).
+    No count warning (dropped in favour of the jaxtap y-tap route).
     """
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         _, params, _ = _run_adaptation(_cliff_target, ss_init=10.0, num_steps=200)
 
     user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
-    count_warns = [m for m in user_msgs if "divergent" in m.lower()]
     frozen_warns = [m for m in user_msgs if "collapsed" in m.lower()]
 
-    assert count_warns, f"expected divergence-count warning, got {user_msgs}"
     assert frozen_warns, f"expected frozen-outcome warning, got {user_msgs}"
-    # The integer count must appear in the message text
-    assert any(
-        re.search(r"\d+ divergent", m) for m in count_warns
-    ), f"count not in message: {count_warns}"
-
-
-def test_step_caused_fires_count_not_frozen():
-    """Bounded target, ss_init=100: initial divergences then convergence.
-
-    The step_size converges to O(1) after the NaN-shrink ratchet; the adapted
-    sampler can traverse the posterior in num_steps steps — frozen warning must
-    NOT fire.  The count warning MUST fire (divergences happened before settling).
-    """
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _, params, _ = _run_adaptation(_bounded_target, ss_init=100.0, num_steps=200)
-
-    user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    # Must not fire a divergence-count warning (machinery was removed)
     count_warns = [m for m in user_msgs if "divergent" in m.lower()]
-    frozen_warns = [m for m in user_msgs if "collapsed" in m.lower()]
-
-    assert count_warns, f"expected divergence-count warning, got {user_msgs}"
-    ss_final = format(float(params.step_size), ".4g")
-    assert not frozen_warns, (
-        f"frozen warning must NOT fire when ss converges "
-        f"(final ss={ss_final}): {frozen_warns}"
+    assert not count_warns, (
+        f"divergence-count warning must not fire (use jaxtap recipe instead), "
+        f"got {count_warns}"
     )
 
 
 def test_healthy_gaussian_zero_warnings():
-    """Std-normal target from reasonable init: all three warnings must be silent.
+    """Std-normal target from reasonable init: all warnings must be silent.
 
     This is the structural no-op prover for the diagnostics layer: healthy runs
     produce zero UserWarnings (zero behavior change, zero output).
@@ -204,3 +178,35 @@ def test_warning_totality_under_w_error():
     # If we reach here the callbacks' try/except prevented any crash
     assert final_params is not None
     assert total_steps >= 0
+
+
+def test_jaxtap_recipe_fires_on_cliff():
+    """The documented jaxtap 0.3.0 recipe emits output events on the cliff target.
+
+    Verifies that the Notes-paragraph recipe in mclmc_find_L_and_step_size
+    actually fires alert_ys on the cliff replica (every step diverges there).
+    Skipped when jax-tap is not installed — it is an optional monitoring layer.
+    """
+    jaxtap = pytest.importorskip(
+        "jaxtap", minversion="0.3.0", reason="jax-tap>=0.3.0 not installed"
+    )
+
+    with jaxtap.record(
+        select_ys=lambda ys: ys[0],  # the single divergence-flag leaf
+        alert_ys=lambda e: "divergence" if e.value else None,
+    ) as rec:
+        _run_adaptation(_cliff_target, ss_init=10.0, num_steps=200)
+
+    output_events = [e for e in rec.events if e.kind == "output"]
+    divergent = [e for e in output_events if e.value]
+    assert output_events, (
+        "jaxtap recipe produced no output events from cliff target — "
+        "check that the scan ys enabling seam is still in place"
+    )
+    assert divergent, (
+        f"jaxtap recipe: no divergent steps detected on cliff target "
+        f"({len(output_events)} output events, all non-divergent)"
+    )
+    # Spot-check: step index 0 should be divergent on the cliff
+    first_output = output_events[0]
+    assert first_output.step == 0, f"unexpected first step index: {first_output.step}"

--- a/tests/adaptation/test_mclmc_warmup_diagnostics.py
+++ b/tests/adaptation/test_mclmc_warmup_diagnostics.py
@@ -1,0 +1,206 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the MCLMC warmup diagnostic warnings (blackjax#973 follow-up trio).
+
+Three warn-only guards added in feat/mclmc-warmup-diagnostics:
+  1. Persistent-divergence count warning — fires when any warmup steps diverge.
+  2. Frozen-outcome warning — fires when adapted step_size cannot traverse the
+     posterior in the sampling budget (mixing infeasibility check).
+  3. Gradient-finiteness init guard — fires when the init-state gradient is
+     non-finite (value-finiteness is insufficient, e.g. lotka ODE stiffness).
+
+All warnings are unreachable on healthy runs (zero behavior change).
+"""
+import re
+import warnings
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.adaptation.mclmc_adaptation import (
+    MCLMCAdaptationState,
+    mclmc_find_L_and_step_size,
+)
+from blackjax.mcmc.integrators import isokinetic_mclachlan
+from blackjax.mcmc.mclmc import build_kernel
+from blackjax.mcmc.mclmc import init as mclmc_init
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+_DIM = 2
+
+
+def _cliff_target(x):
+    """Only finite at x=0 in float32; any kernel step produces ld=-inf (not finite).
+
+    Construction: log(max(1 - |x|^2 * 1e35, 0)).  At x=0 this is log(1)=0.
+    For any |x|^2 > 0 in float32 the factor 1e35 drives the argument below 0,
+    so max clips to 0 and log(0)=-inf.  Since jnp.isfinite(-inf)=False, the
+    kernel flags nonans=False on every step and reverts — position stays at
+    x=0, warmup_position_std accumulates to 0, triggering both the count warning
+    and the frozen-outcome warning.
+    """
+    return jnp.log(jnp.maximum(1.0 - jnp.sum(x**2) * 1e35, 0.0))
+
+
+def _bounded_target(x):
+    """Std-normal inside ±5; large init step size causes initial divergences."""
+    return -0.5 * jnp.sum(x**2) + jnp.sum(jnp.log(5.0 - jnp.abs(x)))
+
+
+def _gaussian_target(x):
+    """Unbounded std-normal; should produce zero warmup warnings."""
+    return -0.5 * jnp.sum(x**2)
+
+
+def _nan_grad_target(x):
+    """Finite logdensity at x=0 but NaN gradient (lotka-style init pathology).
+
+    -sqrt(sum(x^2)) has gradient -x/|x|, which is 0/0 = NaN at x=0.
+    This tests that the init guard catches value-finite but grad-non-finite
+    targets — the same failure mode as lotka-volterra with a stiff ODE solver.
+    """
+    return -0.5 * jnp.sum(x**2) - jnp.sqrt(jnp.sum(x**2))
+
+
+def _run_adaptation(target, ss_init, num_steps=200, frac1=0.5, frac2=0.5, frac3=0.0):
+    kernel = build_kernel(integrator=isokinetic_mclachlan)
+    init_key, tune_key = jax.random.split(jax.random.key(0))
+    state = mclmc_init(jnp.zeros(_DIM), target, init_key)
+    p0 = MCLMCAdaptationState(
+        L=jnp.sqrt(_DIM), step_size=ss_init, inverse_mass_matrix=jnp.ones(_DIM)
+    )
+    return mclmc_find_L_and_step_size(
+        mclmc_kernel=kernel,
+        num_steps=num_steps,
+        state=state,
+        rng_key=tune_key,
+        logdensity_fn=target,
+        params=p0,
+        frac_tune1=frac1,
+        frac_tune2=frac2,
+        frac_tune3=frac3,
+        diagonal_preconditioning=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_cliff_replica_fires_both_warnings():
+    """Cliff target: every kernel step produces ld=-inf, so pos_std stays 0.
+
+    Expected: divergence-count warning (with count in message) + frozen-outcome
+    warning (pos_std < 1e-10 condition).
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _, params, _ = _run_adaptation(_cliff_target, ss_init=10.0, num_steps=200)
+
+    user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    count_warns = [m for m in user_msgs if "divergent" in m.lower()]
+    frozen_warns = [m for m in user_msgs if "collapsed" in m.lower()]
+
+    assert count_warns, f"expected divergence-count warning, got {user_msgs}"
+    assert frozen_warns, f"expected frozen-outcome warning, got {user_msgs}"
+    # The integer count must appear in the message text
+    assert any(
+        re.search(r"\d+ divergent", m) for m in count_warns
+    ), f"count not in message: {count_warns}"
+
+
+def test_step_caused_fires_count_not_frozen():
+    """Bounded target, ss_init=100: initial divergences then convergence.
+
+    The step_size converges to O(1) after the NaN-shrink ratchet; the adapted
+    sampler can traverse the posterior in num_steps steps — frozen warning must
+    NOT fire.  The count warning MUST fire (divergences happened before settling).
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _, params, _ = _run_adaptation(_bounded_target, ss_init=100.0, num_steps=200)
+
+    user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    count_warns = [m for m in user_msgs if "divergent" in m.lower()]
+    frozen_warns = [m for m in user_msgs if "collapsed" in m.lower()]
+
+    assert count_warns, f"expected divergence-count warning, got {user_msgs}"
+    ss_final = format(float(params.step_size), ".4g")
+    assert not frozen_warns, (
+        f"frozen warning must NOT fire when ss converges "
+        f"(final ss={ss_final}): {frozen_warns}"
+    )
+
+
+def test_healthy_gaussian_zero_warnings():
+    """Std-normal target from reasonable init: all three warnings must be silent.
+
+    This is the structural no-op prover for the diagnostics layer: healthy runs
+    produce zero UserWarnings (zero behavior change, zero output).
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _run_adaptation(_gaussian_target, ss_init=1.0, num_steps=100)
+
+    user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    assert not user_msgs, f"healthy Gaussian must emit zero warnings, got: {user_msgs}"
+
+
+def test_grad_finiteness_init_guard():
+    """Finite logdensity but NaN gradient at init: the init guard fires.
+
+    Models like lotka-volterra with stiff ODE solvers can produce NaN gradients
+    even when the log-density value is finite.  Value-checking alone at init is
+    insufficient — this test verifies the gradient guard catches the pathology.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _run_adaptation(
+            _nan_grad_target, ss_init=0.5, num_steps=20, frac1=1.0, frac2=0.0
+        )
+
+    grad_warns = [
+        str(w.message)
+        for w in caught
+        if issubclass(w.category, UserWarning) and "gradient" in str(w.message).lower()
+    ]
+    all_user_msgs = [
+        str(w.message) for w in caught if issubclass(w.category, UserWarning)
+    ]
+    assert grad_warns, f"expected gradient non-finite warning, got {all_user_msgs}"
+    assert (
+        "model/solver/support" in grad_warns[0]
+    ), f"message should direct user to model, got: {grad_warns[0]}"
+
+
+def test_warning_totality_under_w_error():
+    """Warnings promoted to exceptions by -W error must not crash the adaptation.
+
+    jax.debug.callback functions wrap warnings.warn in try/except to ensure a
+    warnings.simplefilter("error") environment cannot raise through the JAX
+    runtime.  This test verifies the adaptation run completes under that
+    environment — the cliff target triggers warnings, but the run must finish.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # promote all warnings to exceptions
+        _, final_params, total_steps = _run_adaptation(
+            _cliff_target, ss_init=10.0, num_steps=200
+        )
+    # If we reach here the callbacks' try/except prevented any crash
+    assert final_params is not None
+    assert total_steps >= 0

--- a/tests/adaptation/test_mclmc_warmup_diagnostics.py
+++ b/tests/adaptation/test_mclmc_warmup_diagnostics.py
@@ -11,20 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the MCLMC warmup diagnostic warnings (blackjax#973 follow-up).
+"""Tests for the MCLMC warmup diagnostic seam (blackjax#973 follow-up).
 
-Two bespoke endpoint guards added in feat/mclmc-warmup-diagnostics:
-  1. Frozen-outcome warning — fires when adapted step_size cannot traverse
-     the posterior in the sampling budget (mixing infeasibility check).
-  2. Gradient-finiteness init guard — fires when the init-state gradient is
-     non-finite (value-finiteness is insufficient, e.g. lotka ODE stiffness).
-
-Per-step divergence monitoring is delegated to jax-tap (>= 0.3.0) via the
-scan ys enabling seam — see Notes in mclmc_find_L_and_step_size docstring.
-
-All warnings are unreachable on healthy runs (zero behavior change).
+The scan ys enabling seam exposes a per-step divergence flag from the internal
+tuning scan.  Per-step monitoring is delegated to jax-tap (>= 0.3.0) via this
+seam — see Notes in mclmc_find_L_and_step_size docstring.
 """
-import warnings
 
 import jax
 import jax.numpy as jnp
@@ -51,26 +43,9 @@ def _cliff_target(x):
     Construction: log(max(1 - |x|^2 * 1e35, 0)).  At x=0 this is log(1)=0.
     For any |x|^2 > 0 in float32 the factor 1e35 drives the argument below 0,
     so max clips to 0 and log(0)=-inf.  Since jnp.isfinite(-inf)=False, the
-    kernel flags nonans=False on every step and reverts — position stays at
-    x=0, warmup_position_std accumulates to 0, triggering the frozen-outcome
-    warning.
+    kernel flags nonans=False on every step and reverts — every step diverges.
     """
     return jnp.log(jnp.maximum(1.0 - jnp.sum(x**2) * 1e35, 0.0))
-
-
-def _gaussian_target(x):
-    """Unbounded std-normal; should produce zero warmup warnings."""
-    return -0.5 * jnp.sum(x**2)
-
-
-def _nan_grad_target(x):
-    """Finite logdensity at x=0 but NaN gradient (lotka-style init pathology).
-
-    -sqrt(sum(x^2)) has gradient -x/|x|, which is 0/0 = NaN at x=0.
-    This tests that the init guard catches value-finite but grad-non-finite
-    targets — the same failure mode as lotka-volterra with a stiff ODE solver.
-    """
-    return -0.5 * jnp.sum(x**2) - jnp.sqrt(jnp.sum(x**2))
 
 
 def _run_adaptation(target, ss_init, num_steps=200, frac1=0.5, frac2=0.5, frac3=0.0):
@@ -97,87 +72,6 @@ def _run_adaptation(target, ss_init, num_steps=200, frac1=0.5, frac2=0.5, frac3=
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
-
-
-def test_cliff_replica_fires_frozen_warning():
-    """Cliff target: every kernel step produces ld=-inf, so pos_std stays 0.
-
-    Expected: frozen-outcome warning (pos_std < 1e-10 condition).
-    No count warning (dropped in favour of the jaxtap y-tap route).
-    """
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _, params, _ = _run_adaptation(_cliff_target, ss_init=10.0, num_steps=200)
-
-    user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
-    frozen_warns = [m for m in user_msgs if "collapsed" in m.lower()]
-
-    assert frozen_warns, f"expected frozen-outcome warning, got {user_msgs}"
-    # Must not fire a divergence-count warning (machinery was removed)
-    count_warns = [m for m in user_msgs if "divergent" in m.lower()]
-    assert not count_warns, (
-        f"divergence-count warning must not fire (use jaxtap recipe instead), "
-        f"got {count_warns}"
-    )
-
-
-def test_healthy_gaussian_zero_warnings():
-    """Std-normal target from reasonable init: all warnings must be silent.
-
-    This is the structural no-op prover for the diagnostics layer: healthy runs
-    produce zero UserWarnings (zero behavior change, zero output).
-    """
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _run_adaptation(_gaussian_target, ss_init=1.0, num_steps=100)
-
-    user_msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
-    assert not user_msgs, f"healthy Gaussian must emit zero warnings, got: {user_msgs}"
-
-
-def test_grad_finiteness_init_guard():
-    """Finite logdensity but NaN gradient at init: the init guard fires.
-
-    Models like lotka-volterra with stiff ODE solvers can produce NaN gradients
-    even when the log-density value is finite.  Value-checking alone at init is
-    insufficient — this test verifies the gradient guard catches the pathology.
-    """
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        _run_adaptation(
-            _nan_grad_target, ss_init=0.5, num_steps=20, frac1=1.0, frac2=0.0
-        )
-
-    grad_warns = [
-        str(w.message)
-        for w in caught
-        if issubclass(w.category, UserWarning) and "gradient" in str(w.message).lower()
-    ]
-    all_user_msgs = [
-        str(w.message) for w in caught if issubclass(w.category, UserWarning)
-    ]
-    assert grad_warns, f"expected gradient non-finite warning, got {all_user_msgs}"
-    assert (
-        "model/solver/support" in grad_warns[0]
-    ), f"message should direct user to model, got: {grad_warns[0]}"
-
-
-def test_warning_totality_under_w_error():
-    """Warnings promoted to exceptions by -W error must not crash the adaptation.
-
-    jax.debug.callback functions wrap warnings.warn in try/except to ensure a
-    warnings.simplefilter("error") environment cannot raise through the JAX
-    runtime.  This test verifies the adaptation run completes under that
-    environment — the cliff target triggers warnings, but the run must finish.
-    """
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # promote all warnings to exceptions
-        _, final_params, total_steps = _run_adaptation(
-            _cliff_target, ss_init=10.0, num_steps=200
-        )
-    # If we reach here the callbacks' try/except prevented any crash
-    assert final_params is not None
-    assert total_steps >= 0
 
 
 def test_jaxtap_recipe_fires_on_cliff():


### PR DESCRIPTION
Follow-up to #974 and the two-class collapse analysis in #973. **Re-scoped 2026-07-10 per maintainer design ruling**: BlackJAX does not perform value-based runtime checking/warning in library code — diagnostics are exposed as *data*, and checking is the user's job. Earlier iterations of this PR carried warn-only callbacks (`jax.debug.callback` → `warnings.warn` on runtime values); all of them are removed.

## What this PR ships

1. **The enabling seam** (the only library behavior change, pure): the MCLMC tuning scan returns the per-step divergence flag (`jnp.logical_not(success)`) as its `ys` output instead of `None`. No API change, no side effects — it makes the warmup divergence stream observable from *outside* the library.
2. **Docstring Notes on `mclmc_find_L_and_step_size`**:
   - *Live divergence monitoring* — a verified [jax-tap](https://github.com/arcueil/jax-tap) ≥ 0.3.0 recipe observing the seam via `select_ys`/`alert_ys` (executed as a test, not just documented):

     ```python
     with jaxtap.record(
         select_ys=lambda ys: ys[0],
         alert_ys=lambda e: "divergence" if e.value else None,
         alert_ys_once=True,
     ) as rec:
         state, params, _ = blackjax.mclmc_find_L_and_step_size(...)
     divergence_steps = [e.step for e in rec.events if e.kind == "output" and e.value]
     ```
   - *Checking for degenerate warmup* — the user-side check formulas from the #969/#973 investigation, as documentation instead of behavior: init-gradient finiteness before calling (finite logdensity + non-finite gradient = model/solver/support issue); the `step_size × num_steps / L` scale ratio after calling (healthy vs frozen runs separate by ~6 orders of magnitude).

## Test

`test_jaxtap_recipe_fires_on_cliff` — the documented recipe fires on a warmup-collapse replica (skips without `jax-tap>=0.3.0`; blackjax's own optional extra floor is unchanged).

## Gates

- Pre-commit (all-files): clean
- `tests/adaptation/` under the `jax-tap>=0.3.0` overlay: 222 passed
- MCLMC-specific suite: 52 passed

## Review trail

Diagnosis via the #969/#973 investigation arc (statistician A/B rounds #11–#12); implementation by the SWE agent; the warn-callback design was struck by maintainer review (design-principles ruling: no value-based runtime warnings in library code — recorded in the project decision log); TL audited the final diff including a forbidden-pattern grep (`warnings.` / `jax.debug.*` absent from library code).

Refs: #969, #973, #974, arcueil/jax-tap#3 (y-taps), tuningfork#209/#215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JsMap6KJUCBNadh5M1FsX
