### PR TITLE
Consolidate the ChEES covariance accumulator onto the moment-buffer layer

### DIFF
--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -919,6 +919,12 @@ def chees_adaptation(
         init_states = batch_init(positions)
         init_adaptation_state = init(init_random_arg, step_size)
         init_mm_accum = wc_init(num_dim) if estimate_mass_matrix else None
+        # Full-covariance moment block for the trajectory-length floor's
+        # lambda_max estimate: accumulated over the SAME late-warmup window,
+        # from the SAME per-step ensemble batch, as the diagonal mass-matrix
+        # Welford accumulator (mm_accum) -- but tracking the full
+        # num_dim x num_dim second moment, since the floor needs the
+        # ensemble's cross-dimension structure, not just per-dimension scale.
         init_cov_accum = (
             MomentBlock(
                 count=jnp.zeros(()),

--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -12,6 +12,7 @@ import blackjax.mcmc.dynamic_hmc as dynamic_hmc
 import blackjax.optimizers.dual_averaging as dual_averaging
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
 from blackjax.adaptation.mass_matrix import welford_algorithm
+from blackjax.adaptation.metric_buffers import MomentBlock, cgl_update_batch
 from blackjax.base import AdaptationAlgorithm
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 from blackjax.util import pytree_size
@@ -126,55 +127,6 @@ _LENGTH_FLOOR_FINAL_POWER_ITERATIONS = 20
 _LENGTH_FLOOR_LAMBDA_EPS = 1e-6
 
 
-class _ChEESCovAccumulatorState(NamedTuple):
-    """Running Chan/Welford full covariance accumulator for the slow-
-    direction trajectory-length floor's ``lambda_max`` estimate.
-
-    Mirrors :class:`~blackjax.adaptation.metric_buffers.MomentBlock` (identical
-    mean/M2/count recurrence) -- mirrored here rather than imported, to keep
-    this feature's diff self-contained to ``chees_adaptation.py``
-    (``meads_adaptation.py`` is out of scope for this change). Accumulated
-    over the SAME late-warmup window, from the SAME per-step ensemble batch,
-    as the diagonal mass-matrix Welford accumulator (``mm_accum``) -- but
-    tracks the full ``num_dim x num_dim`` second moment (not just the
-    diagonal), since the floor needs the ensemble's cross-dimension
-    structure, not just its per-dimension scale.
-    """
-
-    mean: Array
-    m2: Array
-    count: Array
-
-
-def _cov_accumulator_init(num_dim: int) -> _ChEESCovAccumulatorState:
-    return _ChEESCovAccumulatorState(
-        mean=jnp.zeros((num_dim,)),
-        m2=jnp.zeros((num_dim, num_dim)),
-        count=jnp.zeros(()),
-    )
-
-
-def _cov_accumulator_update(
-    acc: _ChEESCovAccumulatorState, batch: Array
-) -> _ChEESCovAccumulatorState:
-    """Merge a batch of samples, shape ``(n_b, num_dim)`` (one step's
-    ensemble of ``num_chains`` positions), into the running accumulator via
-    Chan et al.'s parallel/batch generalization of Welford's algorithm --
-    the same recurrence :func:`~blackjax.adaptation.metric_buffers.cgl_update_batch` uses.
-    """
-    mean_a, m2_a, n_a = acc
-    n_b = batch.shape[0]
-    mean_b = jnp.mean(batch, axis=0)
-    centered_b = batch - mean_b[None, :]
-    m2_b = centered_b.T @ centered_b
-
-    delta = mean_b - mean_a
-    n_ab = n_a + n_b
-    mean_ab = mean_a + delta * (n_b / n_ab)
-    m2_ab = m2_a + m2_b + jnp.outer(delta, delta) * (n_a * n_b / n_ab)
-    return _ChEESCovAccumulatorState(mean=mean_ab, m2=m2_ab, count=n_ab)
-
-
 class _ChEESEigState(NamedTuple):
     """Warm-startable top-eigenvector/eigenvalue estimate of the WHITENED
     ensemble covariance (``D^{-1/2} C_hat D^{-1/2}``, ``D`` = the currently
@@ -215,7 +167,7 @@ def _power_iteration_lambda_max(
 
 
 def _recompute_eig_state(
-    cov_accum: _ChEESCovAccumulatorState,
+    cov_accum: MomentBlock,
     inverse_mass_matrix: Array,
     eig_state: _ChEESEigState,
     num_iterations: int = _LENGTH_FLOOR_POWER_ITERATIONS,
@@ -939,7 +891,7 @@ def chees_adaptation(
                 # implies estimate_mass_matrix (see its derivation above).
                 new_cov_accum = jax.lax.cond(
                     in_window,
-                    lambda acc: _cov_accumulator_update(acc, flat_positions),
+                    lambda acc: cgl_update_batch(acc, flat_positions),
                     lambda acc: acc,
                     cov_accum,
                 )
@@ -967,7 +919,15 @@ def chees_adaptation(
         init_states = batch_init(positions)
         init_adaptation_state = init(init_random_arg, step_size)
         init_mm_accum = wc_init(num_dim) if estimate_mass_matrix else None
-        init_cov_accum = _cov_accumulator_init(num_dim) if enable_length_floor else None
+        init_cov_accum = (
+            MomentBlock(
+                count=jnp.zeros(()),
+                mean=jnp.zeros((num_dim,)),
+                m2=jnp.zeros((num_dim, num_dim)),
+            )
+            if enable_length_floor
+            else None
+        )
         init_eig_state = _eig_state_init(num_dim) if enable_length_floor else None
 
         keys_step = jax.random.split(rng_key, num_steps)

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -11,8 +11,6 @@ from blackjax.adaptation.chees_adaptation import (
     _LENGTH_FLOOR_POWER_ITERATIONS,
     CHEES_LENGTH_FLOOR_FACTOR,
     _apply_length_floor,
-    _cov_accumulator_init,
-    _cov_accumulator_update,
     _diagonal_mass_matrix_or_fallback,
     _eig_state_init,
     _mass_matrix_engagement_threshold,
@@ -21,6 +19,7 @@ from blackjax.adaptation.chees_adaptation import (
 )
 from blackjax.adaptation.chees_adaptation import base as chees_base
 from blackjax.adaptation.mass_matrix import WelfordAlgorithmState, welford_algorithm
+from blackjax.adaptation.metric_buffers import MomentBlock, cgl_update_batch
 from blackjax.diagnostics import effective_sample_size
 from blackjax.util import run_inference_algorithm
 
@@ -456,12 +455,10 @@ def test_length_floor_accumulator_and_power_iteration_recover_planted_eigenvalue
     key = jax.random.key(0)
     samples = jax.random.multivariate_normal(key, jnp.zeros(d), C, shape=(20_000,))
 
-    acc = _cov_accumulator_init(d)
+    acc = MomentBlock(count=jnp.zeros(()), mean=jnp.zeros((d,)), m2=jnp.zeros((d, d)))
     batch_size = 200
     for i in range(samples.shape[0] // batch_size):
-        acc = _cov_accumulator_update(
-            acc, samples[i * batch_size : (i + 1) * batch_size]
-        )
+        acc = cgl_update_batch(acc, samples[i * batch_size : (i + 1) * batch_size])
     # The accumulator must reproduce the naive batch covariance (same check
     # as meads_adaptation's test_accumulator_matches_naive_batch_covariance).
     naive_cov = jnp.cov(samples, rowvar=False)


### PR DESCRIPTION
## Change

`chees_adaptation.py` carried its own copy of the batched Chan–Golub–LeVeque covariance update (`_ChEESCovAccumulatorState` + `_cov_accumulator_init/_update`), used by the trajectory-length floor's `lambda_max` estimate. This replaces it with the shared `MomentBlock` / `cgl_update_batch` from `blackjax.adaptation.metric_buffers` (introduced in #981; the MEADS consumer migrated in #982). Net −43 lines; this removes the last duplicate CGL implementation in the library.

## Behavior-identical

- The deleted update body is character-identical arithmetic to the frozen pre-refactor reference in `tests/adaptation/test_metric_buffers.py`, which `EnsembleMeadsParityX64Test` pins bit-exact against `cgl_update_batch` under x64.
- The eigenvalue consumer (`_recompute_eig_state`) reads the accumulator fields by name (`.m2`, `.count`) and is unchanged.
- The length-floor tests (planted-eigenvalue recovery against an analytic value, naive-covariance parity) pass unmodified apart from the import move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)