### PR TITLE
Docs: GPU-scale validation notes for ChEES mass_matrix_estimation and MEADS-LRD

### DIFF
--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -725,6 +725,18 @@ def chees_adaptation(
         of it. Cold or dispersed initialization on hard geometry is a separate
         warmup-robustness limitation, out of scope for this feature.
 
+        GPU-scale validation (2× independent runs, ensembles up to 5000 chains): the
+        ``"diagonal"`` metric with the trajectory-length floor additionally makes the
+        adaptation robust to *dispersed* initializations — e.g. per-chain uniform box
+        inits on the unconstrained space, which catastrophically break identity-metric
+        ChEES on scale-separated targets (dispersion inflates the cross-chain jump-distance
+        criterion, driving the adapted trajectory length down; the floor's √λ_max term
+        grows with ensemble dispersion and self-corrects). A dispersed initialization is
+        also what gives R̂ its diagnostic power: initializing all chains at a single point
+        (e.g. the origin) can produce clean R̂ that is structurally blind to same-basin
+        non-equilibrium — prefer dispersed inits and treat single-point-init R̂ with
+        caution.
+
         Engagement gate: before the pooled accumulator (effective sample
         size ``num_chains * window_steps``) exceeds ``max(64, 2*sqrt(num_dim))``
         -- a modest floor chosen because a per-dimension variance estimate,

--- a/blackjax/adaptation/meads_adaptation.py
+++ b/blackjax/adaptation/meads_adaptation.py
@@ -490,6 +490,15 @@ def meads_adaptation(
         disables accumulation entirely (falls back to the purely diagonal
         momentum metric throughout the run).
 
+        At GPU scale (independent re-validation, num_chains up to 1024 on a
+        d≈390 hierarchical target): the low-rank metric's de-biasing reproduces
+        (num_chains ≥ 256 with adequate warmup — cutting warmup at high
+        num_chains under-accumulates the metric and re-introduces bias via
+        step-size collapse) and holds as num_chains grows, but residual mean-error
+        stabilizes slightly above strict certification thresholds; treat the
+        low-rank metric as a robust improvement over the diagonal rather than a
+        guarantee of unbiased means on such targets.
+
     Returns
     -------
     A function that returns the last cross-chain state, a sampling kernel with the


### PR DESCRIPTION
## What

Documentation-only (21 added docstring lines, no behavior changes): folds the GPU-scale validation findings for the two recent ensemble-adaptation features into their docstrings.

1. **`chees_adaptation` / `mass_matrix_estimation`** — adds the GPU-scale re-validation result (2 independent runs, ensembles to 5000 chains): the diagonal metric + trajectory-length floor makes the adaptation **robust to dispersed initializations** (per-chain box inits that catastrophically break identity-metric ChEES on scale-separated targets — dispersion inflates the cross-chain jump-distance criterion and collapses the adapted trajectory; the floor's √λ_max term grows with dispersion and self-corrects). Also adds the diagnostics caution: single-point inits can produce clean R̂ that is structurally blind to same-basin non-equilibrium — prefer dispersed inits.

2. **`meads_adaptation` / `low_rank_rank`** — scopes the high-dimensional claim per GPU re-validation (num_chains to 1024, d≈390): de-biasing reproduces at `num_chains ≥ 256` **with adequate warmup** (cutting warmup at high num_chains under-accumulates the metric and re-introduces bias via step-size collapse) and holds as the ensemble grows, but residual mean-error stabilizes slightly above strict certification thresholds — a robust improvement over the diagonal, not a guarantee of unbiased means.

## Why

Both features shipped with claims validated at CPU scale (nc≤32 ChEES / nc≤256 MEADS). The GPU campaign (two independent statistician arms, cross-examined; full record in the project worklog) strengthened one claim (dispersed-init robustness — a new property, mechanism-predicted then confirmed at nc=5000) and softened one (the low-rank de-bias does not reach strict certification on the hardest target). Docstrings should carry both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
