### PR TITLE
Replace flaky single-chain funnel-neck assertions with a multi-chain robust grand-mean gate

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -20,8 +20,6 @@ import jax.numpy as jnp
 import numpy as np
 from jax.flatten_util import ravel_pytree
 
-import blackjax.diagnostics
-
 
 class BlackJAXTest(chex.TestCase):
     """Base test case with date-based PRNG key management.
@@ -125,71 +123,77 @@ def smooth_skewed_logdensity(x):
     return jnp.sum(x - jnp.exp(x))
 
 
-def assert_mean_within_ess_gated_tolerance(
+def assert_grand_mean_within_robust_tolerance(
     samples: np.ndarray,
     expected_mean: float = 0.0,
-    ess_min: float = 100.0,
+    atol_floor: float = 1.0,
     k_sigma: float = 5.0,
 ):
-    """Self-calibrating, ESS-gated assertion for moment recovery in single-chain tests.
+    """Multi-chain robust grand-mean assertion for difficult hierarchical targets.
 
-    Replaces fixed-tolerance assertions like ``assert_allclose(y.mean(), 0.0, atol=X)``
-    with a robust, environment-independent check that scales to the chain's achieved precision.
+    Replaces the single-chain ESS-gated assertion (3rd MC-tolerance escape, issue #970;
+    lineage #957 → #959 → #971 skip): single-chain AR-ESS both over-estimates ESS on
+    poorly-mixing targets (~7× on the funnel) and the ``ess_min`` floor was a
+    per-realization lottery — 6–17% of legitimate chains failed the gate not because the
+    sampler was biased but because their individual ESS draw fell below the floor.
 
-    **Principle**: A test whose pass/fail depends on a single MCMC realization is fragile.
-    By conditioning on the chain's own effective sample size (ESS), we pass whenever
-    the sampler is unbiased-and-mixing regardless of the specific realization or JAX version,
-    and fail only on genuine bias (see worklog/lessons/code-patterns/2026-05-11-*.md).
+    Design rationale
+    ----------------
+    - **LOCATION = plain grand mean** over all K chains: trapped chains' rare deep
+      excursions are physically real target visits that balance the finite-N bias, so
+      median/robust location is deliberately NOT used — it centers on the biased bulk
+      (+0.2 measured skew-bias on the funnel).
 
-    **Tuning ess_min**: Set based on the sampler's typical mixing on the specific target,
-    not a universal default. For difficult hierarchical targets (e.g., Neal's funnel with
-    step-size-only adaptation), ESS may be only 10-20; set ``ess_min`` to reject outliers
-    (e.g., ess_min=6) rather than requiring implausibly high mixing.
+    - **SCALE = MAD of K chain-means** (breakdown point ~50%): a single stuck chain
+      cannot inflate the threshold and hide a real bias.  A std/MCSE-based scale loses
+      up to half its detection power to exactly that trap-inflation mechanism.
+      The Gaussian consistency constant 1.4826 converts MAD to an asymptotically
+      unbiased standard-deviation estimate.
+
+    - **FLOOR = ``atol_floor``**: same-start chains share a common finite-N bias that
+      any cross-chain dispersion is structurally blind to, and a collapsible robust scale
+      can fall below it (measured false-fail without the floor). The asserted claim is
+      therefore "no GROSS systematic bias" (≥ ``atol_floor``), not exact unbiased
+      recovery.
+
+    - **K ≈ 24 recommended**: large K shrinks one trapped chain's leverage on the grand
+      mean below the floor (power) and concentrates the null grand mean well inside it
+      (null-escape rate ≲ 1e-3 by bootstrap).
 
     Parameters
     ----------
     samples : np.ndarray
-        1-D array of post-warmup samples (e.g., ``y = pos[3000:, 0]``).
+        Array of shape ``(K, T)`` — K independent post-burn chains' samples.
     expected_mean : float
         Target mean. Default 0.0.
-    ess_min : float
-        Minimum ESS gate. Pass only if ``ess >= ess_min`` (mixing guard).
-        Default 100.
+    atol_floor : float
+        Minimum threshold (absolute tolerance floor). Guards against a collapsing robust
+        scale when all K chains happen to agree closely. Default 1.0.
     k_sigma : float
-        Sigma multiple for unbiasedness gate. Pass if ``|mean - expected| < k_sigma * se``.
-        Default 5 (passes at ~5-sigma confidence, fails only on real bias).
+        Multiplier on the robust SE for the upper threshold. Default 5.0.
 
     Raises
     ------
     AssertionError
-        If ESS < ess_min (chain is not mixing well) OR if |mean - expected| >= k_sigma * SE
-        (mean is statistically inconsistent with expected).
+        If ``|grand_mean - expected_mean| >= max(atol_floor, k_sigma * robust_se)``.
     """
-    # Reshape to (n_chains=1, n_samples) for diagnostics.effective_sample_size.
-    samples_2d = np.expand_dims(samples, axis=0)
-    ess = float(
-        blackjax.diagnostics.effective_sample_size(
-            samples_2d, chain_axis=0, sample_axis=1
-        )
-    )
-
-    # Gate 1: mixing check
-    assert ess >= ess_min, (
-        "Chain is not mixing well: ESS = {:.1f} < {:.1f}. "
-        "Increase num_samples or check sampler tuning.".format(ess, ess_min)
-    )
-
-    # Gate 2: unbiasedness check (within achieved precision)
-    se = np.std(samples) / np.sqrt(ess)
-    actual_mean = float(np.mean(samples))
-    threshold = k_sigma * se
-    mean_diff = abs(actual_mean - expected_mean)
-    assert mean_diff < threshold, (
-        "Sample mean {:.6f} is statistically inconsistent with "
-        "expected {:.6f} (difference {:.6f} "
-        ">= {}-sigma threshold {:.6f}). "
-        "ESS={:.1f}, SE={:.6f}. "
-        "This may indicate a sampler bias.".format(
-            actual_mean, expected_mean, mean_diff, k_sigma, threshold, ess, se
+    chain_means = np.asarray(samples).mean(axis=1)
+    n_chains = chain_means.shape[0]
+    grand_mean = float(chain_means.mean())
+    # 1.4826 = Gaussian consistency constant: 1.4826 * MAD estimates a std deviation.
+    mad = float(np.median(np.abs(chain_means - np.median(chain_means))))
+    robust_se = 1.4826 * mad / np.sqrt(n_chains)
+    threshold = max(atol_floor, k_sigma * robust_se)
+    assert abs(grand_mean - expected_mean) < threshold, (
+        "Grand mean {:.6f} is inconsistent with expected {:.6f} "
+        "(difference {:.6f} >= threshold {:.6f}). "
+        "atol_floor={:.3f}, robust_se={:.6f}, n_chains={:d}.".format(
+            grand_mean,
+            expected_mean,
+            abs(grand_mean - expected_mean),
+            threshold,
+            atol_floor,
+            robust_se,
+            n_chains,
         )
     )

--- a/tests/mcmc/test_gist_step_size.py
+++ b/tests/mcmc/test_gist_step_size.py
@@ -248,11 +248,11 @@ class MomentRecoveryTest(BlackJAXTest):
         )
         # Pooled std check across all K chains (realization-robust at rtol=0.4).
         np.testing.assert_allclose(np.asarray(ys).std(), 3.0, rtol=0.4)
-        self.assertGreater(float(jnp.mean(accs)), 0.05)
-        self.assertTrue(np.all(np.isfinite(np.asarray(ys))))
         # Regression guard: the symmetric default must not silently degrade
         # to near-zero acceptance the way the asymmetric criterion can
         # ([AutoStep] Fig. 1).
+        self.assertGreater(float(jnp.mean(accs)), 0.05)
+        self.assertTrue(np.all(np.isfinite(np.asarray(ys))))
 
 
 class SelectorUnitTest(BlackJAXTest):

--- a/tests/mcmc/test_gist_step_size.py
+++ b/tests/mcmc/test_gist_step_size.py
@@ -18,7 +18,7 @@ import blackjax
 from blackjax.mcmc import gist, gist_step_size, integrators, metrics
 from tests.fixtures import (
     BlackJAXTest,
-    assert_mean_within_ess_gated_tolerance,
+    assert_grand_mean_within_robust_tolerance,
     neal_funnel_logdensity,
     smooth_skewed_logdensity,
     std_normal_logdensity,
@@ -212,41 +212,47 @@ class MomentRecoveryTest(BlackJAXTest):
     def test_neal_funnel_neck_marginal(self):
         # The canonical stress test for step-size adaptation (a single
         # global step size cannot work). Check only the well-behaved "neck"
-        # marginal y ~ N(0, 3**2) exactly -- the funnel coordinates' marginal
+        # marginal y ~ N(0, 3**2) -- the funnel coordinates' marginal
         # variance is a log-normal mixture (heavy-tailed, high MC variance),
         # not a useful numeric target at feasible sample sizes.
         #
-        # NOTE: step-size-only adaptation mixes the funnel poorly; ESS median
-        # is ~18-25 even on 5000-6000 post-warmup samples. This is a known
-        # limitation of step-size-only adaptation on difficult hierarchical
-        # targets; increased sample count helps but doesn't eliminate the issue.
+        # Multi-chain robust grand-mean gate (replaces the ESS-gated single-
+        # chain assertion, 3rd MC-tolerance escape, issue #970; lineage
+        # #957 → #959 → #971 skip): K=24 independent chains via vmap; grand
+        # mean over chain-means with MAD-based robust SE and an absolute-
+        # tolerance floor.  A single stuck chain cannot inflate the threshold
+        # and hide a real bias (MAD breakdown ~50%).  See
+        # tests/fixtures.py::assert_grand_mean_within_robust_tolerance for
+        # the full design rationale.
+        #
+        # NOTE: step-size-only adaptation mixes the funnel poorly -- this is
+        # a known limitation on difficult hierarchical targets.  K=24 chains
+        # amortize the per-realization variance enough to detect gross bias.
         algo = blackjax.gist_step_size(
             neal_funnel_logdensity,
             inverse_mass_matrix=jnp.ones(3),
             initial_step_size=0.3,
             max_search_steps=20,
         )
-        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 12000)
-        y = np.asarray(pos[6000:, 0])
-        # Self-calibrating ESS-gated assertion: replaces fixed atol=0.6,
-        # robust across JAX versions and environments (see lesson
-        # worklog/lessons/code-patterns/2026-05-11-single-realization-mc-noisy-assertion.md).
-        # ess_min=8 gates on mixing quality (rejects ESS < 8, ~10% of seeds)
-        # while acknowledging step_size's poor mixing on the funnel neck.
-        # ESS range observed: 3.6–45.9 (median 17.8 across 40 seeds). This
-        # principled gate is tighter than the original atol=0.6 (45% pass rate)
-        # yet realistic given step_size's fundamental limitations on hierarchical
-        # targets. Fails only when mixing is genuinely inadequate, not on variance.
-        assert_mean_within_ess_gated_tolerance(
-            y, expected_mean=0.0, ess_min=6, k_sigma=5.0
+
+        K = 24
+        keys = jax.random.split(self.next_key(), K)
+
+        def one_chain(key):
+            pos, infos = run_chain(algo, jnp.zeros(3), key, 6000)
+            return pos[3000:, 0], infos.acceptance_rate
+
+        ys, accs = jax.vmap(one_chain)(keys)  # ys: (K, T)
+        assert_grand_mean_within_robust_tolerance(
+            np.asarray(ys), expected_mean=0.0, atol_floor=1.0, k_sigma=5.0
         )
-        # Check standard deviation against theoretical N(0, 9)
-        np.testing.assert_allclose(y.std(), 3.0, rtol=0.35)
-        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        # Pooled std check across all K chains (realization-robust at rtol=0.4).
+        np.testing.assert_allclose(np.asarray(ys).std(), 3.0, rtol=0.4)
+        self.assertGreater(float(jnp.mean(accs)), 0.05)
+        self.assertTrue(np.all(np.isfinite(np.asarray(ys))))
         # Regression guard: the symmetric default must not silently degrade
         # to near-zero acceptance the way the asymmetric criterion can
         # ([AutoStep] Fig. 1).
-        self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
 
 
 class SelectorUnitTest(BlackJAXTest):

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -19,7 +19,7 @@ import blackjax
 from blackjax.mcmc import gist, gist_trajectory_length, integrators, metrics
 from tests.fixtures import (
     BlackJAXTest,
-    assert_mean_within_ess_gated_tolerance,
+    assert_grand_mean_within_robust_tolerance,
     neal_funnel_logdensity,
     smooth_skewed_logdensity,
     std_normal_logdensity,
@@ -197,33 +197,41 @@ class MomentRecoveryTest(BlackJAXTest):
         np.testing.assert_allclose(skew, -1.1395, atol=1.0)
         self.assertGreater(float(jnp.mean(infos.acceptance_rate)), 0.05)
 
-    @absltest.skip(
-        "Flaky (3rd MC-tolerance escape; #957, #959 insufficient) -- skipped "
-        "pending a multi-seed robust rewrite. Tracking: "
-        "https://github.com/blackjax-devs/blackjax/issues/970"
-    )
     def test_neal_funnel_neck_marginal(self):
-        # The canonical stress test for step-size adaptation (a single
-        # global step size cannot work). Check only the well-behaved "neck"
-        # marginal y ~ N(0, 3**2) exactly -- the funnel coordinates' marginal
+        # The canonical stress test for trajectory-length adaptation (a single
+        # global step size cannot work well here). Check only the well-behaved
+        # "neck" marginal y ~ N(0, 3**2) -- the funnel coordinates' marginal
         # variance is a log-normal mixture (heavy-tailed, high MC variance),
         # not a useful numeric target at feasible sample sizes.
-        # (Rationale mirrors test_gist_step_size.py::test_neal_funnel_neck_marginal)
+        #
+        # Multi-chain robust grand-mean gate (replaces the ESS-gated single-
+        # chain assertion that escaped 3 times, issue #970; lineage
+        # #957 → #959 → #971 skip): K=24 independent chains via vmap; grand
+        # mean over chain-means with MAD-based robust SE and an absolute-
+        # tolerance floor.  A single stuck chain cannot inflate the threshold
+        # and hide a real bias (MAD breakdown ~50%).  See
+        # tests/fixtures.py::assert_grand_mean_within_robust_tolerance for
+        # the full design rationale.
         algo = blackjax.gist_trajectory_length(
             neal_funnel_logdensity,
             inverse_mass_matrix=jnp.ones(3),
             step_size=0.15,
             max_num_steps=128,
         )
-        pos, infos = run_chain(algo, jnp.zeros(3), self.next_key(), 6000)
-        y = np.asarray(pos[3000:, 0])
-        # Self-calibrating ESS-gated assertion: replaces fixed atol=0.7,
-        # robust across JAX versions and environments (see lesson
-        # worklog/lessons/code-patterns/2026-05-11-single-realization-mc-noisy-assertion.md).
-        assert_mean_within_ess_gated_tolerance(
-            y, expected_mean=0.0, ess_min=80, k_sigma=5.0
+
+        K = 24
+        keys = jax.random.split(self.next_key(), K)
+
+        def one_chain(key):
+            pos, infos = run_chain(algo, jnp.zeros(3), key, 3000)
+            return pos[1500:, 0], infos.acceptance_rate
+
+        ys, accs = jax.vmap(one_chain)(keys)  # ys: (K, T)
+        assert_grand_mean_within_robust_tolerance(
+            np.asarray(ys), expected_mean=0.0, atol_floor=1.0, k_sigma=5.0
         )
-        self.assertTrue(np.all(np.isfinite(np.asarray(pos))))
+        self.assertGreater(float(jnp.mean(accs)), 0.05)
+        self.assertTrue(np.all(np.isfinite(np.asarray(ys))))
 
 
 class ClosedFormCrossCheckTest(BlackJAXTest):


### PR DESCRIPTION
## Problem

Neal's funnel \`test_neal_funnel_neck_marginal\` has escaped its MC tolerance three times now (issues #957, #959, and #970 — the third escape triggered \`@absltest.skip\` in #971). The root cause is structural, not a matter of tuning the existing gate further.

The prior assertion (\`assert_mean_within_ess_gated_tolerance\`) used a single-chain AR-ESS as the calibration signal. On the funnel, AR-ESS **over-estimates** actual ESS by ~7× (trapped chains produce high autocorrelation but also the misleadingly large apparent ESS from brief excursions). The \`ess_min\` floor was therefore a per-realization lottery: 6–17% of *legitimate*, unbiased chains happened to fall below it, causing spurious failures that were indistinguishable from genuine sampler failures. Additionally, \`std(samples) / sqrt(ESS)\` underestimates the true Monte Carlo standard error 2–4× on poorly-mixing targets, so the effective tolerance was tighter than intended.

## Fix

**New helper \`assert_grand_mean_within_robust_tolerance\` in \`tests/fixtures.py\`:**

Run K=24 independent chains (via \`jax.vmap\`) and assert on the *grand mean* of their per-chain means, using a MAD-based robust scale:

- **Location = plain grand mean**: trapped chains' rare deep excursions are physically real target visits that balance the finite-N bias — median/robust location is deliberately *not* used, because it centres on the biased bulk (+0.2 measured skew-bias on the funnel).
- **Scale = 1.4826 × MAD / √K**: the Gaussian consistency constant converts MAD to an asymptotically unbiased std estimate; MAD has breakdown point ~50%, so a single stuck chain cannot inflate the threshold and hide a real bias (std/MCSE loses up to half its detection power to that same trap-inflation mechanism).
- **Floor = \`atol_floor=1.0\`**: same-start chains share a common finite-N bias that cross-chain dispersion is structurally blind to; the floor prevents a collapsible robust scale from triggering false failures. The asserted claim is "no gross systematic bias", not exact recovery.
- **K=24**: large enough to shrink one trapped chain's leverage on the grand mean below the floor (power) and concentrate the null grand mean well inside it (null-escape rate ≲ 1e-3 by bootstrap).

The old \`assert_mean_within_ess_gated_tolerance\` is removed entirely — it had exactly two callers, both in the GIST test files.

**Per-variant chain lengths (halved from the prior single-chain budgets):**
- \`test_gist_trajectory_length\`: N=3000, burn=1500 per chain (×24 = effectively 36k post-burn samples)
- \`test_gist_step_size\`: N=6000, burn=3000 per chain (×24 = 72k post-burn samples)
- A pooled std check across all K chains (rtol=0.4) is kept for the step_size variant as a realization-robust sanity assertion.

The \`@absltest.skip\` decorator is removed from \`test_gist_trajectory_length.py::test_neal_funnel_neck_marginal\`.

## Validation

- The two rewritten funnel tests run in ~4.3s combined including JIT compilation (~1.1s warm) — faster than the single-chain versions they replace.
- Power controls: planted mean-biases ≥1.5 and a shifted-target control kernel at μ≥1.5 are each detected at ~100% — the robust gate still fails on genuine sampler bias.
- 490 tests in \`tests/mcmc\` pass (\`-n 2 --benchmark-disable\`), 0 failures
- \`uv run pre-commit run --all-files\` exits 0 — no new warnings
- Zero remaining references to \`assert_mean_within_ess_gated_tolerance\`; zero \`@absltest.skip\` in the two GIST test files

Closes #970

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)