### PR TITLE
Add pure metric-estimator module (E-layer): consolidated low-rank and diagonal estimators

### DIFF
--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -1,0 +1,694 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""E-layer: pure metric estimator functions for the low-rank unification RFC.
+
+Each function is a **pure transformation**: explicit arrays in → metric
+representation out.  No buffer state, no scheduling logic, no side effects.
+All functions are JAX-traceable and safe to use inside ``jax.lax.scan`` /
+``jax.vmap`` provided that ``max_rank`` (where applicable) is a static
+Python integer (required to determine output shapes).
+
+**Source lineage** (R2a census, 2026-07-11, main @ 532631c1):
+
++--------------------------------------+--------------------------------------------+
+| Estimator                            | Extracted from                             |
++======================================+============================================+
+| :func:`fisher_score_low_rank`        | ``low_rank_adaptation._compute_low_rank``  |
+|                                      | ``_metric`` + ``_spd_mean``                |
++--------------------------------------+--------------------------------------------+
+| :func:`draws_singular_value_low_rank`| ``mclmc_lrd_adaptation``                   |
+|                                      | ``._extract_lrd_from_samples``             |
++--------------------------------------+--------------------------------------------+
+| :func:`sample_covariance_eigh_low``  | ``meads_adaptation``                       |
+| ``_rank`                             | ``._lrd_from_accumulated_covariance``      |
++--------------------------------------+--------------------------------------------+
+| :func:`welford_diagonal`             | ``mass_matrix.welford_algorithm``          |
+| :func:`welford_dense`                | (thin scan-wrappers; algorithm untouched)  |
++--------------------------------------+--------------------------------------------+
+| :func:`fisher_score_diagonal`        | branch b197f1e2                            |
+|                                      | ``mass_matrix._fisher_diagonal_inverse``   |
+|                                      | ``_mass`` (dormant; wiring stays dormant)  |
++--------------------------------------+--------------------------------------------+
+| :func:`sample_variance_diagonal`     | ``mclmc_adaptation.py:342`` and            |
+|                                      | ``adjusted_mclmc_adaptation.py:375``       |
+|                                      | (verbatim duplicate; one function here)    |
++--------------------------------------+--------------------------------------------+
+
+**Composition law (RFC §0 L2):** estimators, data-feeding policy, and schedule
+are co-adapted package components.  The functions here are the *estimator*
+component only — callers supply the buffer view.  Gating logic (support gates,
+fraction-window checks, 2·d thresholds) belongs in the G-layer; it is
+explicitly *not* implemented here (docstrings note the relevant gates for each
+estimator).
+
+**Registration (R2a phase):** these functions are module-public (importable
+from ``blackjax.adaptation.metric_estimators``) but are NOT exported at the
+``blackjax`` top-level.  Top-level registration and consumer re-wiring happen
+in R3.
+"""
+
+from typing import Literal
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.adaptation.low_rank_adaptation import (
+    _relative_pd_floor,
+    _spd_mean,
+)
+from blackjax.adaptation.mass_matrix import welford_algorithm
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
+from blackjax.types import Array
+
+__all__ = [
+    "eigenvalue_informativeness",
+    "select_top_eigenvalues_by_informativeness",
+    "fisher_score_low_rank",
+    "draws_singular_value_low_rank",
+    "sample_covariance_eigh_low_rank",
+    "welford_diagonal",
+    "welford_dense",
+    "fisher_score_diagonal",
+    "sample_variance_diagonal",
+]
+
+
+# ---------------------------------------------------------------------------
+# Shared utilities
+# ---------------------------------------------------------------------------
+
+
+def eigenvalue_informativeness(eigenvalues: Array) -> Array:
+    r"""Informativeness of each eigenvalue: how far it deviates from isotropic.
+
+    Computes :math:`|\lambda - 1|` for each entry of ``eigenvalues``.
+    Directions with large informativeness deviate the most from the identity
+    metric and benefit the most from low-rank preconditioning.
+
+    This idiom is used identically in:
+
+    * :func:`fisher_score_low_rank` (step 9 — top-k selection in projected
+      subspace; see ``low_rank_adaptation._compute_low_rank_metric`` :468).
+    * :func:`draws_singular_value_low_rank` (top-k SVD eigenvalue selection;
+      see ``mclmc_lrd_adaptation._extract_lrd_from_samples`` :271).
+    * :func:`sample_covariance_eigh_low_rank` (top-k eigh eigenvalue selection;
+      see ``meads_adaptation._lrd_from_accumulated_covariance`` :309).
+
+    Parameters
+    ----------
+    eigenvalues
+        Shape ``(q,)``.  Eigenvalues of a correlation (or preconditioned)
+        matrix.  An isotropic Gaussian has all eigenvalues equal to 1 and
+        informativeness 0.
+
+    Returns
+    -------
+    Array, shape ``(q,)``
+        :math:`|\lambda_i - 1|` for each :math:`\lambda_i`.
+    """
+    return jnp.abs(eigenvalues - 1.0)
+
+
+def select_top_eigenvalues_by_informativeness(
+    eigenvalues: Array,
+    eigenvectors: Array,
+    max_rank: int,
+    *,
+    tail_handling: Literal["mask_pad", "raw"] = "mask_pad",
+    cutoff: float = 2.0,
+) -> tuple[Array, Array]:
+    r"""Select the top-``max_rank`` eigenpairs by :func:`eigenvalue_informativeness`.
+
+    Two production consumers use this pattern with **divergent tail handling**
+    (D2 in the RFC duplication map):
+
+    ``tail_handling="mask_pad"`` (default)
+        Used by :func:`fisher_score_low_rank`.  Eigenvalues inside the
+        uninformative band :math:`[1/\text{cutoff},\ \text{cutoff}]` are
+        **masked to 1** (they carry no preconditioning benefit), making the
+        corresponding direction a no-op in the metric.  When the input
+        subspace has fewer than ``max_rank`` eigenvectors (``q < max_rank``,
+        which arises when ``d < 2 · max_rank``), the output is **zero-padded**
+        to the requested shape — zero columns in ``U`` and ``lam=1`` entries
+        — so the return shape is always ``(d, max_rank)`` / ``(max_rank,)``.
+        Matches ``low_rank_adaptation._compute_low_rank_metric`` steps 8–9
+        (:468–484).
+
+    ``tail_handling="raw"``
+        Used by :func:`draws_singular_value_low_rank` and
+        :func:`sample_covariance_eigh_low_rank`.  The top-k pairs are
+        returned **as-is**: no informativeness masking, no padding.  The
+        caller must ensure ``max_rank <= q``; behaviour is undefined (JAX
+        will silently return ``q`` columns) when ``max_rank > q``.  Matches
+        ``mclmc_lrd_adaptation._extract_lrd_from_samples`` :271–275 and
+        ``meads_adaptation._lrd_from_accumulated_covariance`` :309–312.
+
+    Parameters
+    ----------
+    eigenvalues
+        Shape ``(q,)``.  Must be the eigenvalues associated with the columns
+        of ``eigenvectors``.
+    eigenvectors
+        Shape ``(d, q)``.  Columns are the eigenvectors.
+    max_rank
+        Number of eigenpairs to return.  Must be a **static Python integer**
+        (determines the output shape).
+    tail_handling
+        See above.  Default ``"mask_pad"`` matches the Fisher-score consumer.
+    cutoff
+        Only used when ``tail_handling="mask_pad"``.  Eigenvalues in
+        :math:`[1/\text{cutoff},\ \text{cutoff}]` are masked to 1.
+        Default ``2.0`` matches nutpie's ``c=2``.
+
+    Returns
+    -------
+    U_out : Array, shape ``(d, max_rank)`` (mask_pad) or ``(d, ≤max_rank)`` (raw)
+        Selected (and possibly masked/padded) eigenvectors.
+    lam_out : Array, shape ``(max_rank,)`` or ``(≤max_rank,)``
+        Selected (and possibly masked) eigenvalues.
+    """
+    if tail_handling not in ("mask_pad", "raw"):
+        raise ValueError(
+            f"tail_handling must be 'mask_pad' or 'raw', got {tail_handling!r}"
+        )
+
+    q = eigenvalues.shape[0]
+    scores = eigenvalue_informativeness(eigenvalues)
+    # Descending order by informativeness — same idiom in both consumers.
+    order = jnp.argsort(-scores)
+
+    if tail_handling == "mask_pad":
+        actual_rank = min(max_rank, q)  # static: both are Python ints at trace time
+        top_order = order[:actual_rank]
+        U_out = eigenvectors[:, top_order]  # (d, actual_rank)
+        lam_raw = eigenvalues[top_order]  # (actual_rank,)
+
+        # Mask eigenvalues inside the uninformative band to 1.0.
+        # nutpie: keep λ < 1/cutoff or λ > cutoff; others set to 1.
+        is_informative = (lam_raw < 1.0 / cutoff) | (lam_raw > cutoff)
+        lam_out = jnp.where(is_informative, lam_raw, 1.0)
+
+        # Zero-pad to max_rank when the input subspace is smaller.
+        if actual_rank < max_rank:
+            d = eigenvectors.shape[0]
+            pad = max_rank - actual_rank
+            U_out = jnp.concatenate([U_out, jnp.zeros((d, pad))], axis=1)
+            lam_out = jnp.concatenate([lam_out, jnp.ones(pad)])
+
+        return U_out, lam_out
+
+    else:  # "raw"
+        top_order = order[:max_rank]
+        return eigenvectors[:, top_order], eigenvalues[top_order]
+
+
+# ---------------------------------------------------------------------------
+# Low-rank estimators
+# ---------------------------------------------------------------------------
+
+
+def fisher_score_low_rank(
+    draws: Array,
+    grads: Array,
+    max_rank: int,
+    *,
+    gamma: float = 1e-5,
+    cutoff: float = 2.0,
+) -> LowRankInverseMassMatrix:
+    r"""Fisher-divergence-minimising low-rank inverse mass matrix.
+
+    Implements Steps 1–9 of Algorithm 1 of
+    :cite:p:`seyboldt2026preconditioning`, following the nutpie reference
+    implementation (``nuts-rs`` ``src/transform/adapt/low_rank.rs``
+    ``estimate_mass_matrix``).
+
+    The inverse mass matrix has the form
+
+    .. math::
+
+        M^{-1} = \operatorname{diag}(\sigma)
+                 \bigl(I + U(\Lambda - I)U^\top\bigr)
+                 \operatorname{diag}(\sigma)
+
+    where :math:`\sigma`, :math:`U`, :math:`\Lambda` minimise the sample
+    Fisher divergence from :math:`\{(x_i, \nabla \log p(x_i))\}`.
+
+    **Extracted from:** ``blackjax.adaptation.low_rank_adaptation``
+    ``._compute_low_rank_metric`` + ``._spd_mean`` (main @ 532631c1).
+
+    **Key asymmetry vs** :func:`draws_singular_value_low_rank`: this estimator
+    uses BOTH draws and score gradients and applies γ-regularisation plus
+    cutoff-masking on the eigenvalues.  :func:`draws_singular_value_low_rank`
+    uses draws only and applies neither — the docstring notes this divergence
+    explicitly.
+
+    **Diagonal scale** ``σ = (Var[x] / Var[∇ log p])^{1/4}`` is the
+    per-coordinate optimal scale (paper §3.1); clipped to ``[1e-20, 1e20]``
+    (nutpie range).
+
+    **AIRM geometric mean** ``Σ = C_x # C_a^{-1}`` (AIRM = affine-invariant
+    Riemannian metric): Theorem 2.3 / Eq. 9 of
+    :cite:p:`seyboldt2026preconditioning` — the regularised optimal inverse
+    mass matrix is the geometric mean of the draw covariance with the
+    *inverse* score covariance.
+
+    **γ-regularisation** ``C = P P^T / γ + I`` (nutpie convention: the
+    *unnormalised* sum-of-outer-products divided by ``γ`` directly, no ``n``
+    scaling). Influence fades as ``n`` grows (Theorem 2.4).
+
+    **Cutoff masking**: eigenvalues in ``[1/cutoff, cutoff]`` are set to 1
+    (no preconditioning benefit); default ``cutoff=2`` matches nutpie.
+
+    **dtype promotion** (round-9 schedule-port audit): promotes internally to
+    ``float64`` when ``jax_enable_x64`` is active, regardless of the chain's
+    working dtype.  Returns in the caller's original dtype.
+
+    **G-layer note:** the 2·d support gate (``n ≥ 2·d`` before the LR
+    estimate is trusted) and any fraction-window guard are G-layer concerns
+    and are NOT implemented here.
+
+    Parameters
+    ----------
+    draws
+        Shape ``(n, d)``.  Chain positions (all rows must be valid samples —
+        no zero-padding).
+    grads
+        Shape ``(n, d)``.  Log-density gradients at the corresponding draws.
+    max_rank
+        Maximum number of eigenvectors in the low-rank correction.  Must be
+        a **static Python integer** (determines output shape).
+    gamma
+        Regularisation scale (nutpie convention).  Default ``1e-5`` matches
+        nutpie's ``LowRankSettings::default``.
+    cutoff
+        Eigenvalue cutoff for informativeness masking.  Default ``2.0``
+        matches nutpie's ``c=2``.
+
+    Returns
+    -------
+    LowRankInverseMassMatrix
+        ``(sigma, U, lam)`` with shapes ``(d,)``, ``(d, max_rank)``,
+        ``(max_rank,)``.
+
+    Notes
+    -----
+    The optimal translation ``μ* = x̄ + σ² ⊙ ᾱ`` (paper §3.2) is an
+    adaptation-layer output, not part of the metric.  Compute it separately
+    from the per-draw means if needed by the warmup wiring (R3 concern).
+    """
+    orig_dtype = draws.dtype
+    compute_dtype = jnp.float64 if jax.config.jax_enable_x64 else orig_dtype
+    draws = draws.astype(compute_dtype)
+    grads = grads.astype(compute_dtype)
+
+    n, d = draws.shape
+
+    # --- Step 1: diagonal scaling  σ = (Var[x] / Var[∇log p])^{1/4} ---
+    # draws.shape[0] is a static Python int for the pure estimator interface.
+    mean_x = draws.mean(0)  # (d,)
+    mean_g = grads.mean(0)  # (d,)
+
+    diff_x = draws - mean_x[None, :]  # (n, d)
+    diff_g = grads - mean_g[None, :]  # (n, d)
+
+    # Population variance (n not n-1), matching nutpie.
+    var_x = (diff_x**2).sum(0) / n  # (d,)
+    var_g = (diff_g**2).sum(0) / n  # (d,)
+
+    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
+    sigma = jnp.clip(sigma, 1e-20, 1e20)  # nutpie range
+
+    # --- Step 2: scale draws and gradients ---
+    X = diff_x / sigma[None, :]  # (n, d)  scaled centered draws
+    A = diff_g * sigma[None, :]  # (n, d)  scaled centered gradients
+
+    # --- Step 3: principal subspaces via thin SVD ---
+    _, _, Vt_x = jnp.linalg.svd(X, full_matrices=False)  # Vt_x: (min(n,d), d)
+    _, _, Vt_a = jnp.linalg.svd(A, full_matrices=False)
+    U_x = Vt_x[:max_rank].T  # (d, max_rank)
+    U_a = Vt_a[:max_rank].T  # (d, max_rank)
+
+    # --- Step 4: combined orthonormal basis Q ∈ ℝ^{d × q} ---
+    combined = jnp.concatenate([U_x, U_a], axis=1)  # (d, 2*max_rank)
+    Q, _ = jnp.linalg.qr(combined)  # Q: (d, min(d, 2*max_rank))
+    q = Q.shape[1]  # actual subspace dimension
+
+    # --- Step 5: project onto Q ---
+    P_x = Q.T @ X.T  # (q, n)
+    P_a = Q.T @ A.T  # (q, n)
+
+    # --- Step 6: projected covariance matrices ---
+    # nutpie: C = P P^T / gamma + I  (raw gamma, no /n).
+    C_x = (P_x @ P_x.T) / gamma + jnp.eye(q, dtype=compute_dtype)
+    C_a = (P_a @ P_a.T) / gamma + jnp.eye(q, dtype=compute_dtype)
+
+    # --- Step 7: SPD geometric mean Σ = C_x # C_a^{-1} ---
+    # Theorem 2.3 / Eq. 9 of arXiv:2603.18845.
+    Sigma = _spd_mean(C_x, jnp.linalg.inv(C_a))
+
+    # --- Step 8: eigendecompose Σ in the projected subspace ---
+    vals, vecs = jnp.linalg.eigh(Sigma)  # ascending, (q,)
+    vals = jnp.maximum(vals, _relative_pd_floor(vals))
+    U_full = Q @ vecs  # (d, q) back to original space
+
+    # --- Step 9: select top max_rank by |λ-1|; mask near-unity eigenvalues ---
+    U_out, lam_out = select_top_eigenvalues_by_informativeness(
+        vals, U_full, max_rank, tail_handling="mask_pad", cutoff=cutoff
+    )
+
+    return LowRankInverseMassMatrix(
+        sigma=sigma.astype(orig_dtype),
+        U=U_out.astype(orig_dtype),
+        lam=lam_out.astype(orig_dtype),
+    )
+
+
+def draws_singular_value_low_rank(
+    draws: Array,
+    max_rank: int,
+) -> LowRankInverseMassMatrix:
+    r"""Draws-only SVD low-rank inverse mass matrix (MCLMC Scheme A estimator).
+
+    Estimates the low-rank inverse mass matrix from the SVD of centred,
+    standardised draws.  No gradient information is required.
+
+    **Extracted from:** ``blackjax.adaptation.mclmc_lrd_adaptation``
+    ``._extract_lrd_from_samples`` (main @ 532631c1).
+
+    **Key asymmetry vs** :func:`fisher_score_low_rank`:
+
+    * Draws only — no score gradients.
+    * **No regularisation** (no γ): the covariance is estimated from raw
+      outer products without a ``P P^T / γ + I`` regularisation term.
+    * **No masking**: eigenvalues are returned as-is (``tail_handling="raw"``
+      in :func:`select_top_eigenvalues_by_informativeness`); non-informative
+      eigenvalues are NOT masked to 1.  This is a deliberate design choice
+      in the MCLMC-LRD pilot estimator: the raw eigenspectrum is what drives
+      the effective condition number diagnostics downstream.
+
+    This asymmetry is preserved faithfully here; see the RFC duplication map
+    D2 for context.
+
+    **G-layer note:** the Geyer-ESS support gate
+    (``k_used = min(k, ⌊n_eff/2⌋)``, ``mclmc_lrd_adaptation.py:636``) and
+    the ``n ≥ 2·d`` threshold are G-layer concerns.  Ensure ``max_rank ≤
+    min(n, d)`` before calling (behaviour is undefined otherwise; JAX will
+    return fewer than ``max_rank`` columns when ``max_rank > min(n, d)``).
+
+    Parameters
+    ----------
+    draws
+        Shape ``(n, d)``.  All rows must be valid samples (no zero-padding).
+    max_rank
+        Number of eigenpairs to return.  Must be a static Python integer and
+        satisfy ``max_rank ≤ min(n, d)``.
+
+    Returns
+    -------
+    LowRankInverseMassMatrix
+        ``(sigma, U, lam)`` where ``sigma`` is the per-coordinate standard
+        deviation and ``lam`` are the raw SVD eigenvalues of the sample
+        correlation matrix (not masked to 1 for near-unity values).
+
+    Notes
+    -----
+    The full eigenspectrum needed for :func:`~blackjax.adaptation.mclmc_lrd_adaptation._kappa_eff_pilot`
+    diagnostics is NOT returned here — that function operates on the full
+    sorted spectrum (``lam_all_sorted``).  If you need the full spectrum,
+    call ``_extract_lrd_from_samples`` directly (G-layer concern, not part
+    of the pure estimator).
+    """
+    mean = jnp.mean(draws, axis=0)  # (d,)
+    sigma = jnp.std(draws, axis=0)  # (d,)
+    sigma = jnp.where(sigma == 0.0, 1.0, sigma)  # avoid div-by-zero
+
+    standardised = (draws - mean[None, :]) / sigma[None, :]  # (n, d)
+    n = draws.shape[0]
+
+    # Thin SVD; eigenvalues of the sample correlation matrix: lam_i = s_i^2 / n.
+    _, S, Vt = jnp.linalg.svd(standardised, full_matrices=False)
+    V = Vt.T  # (d, min(n, d))
+    lam = (S**2) / n  # (min(n, d),)
+
+    # Raw top-k selection by |λ-1|: no masking, no padding.
+    U_k, lam_k = select_top_eigenvalues_by_informativeness(
+        lam, V, max_rank, tail_handling="raw"
+    )
+
+    return LowRankInverseMassMatrix(sigma=sigma, U=U_k, lam=lam_k)
+
+
+def sample_covariance_eigh_low_rank(
+    m2: Array,
+    count: Array | int,
+    max_rank: int,
+) -> LowRankInverseMassMatrix:
+    r"""Chan/Welford-accumulated covariance → low-rank metric via ``eigh``.
+
+    Extracts a low-rank inverse mass matrix from a Chan-parallel-accumulated
+    sum of squared deviations matrix (MEADS / MCLMC-LRD Scheme-B estimator).
+
+    **Extracted from:** ``blackjax.adaptation.meads_adaptation``
+    ``._lrd_from_accumulated_covariance`` (main @ 532631c1, landed via #954).
+
+    The input ``m2`` is the accumulated Chan-parallel M2 matrix (shape
+    ``(d, d)``):
+
+    .. math::
+
+        M_2 = \sum_{i=1}^n (x_i - \bar{x}_n)(x_i - \bar{x}_n)^T
+
+    which gives the Bessel-corrected sample covariance as
+    ``C = M_2 / (n - 1)``.  The correlation matrix is then
+    ``R = D^{-1/2} C D^{-1/2}`` where ``D = diag(C)``, and ``eigh`` of ``R``
+    gives the eigenbasis.
+
+    **Tail handling:** raw (no cutoff masking, no zero-padding) — matching the
+    MEADS implementation.  The G-layer (``meads_adaptation``'s
+    ``low_rank_window_fraction`` / 2·d gate) ensures the estimate is only used
+    when the accumulated support suffices.
+
+    **G-layer note:** the fraction-window gate (only accumulate draws in the
+    second half of the adaptation window, ``low_rank_window_fraction=0.5``) and
+    the 2·d support threshold are G-layer concerns; they gate *when* to call
+    this estimator, not what it computes.  Callers must ensure ``count``
+    reflects enough effective support before calling.
+
+    Parameters
+    ----------
+    m2
+        Shape ``(d, d)``.  Accumulated Chan-Welford sum of squared deviations
+        (NOT divided by ``count``; this function applies the Bessel correction
+        ``/ max(count - 1, 1)`` internally).
+    count
+        Total number of samples accumulated into ``m2``.  May be a traced
+        JAX integer (safe inside ``jax.lax.scan``).
+    max_rank
+        Number of eigenpairs to return.  Must be a static Python integer and
+        satisfy ``max_rank ≤ d``.
+
+    Returns
+    -------
+    LowRankInverseMassMatrix
+        ``(sigma, U, lam)`` with shapes ``(d,)``, ``(d, max_rank)``,
+        ``(max_rank,)``.
+    """
+    # Bessel-corrected covariance from the accumulated M2.
+    covariance = m2 / jnp.maximum(count - 1.0, 1.0)  # (d, d)
+    variance = jnp.diag(covariance)  # (d,)
+    sigma = jnp.sqrt(jnp.maximum(variance, 0.0))  # (d,)
+    sigma = jnp.where(sigma <= 0.0, 1.0, sigma)  # avoid div-by-zero
+
+    inv_sigma = 1.0 / sigma  # (d,)
+    correlation = covariance * inv_sigma[:, None] * inv_sigma[None, :]  # (d, d)
+
+    # eigh gives ascending eigenvalues of the (symmetric) correlation matrix.
+    lam_all, V = jnp.linalg.eigh(correlation)  # (d,), (d, d)
+
+    # Raw top-k selection by |λ-1|: no masking, no padding.
+    U, lam = select_top_eigenvalues_by_informativeness(
+        lam_all, V, max_rank, tail_handling="raw"
+    )
+
+    return LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
+
+
+# ---------------------------------------------------------------------------
+# Diagonal estimators
+# ---------------------------------------------------------------------------
+
+
+def welford_diagonal(draws: Array) -> Array:
+    r"""Diagonal (per-coordinate) sample variance via Welford's algorithm.
+
+    Thin scan-wrapper over :func:`blackjax.adaptation.mass_matrix.welford_algorithm`
+    with ``is_diagonal_matrix=True``.  Computes the Bessel-corrected sample
+    variance :math:`s^2_i = \frac{1}{n-1}\sum_{j=1}^n (x_{ji} - \bar{x}_i)^2`
+    for each coordinate ``i``.
+
+    **Why a wrapper instead of direct ``jnp.var``:** R2b/R3 must have a
+    single estimator import surface; this function ensures future callers can
+    swap to streaming Welford (e.g., for online adaptation) without changing
+    call sites.  The algorithm itself is NOT moved or duplicated — only the
+    call site is unified here.
+
+    **Source:** ``blackjax.adaptation.mass_matrix.welford_algorithm``
+    (``is_diagonal_matrix=True``).
+
+    Parameters
+    ----------
+    draws
+        Shape ``(n, d)``.
+
+    Returns
+    -------
+    Array, shape ``(d,)``
+        Bessel-corrected per-coordinate sample variance (= diagonal of the
+        sample covariance matrix).
+    """
+    n, d = draws.shape
+    wc_init, wc_update, wc_final = welford_algorithm(is_diagonal_matrix=True)
+
+    def scan_fn(state, draw):
+        return wc_update(state, draw), None
+
+    final_state, _ = jax.lax.scan(scan_fn, wc_init(d), draws)
+    covariance, _, _ = wc_final(final_state)
+    return covariance
+
+
+def welford_dense(draws: Array) -> Array:
+    r"""Dense sample covariance via Welford's algorithm.
+
+    Thin scan-wrapper over :func:`blackjax.adaptation.mass_matrix.welford_algorithm`
+    with ``is_diagonal_matrix=False``.  Computes the Bessel-corrected sample
+    covariance matrix.
+
+    **Source:** ``blackjax.adaptation.mass_matrix.welford_algorithm``
+    (``is_diagonal_matrix=False``).
+
+    Parameters
+    ----------
+    draws
+        Shape ``(n, d)``.
+
+    Returns
+    -------
+    Array, shape ``(d, d)``
+        Bessel-corrected sample covariance matrix.
+    """
+    n, d = draws.shape
+    wc_init, wc_update, wc_final = welford_algorithm(is_diagonal_matrix=False)
+
+    def scan_fn(state, draw):
+        return wc_update(state, draw), None
+
+    final_state, _ = jax.lax.scan(scan_fn, wc_init(d), draws)
+    covariance, _, _ = wc_final(final_state)
+    return covariance
+
+
+def fisher_score_diagonal(
+    draws: Array,
+    grads: Array,
+) -> Array:
+    r"""Fisher-divergence-minimising diagonal inverse mass matrix.
+
+    Computes :math:`\sigma^2 = \sqrt{\mathrm{Var}[x] / \mathrm{Var}[\nabla
+    \log p]}`, the per-coordinate diagonal estimator of
+    :cite:p:`seyboldt2026preconditioning`.
+
+    This is the **diagonal-only** analogue of :func:`fisher_score_low_rank`:
+    that function's diagonal scale :math:`\sigma =
+    (\mathrm{Var}[x] / \mathrm{Var}[\nabla \log p])^{1/4}` gives the
+    corresponding inverse mass matrix as
+    :math:`\sigma^2 = \sqrt{\mathrm{Var}[x] / \mathrm{Var}[\nabla \log p]}`
+    when the low-rank correction ``(U, lam)`` is dropped.
+
+    **Extracted from:** branch ``b197f1e2`` (``feat/window-adaptation-fisher-diag``,
+    2026-07-04), ``blackjax.adaptation.mass_matrix._fisher_diagonal_inverse_mass``.
+    The branch is DORMANT — its ``window_adaptation`` wiring (the diagonal
+    estimator opt-in in ``mass_matrix_adaptation``) is NOT reproduced here and
+    stays dormant.  Only the pure estimator math is extracted.
+
+    **Near-zero gradient protection** (same as :func:`fisher_score_low_rank`):
+    ``Var[∇ log p]`` is floored at ``1e-10`` before division, and the result
+    is clipped to nutpie's ``[1e-20, 1e20]`` range before squaring.
+
+    **Note on variance convention:** ``Var[x]`` and ``Var[∇ log p]`` are
+    computed with the same normalisation (Bessel-corrected, ``n-1`` divisor,
+    via :func:`welford_diagonal`); the ratio is invariant to a shared
+    ``n`` vs ``n-1`` factor (branch ``b197f1e2`` commit message, verified).
+
+    Parameters
+    ----------
+    draws
+        Shape ``(n, d)``.  Chain positions.
+    grads
+        Shape ``(n, d)``.  Log-density gradients at the corresponding draws.
+
+    Returns
+    -------
+    Array, shape ``(d,)``
+        Diagonal inverse mass matrix :math:`\sigma^2`.
+    """
+    var_x = welford_diagonal(draws)  # (d,)  Bessel-corrected
+    var_g = welford_diagonal(grads)  # (d,)
+
+    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
+    sigma = jnp.clip(sigma, 1e-20, 1e20)  # nutpie range
+    return sigma**2
+
+
+def sample_variance_diagonal(draws: Array) -> Array:
+    r"""Coordinate-wise population variance from raw draws.
+
+    Computes :math:`\hat{\sigma}^2_i = \mathbb{E}[x_i^2] - \mathbb{E}[x_i]^2`
+    (population variance, no Bessel correction) for each coordinate ``i``.
+
+    **Extracted from (verbatim duplicate):**
+
+    * ``blackjax.adaptation.mclmc_adaptation``, ``L_step_size_adaptation``
+      :341–342: ``variances = x_squared_average - jnp.square(x_average)``
+      where ``x_average = E[x]`` and ``x_squared_average = E[x^2]`` are
+      streaming step-size-weighted averages.
+
+    * ``blackjax.adaptation.adjusted_mclmc_adaptation``,
+      ``adjusted_mclmc_find_L_and_step_size`` :374–375: identical formula.
+
+    Both inline occurrences use the result as ``inverse_mass_matrix = variances``,
+    i.e., the population variance IS the diagonal IMM.  The streaming-average
+    formulation (weighted by step size via ``incremental_value_update``) is an
+    adaptation-layer scheduling concern; the pure estimator here takes the batch
+    of accumulated draws directly.
+
+    **Population (not Bessel-corrected)** to match the MCLMC streaming form:
+    the weighted incremental average
+    ``avg ← avg + w·(x − avg) / Σw`` converges to :math:`\mathbb{E}[x]` under
+    uniform weights, not the unbiased :math:`n/(n-1)` form.
+
+    Parameters
+    ----------
+    draws
+        Shape ``(n, d)``.  The draws accumulated over the estimation window.
+
+    Returns
+    -------
+    Array, shape ``(d,)``
+        Per-coordinate population variance
+        :math:`\mathbb{E}[x^2] - \mathbb{E}[x]^2`.
+    """
+    x_average = jnp.mean(draws, axis=0)  # (d,)
+    x_squared_average = jnp.mean(draws**2, axis=0)  # (d,)
+    return x_squared_average - jnp.square(x_average)

--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -63,10 +63,7 @@ from typing import Literal
 import jax
 import jax.numpy as jnp
 
-from blackjax.adaptation.low_rank_adaptation import (
-    _relative_pd_floor,
-    _spd_mean,
-)
+from blackjax.adaptation.low_rank_adaptation import _relative_pd_floor, _spd_mean
 from blackjax.adaptation.mass_matrix import welford_algorithm
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from blackjax.types import Array
@@ -154,6 +151,16 @@ def select_top_eigenvalues_by_informativeness(
         ``mclmc_lrd_adaptation._extract_lrd_from_samples`` :271–275 and
         ``meads_adaptation._lrd_from_accumulated_covariance`` :309–312.
 
+        **Tie-break divergence:** the two modes differ not only in masking
+        but also in sort stability for exact ``|λ−1|`` ties:
+        ``"mask_pad"`` uses ``argsort(-scores)`` (ascending original-index
+        among ties; Fisher consumer convention); ``"raw"`` uses
+        ``argsort(scores)[::-1]`` (descending original-index; both raw-source
+        conventions).  On real ``eigh``/``svd`` spectra bit-exact ties do
+        not occur — even truly degenerate inputs return ulp-broken eigenvalues
+        — so the difference is behaviorally inert on continuous data; the raw
+        path preserves byte-fidelity to its sources nonetheless.
+
     Parameters
     ----------
     eigenvalues
@@ -185,10 +192,11 @@ def select_top_eigenvalues_by_informativeness(
 
     q = eigenvalues.shape[0]
     scores = eigenvalue_informativeness(eigenvalues)
-    # Descending order by informativeness — same idiom in both consumers.
-    order = jnp.argsort(-scores)
 
     if tail_handling == "mask_pad":
+        # argsort(-scores): ascending original-index tie-break — matches the
+        # fisher consumer (low_rank_adaptation._compute_low_rank_metric :468).
+        order = jnp.argsort(-scores)
         actual_rank = min(max_rank, q)  # static: both are Python ints at trace time
         top_order = order[:actual_rank]
         U_out = eigenvectors[:, top_order]  # (d, actual_rank)
@@ -209,6 +217,15 @@ def select_top_eigenvalues_by_informativeness(
         return U_out, lam_out
 
     else:  # "raw"
+        # argsort(scores)[::-1]: descending original-index tie-break — matches
+        # BOTH raw consumers (mclmc_lrd_adaptation._extract_lrd_from_samples :271
+        # and meads_adaptation._lrd_from_accumulated_covariance :309).
+        # This differs from mask_pad's argsort(-scores) tie-break in degenerate
+        # spectra; on real eigh/SVD spectra bit-exact |λ−1| ties never occur
+        # (ulp-broken even for truly degenerate inputs), so the difference is
+        # behaviorally inert on continuous data — but the raw path stays
+        # byte-faithful to its sources.
+        order = jnp.argsort(scores)[::-1]
         top_order = order[:max_rank]
         return eigenvectors[:, top_order], eigenvalues[top_order]
 

--- a/tests/adaptation/test_metric_estimators.py
+++ b/tests/adaptation/test_metric_estimators.py
@@ -1,0 +1,690 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Parity golden tests for blackjax.adaptation.metric_estimators (E-layer).
+
+Each test class follows the RFC R2a pattern: a **frozen inline reference** of
+the original implementation is embedded directly in the test (not imported, to
+prevent any module-level mutation from silencing the golden — see
+worklog/lessons/code-patterns/2026-07-11-monkeypatch-mutation-restore-before-call.md).
+The E-layer function must produce the same result as the inline reference on
+the same structured test inputs.
+
+Test data strategy
+------------------
+- Correlated Gaussian draws with known analytic structure (Σ with off-diagonal
+  correlations, so the eigenbasis is non-trivial).
+- Analytic score gradients for Fisher estimators (for a Gaussian target with
+  mean μ and covariance Σ, ∇ log p(x) = -Σ^{-1}(x - μ)).
+- n > d AND n < d shapes tested for SVD/eigh estimators.
+- max_rank ∈ {0-equivalent (k=1), 1, d//2, d} tested where meaningful.
+  (k=d is tested since it earned its own case in R1's adversarial review.)
+- f32 atol 1e-5 / f64 atol 1e-9.
+- Degenerate-support shapes (n small vs d) are included; parity must hold
+  on the MASKED / raw behavior in those shapes too.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+
+import blackjax.adaptation.mass_matrix as mass_matrix_module
+from blackjax.adaptation.metric_estimators import (
+    draws_singular_value_low_rank,
+    eigenvalue_informativeness,
+    fisher_score_diagonal,
+    fisher_score_low_rank,
+    sample_covariance_eigh_low_rank,
+    sample_variance_diagonal,
+    select_top_eigenvalues_by_informativeness,
+    welford_dense,
+    welford_diagonal,
+)
+from tests.fixtures import BlackJAXTest
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across test classes
+# ---------------------------------------------------------------------------
+
+
+def _make_correlated_draws(key, n, d, rho=0.7, scale=None):
+    """Draws from a correlated Gaussian: Σ = scale * (rho * 11^T + (1-rho) * I).
+
+    When ``scale`` is None, uses ``jnp.ones(d)`` (isotropic up to rho).
+    When ``scale`` is an array of shape ``(d,)``, each coordinate is scaled
+    independently.
+
+    Returns ``(draws, mean, cov)`` where ``mean=0`` and ``cov`` is the true
+    covariance.
+    """
+    if scale is None:
+        scale = jnp.ones(d)
+    # Build correlation matrix
+    corr = rho * jnp.ones((d, d)) + (1.0 - rho) * jnp.eye(d)
+    # Scale to covariance
+    cov = scale[:, None] * corr * scale[None, :]
+    L = jnp.linalg.cholesky(cov)
+    z = jax.random.normal(key, (n, d))
+    draws = z @ L.T  # (n, d)  mean 0
+    return draws, jnp.zeros(d), cov
+
+
+def _analytic_score_grads(draws, cov):
+    """Score gradients for N(0, cov): ∇ log p(x) = -cov^{-1} x."""
+    cov_inv = jnp.linalg.inv(cov)
+    return -(draws @ cov_inv.T)  # (n, d)
+
+
+# ---------------------------------------------------------------------------
+# Frozen inline reference implementations (parity goldens)
+# These are NOT imports — they are frozen copies of the originals so that
+# any change to the source module does not silently alias the golden.
+# ---------------------------------------------------------------------------
+
+
+def _ref_relative_pd_floor(vals):
+    """Frozen copy of low_rank_adaptation._relative_pd_floor (main@532631c1)."""
+    scale = jnp.maximum(jnp.max(jnp.abs(vals)), jnp.finfo(vals.dtype).tiny)
+    return jnp.finfo(vals.dtype).eps * scale
+
+
+def _ref_spd_mean(A, B):
+    """Frozen copy of low_rank_adaptation._spd_mean (main@532631c1)."""
+    vals_b, vecs_b = jnp.linalg.eigh(B)
+    vals_b = jnp.maximum(vals_b, _ref_relative_pd_floor(vals_b))
+    sqrt_b = jnp.sqrt(vals_b)
+    inv_sqrt_b = 1.0 / sqrt_b
+    tmp = vecs_b.T @ A @ vecs_b
+    M = inv_sqrt_b[:, None] * tmp * inv_sqrt_b[None, :]
+    vals_m, vecs_m = jnp.linalg.eigh(M)
+    vals_m = jnp.maximum(vals_m, _ref_relative_pd_floor(vals_m))
+    sqrt_m = jnp.sqrt(vals_m)
+    W = vecs_b @ (sqrt_b[:, None] * vecs_m)
+    return (W * sqrt_m[None, :]) @ W.T
+
+
+def _ref_fisher_score_low_rank(draws, grads, max_rank, gamma, cutoff):
+    """Frozen parity golden for fisher_score_low_rank.
+
+    Adapted from low_rank_adaptation._compute_low_rank_metric (main@532631c1),
+    taking raw draw/grad arrays (all-valid, no buffer masking needed).
+    """
+    orig_dtype = draws.dtype
+    compute_dtype = jnp.float64 if jax.config.jax_enable_x64 else orig_dtype
+    draws = draws.astype(compute_dtype)
+    grads = grads.astype(compute_dtype)
+
+    n, d = draws.shape
+    n_f = float(n)
+
+    mean_x = draws.mean(0)
+    mean_g = grads.mean(0)
+    diff_x = draws - mean_x[None, :]
+    diff_g = grads - mean_g[None, :]
+    var_x = (diff_x**2).sum(0) / n_f
+    var_g = (diff_g**2).sum(0) / n_f
+
+    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
+    sigma = jnp.clip(sigma, 1e-20, 1e20)
+
+    X = diff_x / sigma[None, :]
+    A = diff_g * sigma[None, :]
+
+    _, _, Vt_x = jnp.linalg.svd(X, full_matrices=False)
+    _, _, Vt_a = jnp.linalg.svd(A, full_matrices=False)
+    U_x = Vt_x[:max_rank].T
+    U_a = Vt_a[:max_rank].T
+
+    combined = jnp.concatenate([U_x, U_a], axis=1)
+    Q, _ = jnp.linalg.qr(combined)
+    q = Q.shape[1]
+
+    P_x = Q.T @ X.T
+    P_a = Q.T @ A.T
+
+    C_x = (P_x @ P_x.T) / gamma + jnp.eye(q, dtype=compute_dtype)
+    C_a = (P_a @ P_a.T) / gamma + jnp.eye(q, dtype=compute_dtype)
+
+    Sigma = _ref_spd_mean(C_x, jnp.linalg.inv(C_a))
+
+    vals, vecs = jnp.linalg.eigh(Sigma)
+    vals = jnp.maximum(vals, _ref_relative_pd_floor(vals))
+    U_full = Q @ vecs
+
+    actual_rank = min(max_rank, q)
+    distances = jnp.abs(vals - 1.0)
+    order = jnp.argsort(-distances)[:actual_rank]
+    U_out = U_full[:, order]
+    lam_raw = vals[order]
+    is_informative = (lam_raw < 1.0 / cutoff) | (lam_raw > cutoff)
+    lam_out = jnp.where(is_informative, lam_raw, 1.0)
+
+    if actual_rank < max_rank:
+        pad = max_rank - actual_rank
+        U_out = jnp.concatenate([U_out, jnp.zeros((d, pad))], axis=1)
+        lam_out = jnp.concatenate([lam_out, jnp.ones(pad)])
+
+    return (
+        sigma.astype(orig_dtype),
+        U_out.astype(orig_dtype),
+        lam_out.astype(orig_dtype),
+    )
+
+
+def _ref_draws_singular_value_low_rank(draws, max_rank):
+    """Frozen parity golden for draws_singular_value_low_rank.
+
+    Adapted from mclmc_lrd_adaptation._extract_lrd_from_samples (main@532631c1).
+    """
+    mean = jnp.mean(draws, axis=0)
+    sigma = jnp.std(draws, axis=0)
+    sigma = jnp.where(sigma == 0.0, 1.0, sigma)
+
+    standardised = (draws - mean[None, :]) / sigma[None, :]
+    n = draws.shape[0]
+
+    _, S, Vt = jnp.linalg.svd(standardised, full_matrices=False)
+    V = Vt.T
+    lam = (S**2) / n
+
+    sort_idx = jnp.argsort(jnp.abs(lam - 1.0))[::-1]
+    top_idx = sort_idx[:max_rank]
+
+    lam_k = lam[top_idx]
+    U_k = V[:, top_idx]
+    return sigma, U_k, lam_k
+
+
+def _ref_sample_covariance_eigh_low_rank(m2, count, max_rank):
+    """Frozen parity golden for sample_covariance_eigh_low_rank.
+
+    Adapted from meads_adaptation._lrd_from_accumulated_covariance (main@532631c1).
+    """
+    covariance = m2 / jnp.maximum(count - 1.0, 1.0)
+    variance = jnp.diag(covariance)
+    sigma = jnp.sqrt(jnp.maximum(variance, 0.0))
+    sigma = jnp.where(sigma <= 0.0, 1.0, sigma)
+
+    inv_sigma = 1.0 / sigma
+    correlation = covariance * inv_sigma[:, None] * inv_sigma[None, :]
+
+    lam_all, V = jnp.linalg.eigh(correlation)
+    sort_idx = jnp.argsort(jnp.abs(lam_all - 1.0))[::-1]
+    top_idx = sort_idx[:max_rank]
+    lam = lam_all[top_idx]
+    U = V[:, top_idx]
+    return sigma, U, lam
+
+
+def _ref_fisher_score_diagonal(draws, grads):
+    """Frozen parity golden for fisher_score_diagonal.
+
+    Source: branch b197f1e2, mass_matrix._fisher_diagonal_inverse_mass.
+    """
+    # Bessel-corrected variance via Welford (same as welford_diagonal).
+    n, d = draws.shape
+
+    def _welford_var(xs):
+        wc_init, wc_update, wc_final = mass_matrix_module.welford_algorithm(
+            is_diagonal_matrix=True
+        )
+
+        def scan_fn(state, draw):
+            return wc_update(state, draw), None
+
+        final_state, _ = jax.lax.scan(scan_fn, wc_init(d), xs)
+        cov, _, _ = wc_final(final_state)
+        return cov
+
+    var_x = _welford_var(draws)
+    var_g = _welford_var(grads)
+
+    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
+    sigma = jnp.clip(sigma, 1e-20, 1e20)
+    return sigma**2
+
+
+def _ref_sample_variance_diagonal_mclmc(draws):
+    """Frozen parity golden for sample_variance_diagonal — MCLMC twin.
+
+    Source: mclmc_adaptation.py:341-342 (inline population variance).
+    """
+    x_average = jnp.mean(draws, axis=0)
+    x_squared_average = jnp.mean(draws**2, axis=0)
+    return x_squared_average - jnp.square(x_average)
+
+
+def _ref_sample_variance_diagonal_adjusted(draws):
+    """Frozen parity golden for sample_variance_diagonal — adjusted_mclmc twin.
+
+    Source: adjusted_mclmc_adaptation.py:374-375 (verbatim duplicate).
+    """
+    x_average = jnp.mean(draws, axis=0)
+    x_squared_average = jnp.mean(draws**2, axis=0)
+    return x_squared_average - jnp.square(x_average)
+
+
+# Metric reconstruction helper for visual sanity checks
+def _dense_imm_from_lowrank(sigma, U, lam):
+    """M^{-1} = diag(sigma) (I + U (lam-I) U^T) diag(sigma)."""
+    d = sigma.shape[0]
+    correction = U @ jnp.diag(lam - 1.0) @ U.T
+    return jnp.diag(sigma) @ (jnp.eye(d) + correction) @ jnp.diag(sigma)
+
+
+# ---------------------------------------------------------------------------
+# Test classes
+# ---------------------------------------------------------------------------
+
+
+class EigenvalueInformativenessTest(BlackJAXTest):
+    """Tests for eigenvalue_informativeness."""
+
+    def test_isotropic(self):
+        """All-ones eigenvalues → all-zero informativeness."""
+        lam = jnp.ones(5)
+        inf = eigenvalue_informativeness(lam)
+        np.testing.assert_allclose(inf, jnp.zeros(5), atol=1e-9)
+
+    def test_known_values(self):
+        lam = jnp.array([0.5, 1.0, 2.0, 3.0])
+        expected = jnp.array([0.5, 0.0, 1.0, 2.0])
+        np.testing.assert_allclose(eigenvalue_informativeness(lam), expected, atol=1e-9)
+
+    def test_symmetric_around_one(self):
+        """λ and 2-λ have the same informativeness."""
+        lam = jnp.array([0.3, 1.7])
+        inf = eigenvalue_informativeness(lam)
+        np.testing.assert_allclose(inf[0], inf[1], atol=1e-9)
+
+
+class SelectTopEigenvaluesTest(BlackJAXTest):
+    """Tests for select_top_eigenvalues_by_informativeness."""
+
+    def _make_random_eigenpairs(self, d, q):
+        key = self.next_key()
+        raw = jax.random.normal(key, (d, q))
+        Q, _ = jnp.linalg.qr(raw)  # orthonormal columns
+        lam = jax.random.uniform(self.next_key(), (q,), minval=0.1, maxval=4.0)
+        return Q[:, :q], lam
+
+    def test_mask_pad_selects_top_k_by_informativeness(self):
+        d, q, k = 6, 5, 3
+        V, lam = self._make_random_eigenpairs(d, q)
+        U_out, lam_out = select_top_eigenvalues_by_informativeness(
+            lam, V, k, tail_handling="mask_pad"
+        )
+        self.assertEqual(U_out.shape, (d, k))
+        self.assertEqual(lam_out.shape, (k,))
+
+        # The returned eigenvalues must be the top-k by |λ-1|.
+        expected_order = jnp.argsort(-jnp.abs(lam - 1.0))[:k]
+        expected_lam_raw = lam[expected_order]
+        # After masking, informative ones are preserved.
+        cutoff = 2.0
+        is_inf = (expected_lam_raw < 1.0 / cutoff) | (expected_lam_raw > cutoff)
+        expected_lam = jnp.where(is_inf, expected_lam_raw, 1.0)
+        np.testing.assert_allclose(lam_out, expected_lam, atol=1e-6)
+
+    def test_raw_selects_top_k_no_masking(self):
+        d, q, k = 6, 5, 3
+        V, lam = self._make_random_eigenpairs(d, q)
+        U_out, lam_out = select_top_eigenvalues_by_informativeness(
+            lam, V, k, tail_handling="raw"
+        )
+        self.assertEqual(U_out.shape, (d, k))
+        self.assertEqual(lam_out.shape, (k,))
+
+        expected_order = jnp.argsort(-jnp.abs(lam - 1.0))[:k]
+        np.testing.assert_allclose(lam_out, lam[expected_order], atol=1e-9)
+
+    def test_mask_pad_pads_when_q_lt_max_rank(self):
+        """When fewer eigenvectors than max_rank are available, zero-pad."""
+        d, q, k = 8, 3, 6  # q < k → must pad
+        V, lam = self._make_random_eigenpairs(d, q)
+        U_out, lam_out = select_top_eigenvalues_by_informativeness(
+            lam, V, k, tail_handling="mask_pad"
+        )
+        self.assertEqual(U_out.shape, (d, k))
+        self.assertEqual(lam_out.shape, (k,))
+        # Padded lam entries must be 1.0.
+        np.testing.assert_allclose(lam_out[q:], jnp.ones(k - q), atol=1e-9)
+        # Padded U columns must be zeros.
+        np.testing.assert_allclose(U_out[:, q:], jnp.zeros((d, k - q)), atol=1e-9)
+
+    def test_mask_pad_k_equals_d(self):
+        """k=d: all eigenvectors selected (edge case from R1 adversarial review)."""
+        d = 5
+        V, lam = self._make_random_eigenpairs(d, d)
+        U_out, lam_out = select_top_eigenvalues_by_informativeness(
+            lam, V, d, tail_handling="mask_pad"
+        )
+        self.assertEqual(U_out.shape, (d, d))
+        self.assertEqual(lam_out.shape, (d,))
+
+    def test_invalid_tail_handling_raises(self):
+        with self.assertRaises(ValueError):
+            select_top_eigenvalues_by_informativeness(
+                jnp.ones(3), jnp.eye(3), 2, tail_handling="invalid"
+            )
+
+
+class FisherScoreLowRankParityTest(BlackJAXTest):
+    """Parity goldens for fisher_score_low_rank vs _ref_fisher_score_low_rank."""
+
+    @parameterized.parameters(
+        # (n, d, max_rank, gamma, cutoff, dtype)
+        (50, 10, 3, 1e-5, 2.0, jnp.float32),
+        (50, 10, 1, 1e-5, 2.0, jnp.float32),
+        (50, 10, 5, 1e-5, 2.0, jnp.float32),
+        (50, 10, 10, 1e-5, 2.0, jnp.float32),  # k=d
+        (8, 10, 3, 1e-5, 2.0, jnp.float32),  # n < d
+    )
+    def test_parity_vs_reference(self, n, d, max_rank, gamma, cutoff, dtype):
+        draws_f32, _, cov = _make_correlated_draws(
+            self.next_key(), n, d, rho=0.5, scale=jnp.arange(1, d + 1, dtype=jnp.float32)
+        )
+        grads_f32 = _analytic_score_grads(draws_f32, cov)
+
+        draws = draws_f32.astype(dtype)
+        grads = grads_f32.astype(dtype)
+
+        result = fisher_score_low_rank(draws, grads, max_rank, gamma=gamma, cutoff=cutoff)
+        ref_sigma, ref_U, ref_lam = _ref_fisher_score_low_rank(
+            draws, grads, max_rank, gamma, cutoff
+        )
+
+        atol = 1e-5 if dtype == jnp.float32 else 1e-9
+        np.testing.assert_allclose(result.sigma, ref_sigma, atol=atol, err_msg="sigma")
+        np.testing.assert_allclose(result.lam, ref_lam, atol=atol, err_msg="lam")
+
+        # U is defined up to column sign flips — compare IMM reconstructions.
+        if n >= d:  # well-defined reconstruction
+            M_result = _dense_imm_from_lowrank(result.sigma, result.U, result.lam)
+            M_ref = _dense_imm_from_lowrank(ref_sigma, ref_U, ref_lam)
+            np.testing.assert_allclose(M_result, M_ref, atol=atol * 10, err_msg="dense IMM")
+
+    def test_output_shapes(self):
+        n, d, k = 30, 6, 4
+        draws, _, cov = _make_correlated_draws(self.next_key(), n, d)
+        grads = _analytic_score_grads(draws, cov)
+        result = fisher_score_low_rank(draws, grads, k)
+        self.assertEqual(result.sigma.shape, (d,))
+        self.assertEqual(result.U.shape, (d, k))
+        self.assertEqual(result.lam.shape, (k,))
+
+    def test_sigma_positive(self):
+        n, d, k = 30, 6, 2
+        draws, _, cov = _make_correlated_draws(self.next_key(), n, d)
+        grads = _analytic_score_grads(draws, cov)
+        result = fisher_score_low_rank(draws, grads, k)
+        self.assertTrue(jnp.all(result.sigma > 0).item())
+
+    def test_lam_informative_elements_not_masked(self):
+        """Informative eigenvalues (outside [1/cutoff, cutoff]) are preserved."""
+        n, d, k = 100, 10, 5
+        # Use highly correlated draws to ensure some eigenvalues are far from 1.
+        draws, _, cov = _make_correlated_draws(
+            self.next_key(), n, d, rho=0.9, scale=jnp.linspace(0.5, 3.0, d)
+        )
+        grads = _analytic_score_grads(draws, cov)
+        result = fisher_score_low_rank(draws, grads, k, cutoff=2.0)
+        # All lam values must be >= 0 (not NaN).
+        self.assertTrue(jnp.all(jnp.isfinite(result.lam)).item())
+
+
+class DrawsSingularValueLowRankParityTest(BlackJAXTest):
+    """Parity goldens for draws_singular_value_low_rank vs _ref_draws_svd_lrd."""
+
+    @parameterized.parameters(
+        # (n, d, max_rank)
+        (50, 10, 3),
+        (50, 10, 1),
+        (50, 10, 5),
+        (50, 10, 10),  # k=d  (only works when min(n,d) >= d, i.e. n >= d)
+        (10, 6, 3),   # n > d, k < n
+    )
+    def test_parity_vs_reference(self, n, d, max_rank):
+        k = min(max_rank, min(n, d))  # respect SVD rank constraint
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d, rho=0.6)
+
+        result = draws_singular_value_low_rank(draws, k)
+        ref_sigma, ref_U, ref_lam = _ref_draws_singular_value_low_rank(draws, k)
+
+        np.testing.assert_allclose(result.sigma, ref_sigma, atol=1e-5, err_msg="sigma")
+        np.testing.assert_allclose(result.lam, ref_lam, atol=1e-5, err_msg="lam")
+
+        # U defined up to column sign — compare IMM reconstructions.
+        M_result = _dense_imm_from_lowrank(result.sigma, result.U, result.lam)
+        M_ref = _dense_imm_from_lowrank(ref_sigma, ref_U, ref_lam)
+        np.testing.assert_allclose(M_result, M_ref, atol=1e-4, err_msg="dense IMM")
+
+    def test_n_less_than_d(self):
+        """n < d: only min(n,d)=n eigenvalues available from SVD."""
+        n, d, k = 4, 10, 4  # k = n = min(n,d)
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = draws_singular_value_low_rank(draws, k)
+        # Shape must be (d, k) for U and (k,) for lam.
+        self.assertEqual(result.U.shape, (d, k))
+        self.assertEqual(result.lam.shape, (k,))
+
+    def test_no_regularisation_or_masking(self):
+        """Raw lam values: eigenvalues inside [1/2, 2] are NOT masked to 1."""
+        n, d, k = 100, 5, 5
+        # Draws from near-isotropic Gaussian — most eigenvalues near 1.
+        draws = jax.random.normal(self.next_key(), (n, d))
+        result = draws_singular_value_low_rank(draws, k)
+        ref_sigma, ref_U, ref_lam = _ref_draws_singular_value_low_rank(draws, k)
+        # lam values that are near 1 in reference must also be near 1 in result
+        # (not masked — raw preservation).
+        np.testing.assert_allclose(result.lam, ref_lam, atol=1e-5)
+
+
+class SampleCovarianceEighLowRankParityTest(BlackJAXTest):
+    """Parity goldens for sample_covariance_eigh_low_rank vs reference."""
+
+    def _make_m2(self, draws):
+        """Compute Chan-Welford M2 from draws in one batch."""
+        mean = jnp.mean(draws, axis=0)
+        diff = draws - mean[None, :]
+        return diff.T @ diff, draws.shape[0]
+
+    @parameterized.parameters(
+        # (n, d, max_rank)
+        (100, 10, 3),
+        (100, 10, 1),
+        (100, 10, 5),
+        (100, 10, 10),  # k=d
+        (8, 10, 3),    # n < d: rank-deficient correlation matrix
+    )
+    def test_parity_vs_reference(self, n, d, max_rank):
+        k = min(max_rank, d)
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d, rho=0.6)
+        m2, count = self._make_m2(draws)
+
+        result = sample_covariance_eigh_low_rank(m2, count, k)
+        ref_sigma, ref_U, ref_lam = _ref_sample_covariance_eigh_low_rank(m2, count, k)
+
+        np.testing.assert_allclose(result.sigma, ref_sigma, atol=1e-5, err_msg="sigma")
+        np.testing.assert_allclose(result.lam, ref_lam, atol=1e-5, err_msg="lam")
+
+        # U defined up to column sign — compare IMM reconstructions.
+        M_result = _dense_imm_from_lowrank(result.sigma, result.U, result.lam)
+        M_ref = _dense_imm_from_lowrank(ref_sigma, ref_U, ref_lam)
+        np.testing.assert_allclose(M_result, M_ref, atol=1e-4, err_msg="dense IMM")
+
+    def test_count_1_degenerate_support(self):
+        """count=1: Bessel denominator clamped to 1 (no division by zero)."""
+        d, k = 5, 2
+        # Single draw → m2 = 0 (mean subtraction gives zero).
+        m2 = jnp.zeros((d, d))
+        count = 1
+        result = sample_covariance_eigh_low_rank(m2, count, k)
+        # sigma must be 1.0 everywhere (zero variance → fallback to 1.0).
+        np.testing.assert_allclose(result.sigma, jnp.ones(d), atol=1e-6)
+
+
+class WelfordDiagonalParityTest(BlackJAXTest):
+    """Parity goldens for welford_diagonal vs np.var(..., ddof=1)."""
+
+    @parameterized.parameters(
+        (50, 5),
+        (3, 4),   # small n
+        (200, 2),
+    )
+    def test_parity_vs_numpy_var(self, n, d):
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = welford_diagonal(draws)
+        expected = jnp.array(np.var(np.array(draws), axis=0, ddof=1))
+        np.testing.assert_allclose(result, expected, atol=1e-5)
+
+    def test_output_shape(self):
+        n, d = 30, 7
+        draws = jax.random.normal(self.next_key(), (n, d))
+        self.assertEqual(welford_diagonal(draws).shape, (d,))
+
+
+class WelfordDenseParityTest(BlackJAXTest):
+    """Parity goldens for welford_dense vs np.cov."""
+
+    @parameterized.parameters(
+        (50, 5),
+        (4, 3),
+    )
+    def test_parity_vs_numpy_cov(self, n, d):
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = welford_dense(draws)
+        expected = jnp.array(np.cov(np.array(draws).T))  # np.cov uses ddof=1
+        np.testing.assert_allclose(result, expected, atol=1e-5)
+
+    def test_output_shape(self):
+        n, d = 30, 7
+        draws = jax.random.normal(self.next_key(), (n, d))
+        self.assertEqual(welford_dense(draws).shape, (d, d))
+
+
+class FisherScoreDiagonalParityTest(BlackJAXTest):
+    """Parity goldens for fisher_score_diagonal vs branch b197f1e2 reference."""
+
+    @parameterized.parameters(
+        # (n, d)
+        (50, 5),
+        (4, 5),   # n < d
+        (200, 3),
+    )
+    def test_parity_vs_reference(self, n, d):
+        draws, _, cov = _make_correlated_draws(
+            self.next_key(), n, d, scale=jnp.linspace(0.3, 2.0, d)
+        )
+        grads = _analytic_score_grads(draws, cov)
+
+        result = fisher_score_diagonal(draws, grads)
+        ref = _ref_fisher_score_diagonal(draws, grads)
+        np.testing.assert_allclose(result, ref, atol=1e-5)
+
+    def test_output_shape(self):
+        n, d = 30, 6
+        draws = jax.random.normal(self.next_key(), (n, d))
+        grads = jax.random.normal(self.next_key(), (n, d))
+        self.assertEqual(fisher_score_diagonal(draws, grads).shape, (d,))
+
+    def test_positive(self):
+        n, d = 40, 4
+        draws, _, cov = _make_correlated_draws(self.next_key(), n, d)
+        grads = _analytic_score_grads(draws, cov)
+        result = fisher_score_diagonal(draws, grads)
+        self.assertTrue(jnp.all(result > 0).item())
+
+    def test_consistency_with_fisher_score_low_rank_sigma_sq(self):
+        """fisher_score_diagonal(draws, grads) ≈ fisher_score_low_rank sigma^2.
+
+        Both estimators use the same diagonal scale formula; the diagonal-only
+        version omits the low-rank correction (U=0 effective).  The sigma^2
+        output of the two must agree (up to f32 atol) because both compute:
+            sigma = (Var[x] / Var[grad])^{0.25} clipped to [1e-20, 1e20]
+            IMM_diag = sigma^2
+        with the same Welford variance.
+        """
+        n, d, k = 80, 6, 3
+        draws, _, cov = _make_correlated_draws(self.next_key(), n, d)
+        grads = _analytic_score_grads(draws, cov)
+
+        diag_result = fisher_score_diagonal(draws, grads)
+        lr_result = fisher_score_low_rank(draws, grads, k)
+
+        # sigma^2 from low-rank matches the diagonal estimator.
+        np.testing.assert_allclose(
+            diag_result, lr_result.sigma**2, atol=1e-5,
+            err_msg="diagonal fisher sigma^2 must match low-rank sigma^2"
+        )
+
+
+class SampleVarianceDiagonalParityTest(BlackJAXTest):
+    """Parity goldens for sample_variance_diagonal vs both MCLMC inline twins."""
+
+    @parameterized.parameters(
+        # (n, d)
+        (50, 5),
+        (3, 4),   # n < d
+        (100, 8),
+    )
+    def test_parity_vs_mclmc_twin(self, n, d):
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = sample_variance_diagonal(draws)
+        ref = _ref_sample_variance_diagonal_mclmc(draws)
+        np.testing.assert_allclose(result, ref, atol=1e-6,
+                                   err_msg="parity vs mclmc_adaptation twin")
+
+    @parameterized.parameters(
+        (50, 5),
+        (3, 4),
+        (100, 8),
+    )
+    def test_parity_vs_adjusted_mclmc_twin(self, n, d):
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = sample_variance_diagonal(draws)
+        ref = _ref_sample_variance_diagonal_adjusted(draws)
+        np.testing.assert_allclose(result, ref, atol=1e-6,
+                                   err_msg="parity vs adjusted_mclmc_adaptation twin")
+
+    def test_population_not_bessel(self):
+        """sample_variance_diagonal uses population variance (n denominator)."""
+        n, d = 10, 3
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = sample_variance_diagonal(draws)
+        pop_var = jnp.mean(draws**2, axis=0) - jnp.mean(draws, axis=0) ** 2
+        bessel_var = jnp.array(np.var(np.array(draws), axis=0, ddof=1))
+        # Should match population variance, not Bessel-corrected.
+        np.testing.assert_allclose(result, pop_var, atol=1e-6)
+        # Must differ from Bessel for n>1.
+        self.assertFalse(
+            jnp.allclose(result, bessel_var, atol=1e-6).item(),
+            "Expected population variance to differ from Bessel-corrected"
+        )
+
+    def test_non_negative(self):
+        """Variance must be non-negative for any input."""
+        n, d = 20, 4
+        draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
+        result = sample_variance_diagonal(draws)
+        self.assertTrue(jnp.all(result >= 0.0).item())
+
+    def test_output_shape(self):
+        n, d = 30, 7
+        draws = jax.random.normal(self.next_key(), (n, d))
+        self.assertEqual(sample_variance_diagonal(draws).shape, (d,))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/adaptation/test_metric_estimators.py
+++ b/tests/adaptation/test_metric_estimators.py
@@ -52,7 +52,6 @@ from blackjax.adaptation.metric_estimators import (
 )
 from tests.fixtures import BlackJAXTest
 
-
 # ---------------------------------------------------------------------------
 # Helpers shared across test classes
 # ---------------------------------------------------------------------------
@@ -379,6 +378,53 @@ class SelectTopEigenvaluesTest(BlackJAXTest):
                 jnp.ones(3), jnp.eye(3), 2, tail_handling="invalid"
             )
 
+    def test_raw_tie_straddling_exact_selection(self):
+        """Exact-tie case: raw mode must match its source consumers' convention.
+
+        lam = [0.4, 1.6, 2.5] → |λ-1| = [0.6, 0.6, 1.5].
+        max_rank=2: index 2 (score 1.5) is unambiguously first; indices 0 and 1
+        are tied at 0.6.  The raw sources (mclmc_lrd/_meads) use
+        argsort(scores)[::-1], which breaks ties by descending original index,
+        selecting {2.5, 1.6} (indices [2, 1]).  mask_pad uses argsort(-scores),
+        breaking ties by ascending index → {2.5, 0.4} (indices [2, 0]).
+        Assert selected SETS (not order) to be sign/ordering-agnostic, but also
+        check against the raw-source convention explicitly.
+        """
+        lam = jnp.array([0.4, 1.6, 2.5])
+        d = 3
+        V = jnp.eye(d)  # trivial eigenvectors: each column is a basis vector
+
+        U_raw, lam_raw = select_top_eigenvalues_by_informativeness(
+            lam, V, max_rank=2, tail_handling="raw"
+        )
+        self.assertEqual(U_raw.shape, (d, 2))
+        self.assertEqual(lam_raw.shape, (2,))
+
+        # The raw sources select {2.5, 1.6} — descending-index tie-break.
+        # Sort descending to get a canonical order for comparison.
+        lam_raw_sorted = jnp.sort(lam_raw)[::-1]
+        np.testing.assert_allclose(
+            lam_raw_sorted,
+            jnp.array([2.5, 1.6]),
+            atol=1e-5,
+            err_msg="raw mode must select {2.5, 1.6}",
+        )
+
+        # mask_pad gets the other convention ({2.5, 0.4}) via ascending-index
+        # tie-break: argsort(-scores) selects index 0 (0.4) over index 1 (1.6)
+        # when both have tied |λ-1|=0.6.  cutoff=2.0: 0.4 < 0.5 and 2.5 > 2.0
+        # are both informative, so the values are not masked.
+        U_mp, lam_mp = select_top_eigenvalues_by_informativeness(
+            lam, V, max_rank=2, tail_handling="mask_pad", cutoff=2.0
+        )
+        lam_mp_sorted = jnp.sort(lam_mp)[::-1]
+        np.testing.assert_allclose(
+            lam_mp_sorted,
+            jnp.array([2.5, 0.4]),
+            atol=1e-5,
+            err_msg="mask_pad must select {2.5, 0.4}",
+        )
+
 
 class FisherScoreLowRankParityTest(BlackJAXTest):
     """Parity goldens for fisher_score_low_rank vs _ref_fisher_score_low_rank."""
@@ -393,14 +439,20 @@ class FisherScoreLowRankParityTest(BlackJAXTest):
     )
     def test_parity_vs_reference(self, n, d, max_rank, gamma, cutoff, dtype):
         draws_f32, _, cov = _make_correlated_draws(
-            self.next_key(), n, d, rho=0.5, scale=jnp.arange(1, d + 1, dtype=jnp.float32)
+            self.next_key(),
+            n,
+            d,
+            rho=0.5,
+            scale=jnp.arange(1, d + 1, dtype=jnp.float32),
         )
         grads_f32 = _analytic_score_grads(draws_f32, cov)
 
         draws = draws_f32.astype(dtype)
         grads = grads_f32.astype(dtype)
 
-        result = fisher_score_low_rank(draws, grads, max_rank, gamma=gamma, cutoff=cutoff)
+        result = fisher_score_low_rank(
+            draws, grads, max_rank, gamma=gamma, cutoff=cutoff
+        )
         ref_sigma, ref_U, ref_lam = _ref_fisher_score_low_rank(
             draws, grads, max_rank, gamma, cutoff
         )
@@ -413,7 +465,9 @@ class FisherScoreLowRankParityTest(BlackJAXTest):
         if n >= d:  # well-defined reconstruction
             M_result = _dense_imm_from_lowrank(result.sigma, result.U, result.lam)
             M_ref = _dense_imm_from_lowrank(ref_sigma, ref_U, ref_lam)
-            np.testing.assert_allclose(M_result, M_ref, atol=atol * 10, err_msg="dense IMM")
+            np.testing.assert_allclose(
+                M_result, M_ref, atol=atol * 10, err_msg="dense IMM"
+            )
 
     def test_output_shapes(self):
         n, d, k = 30, 6, 4
@@ -453,7 +507,7 @@ class DrawsSingularValueLowRankParityTest(BlackJAXTest):
         (50, 10, 1),
         (50, 10, 5),
         (50, 10, 10),  # k=d  (only works when min(n,d) >= d, i.e. n >= d)
-        (10, 6, 3),   # n > d, k < n
+        (10, 6, 3),  # n > d, k < n
     )
     def test_parity_vs_reference(self, n, d, max_rank):
         k = min(max_rank, min(n, d))  # respect SVD rank constraint
@@ -506,7 +560,7 @@ class SampleCovarianceEighLowRankParityTest(BlackJAXTest):
         (100, 10, 1),
         (100, 10, 5),
         (100, 10, 10),  # k=d
-        (8, 10, 3),    # n < d: rank-deficient correlation matrix
+        (8, 10, 3),  # n < d: rank-deficient correlation matrix
     )
     def test_parity_vs_reference(self, n, d, max_rank):
         k = min(max_rank, d)
@@ -540,7 +594,7 @@ class WelfordDiagonalParityTest(BlackJAXTest):
 
     @parameterized.parameters(
         (50, 5),
-        (3, 4),   # small n
+        (3, 4),  # small n
         (200, 2),
     )
     def test_parity_vs_numpy_var(self, n, d):
@@ -580,7 +634,7 @@ class FisherScoreDiagonalParityTest(BlackJAXTest):
     @parameterized.parameters(
         # (n, d)
         (50, 5),
-        (4, 5),   # n < d
+        (4, 5),  # n < d
         (200, 3),
     )
     def test_parity_vs_reference(self, n, d):
@@ -625,8 +679,10 @@ class FisherScoreDiagonalParityTest(BlackJAXTest):
 
         # sigma^2 from low-rank matches the diagonal estimator.
         np.testing.assert_allclose(
-            diag_result, lr_result.sigma**2, atol=1e-5,
-            err_msg="diagonal fisher sigma^2 must match low-rank sigma^2"
+            diag_result,
+            lr_result.sigma**2,
+            atol=1e-5,
+            err_msg="diagonal fisher sigma^2 must match low-rank sigma^2",
         )
 
 
@@ -636,15 +692,16 @@ class SampleVarianceDiagonalParityTest(BlackJAXTest):
     @parameterized.parameters(
         # (n, d)
         (50, 5),
-        (3, 4),   # n < d
+        (3, 4),  # n < d
         (100, 8),
     )
     def test_parity_vs_mclmc_twin(self, n, d):
         draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
         result = sample_variance_diagonal(draws)
         ref = _ref_sample_variance_diagonal_mclmc(draws)
-        np.testing.assert_allclose(result, ref, atol=1e-6,
-                                   err_msg="parity vs mclmc_adaptation twin")
+        np.testing.assert_allclose(
+            result, ref, atol=1e-6, err_msg="parity vs mclmc_adaptation twin"
+        )
 
     @parameterized.parameters(
         (50, 5),
@@ -655,8 +712,9 @@ class SampleVarianceDiagonalParityTest(BlackJAXTest):
         draws, _, _ = _make_correlated_draws(self.next_key(), n, d)
         result = sample_variance_diagonal(draws)
         ref = _ref_sample_variance_diagonal_adjusted(draws)
-        np.testing.assert_allclose(result, ref, atol=1e-6,
-                                   err_msg="parity vs adjusted_mclmc_adaptation twin")
+        np.testing.assert_allclose(
+            result, ref, atol=1e-6, err_msg="parity vs adjusted_mclmc_adaptation twin"
+        )
 
     def test_population_not_bessel(self):
         """sample_variance_diagonal uses population variance (n denominator)."""
@@ -670,7 +728,7 @@ class SampleVarianceDiagonalParityTest(BlackJAXTest):
         # Must differ from Bessel for n>1.
         self.assertFalse(
             jnp.allclose(result, bessel_var, atol=1e-6).item(),
-            "Expected population variance to differ from Bessel-corrected"
+            "Expected population variance to differ from Bessel-corrected",
         )
 
     def test_non_negative(self):


### PR DESCRIPTION
## Problem

Eight estimator routines and five independent centered-second-moment implementations had grown across the adaptation modules (`low_rank_adaptation`, `mclmc_lrd_adaptation`, `meads_adaptation`, `mass_matrix`, `mclmc_adaptation`, `adjusted_mclmc_adaptation`) with no shared call surface. There was no single place to import a diagonal or low-rank metric estimator; every consumer duplicated the math independently.

## Change

New module `blackjax.adaptation.metric_estimators` with 9 pure array-in estimator and utility functions, extracted from their existing in-tree implementations:

| Function | Source |
|---|---|
| `fisher_score_low_rank` | `low_rank_adaptation._compute_low_rank_metric` + `_spd_mean` |
| `draws_singular_value_low_rank` | `mclmc_lrd_adaptation._extract_lrd_from_samples` |
| `sample_covariance_eigh_low_rank` | `meads_adaptation._lrd_from_accumulated_covariance` |
| `welford_diagonal` / `welford_dense` | thin scan-wrappers over `mass_matrix.welford_algorithm` |
| `fisher_score_diagonal` | branch `b197f1e2` (dormant; wiring stays dormant) |
| `sample_variance_diagonal` | `mclmc_adaptation` / `adjusted_mclmc_adaptation` (verbatim duplicate) |
| `eigenvalue_informativeness` | shared idiom across all three LR consumers |
| `select_top_eigenvalues_by_informativeness` | shared idiom, with explicit `tail_handling` parameter exposing the masking/padding divergence between the fisher and SVD/eigh consumers |

**Additive only:** zero changes to any existing module. All existing code continues to call its own in-place implementation unchanged. Consumer migration is deliberately deferred to a follow-up.

**No top-level registration:** functions are importable from `blackjax.adaptation.metric_estimators` but are not added to `blackjax.__init__` in this PR.

## Fidelity

52 golden parity tests against frozen copies of the original implementations (f32 atol 1e-5 / f64 atol 1e-9), covering:

- `n > d`, `n < d`, `k = 1`, `k = d//2`, `k = d` shapes
- Degenerate-support cases (`count = 1` for Welford/Chan-Welford paths)
- Population-variance vs Bessel-corrected discriminators
- An exact-tie selection case (`lam = [0.4, 1.6, 2.5]`, `max_rank = 2`) that catches the tie-break convention divergence between the fisher consumer (`argsort(-scores)`) and the SVD/eigh consumers (`argsort(scores)[::-1]`)

Each parity golden is a frozen inline copy of the source implementation (not an import), so changes to the originals cannot silently alias the test.

Full suite: **1419 passed / 1 pre-existing skip**, zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt9Qcy31ieBEAaesAbp5Bx