### PR TITLE
Add a Fisher-divergence diagonal estimator option to window adaptation

### DIFF
--- a/blackjax/adaptation/mass_matrix.py
+++ b/blackjax/adaptation/mass_matrix.py
@@ -94,9 +94,13 @@ class FisherMassMatrixAdaptationState(NamedTuple):
     Notes
     -----
     The Fisher-diagonal IMM is ``sqrt(Var[x] / Var[∇ log p])`` per coordinate
-    (see :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal`).
+    (see
+    :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal_from_moments`).
     This state type accumulates the moments needed to compute those per-window
-    variances without storing raw draw arrays.
+    variances without storing raw draw arrays.  The IMM computation is
+    deliberately NOT performed inside ``mass_matrix_adaptation``'s ``final()``
+    — it is composed by the consumer (:func:`~blackjax.adaptation.window_adaptation.base`)
+    to avoid a circular import between this module and ``metric_estimators``.
     """
 
     inverse_mass_matrix: Array  # (d,)
@@ -290,50 +294,39 @@ def mass_matrix_adaptation(
     ) -> MassMatrixAdaptationState | FisherMassMatrixAdaptationState:
         """Final iteration of the mass matrix adaptation.
 
-        Computes the inverse mass matrix from the current window's accumulated
-        statistics, then resets the accumulator for the next window.
+        For the Welford path, computes the regularised inverse mass matrix
+        from the current window's accumulated statistics, then resets the
+        accumulator for the next window.
 
-        **Welford path** (default): the IMM is regularized as a convex
-        combination of this window's empirical covariance (weight:
-        ``count / denom``), the previous window's IMM (weight:
-        ``imm_shrinkage_to_previous / denom``), and a small identity matrix
-        (weight: ``5 / denom``), where ``denom = count + 5 +
-        imm_shrinkage_to_previous``.  When ``imm_shrinkage_to_previous=0.0``
-        (default) this reduces to the standard Stan formula.
+        For the Fisher path, resets the :class:`_FisherMomentBlock` accumulator
+        for the next window and passes the previous window's IMM through
+        unchanged.  **The caller is responsible for computing the new IMM**
+        from the block's accumulated moments before calling ``final()`` — the
+        from-moments entry point is
+        :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal_from_moments`.
+        This separation avoids a circular import
+        (``metric_estimators`` imports ``welford_algorithm`` from this module,
+        so this module must not import from ``metric_estimators``).
+        :func:`~blackjax.adaptation.window_adaptation.base` composes the
+        estimator call in its ``slow_final`` closure for the Fisher path.
 
-        **Fisher path** (``diagonal_estimator='fisher'``): the IMM is
-        ``sqrt(Var[x] / Var[∇ log p])`` per coordinate, computed via
-        :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal`
-        from the window's accumulated position and gradient moment statistics.
-        The Welford regularization does NOT apply on the Fisher path.
+        **Welford path**: the IMM is regularized as a convex combination of
+        this window's empirical covariance (weight: ``count / denom``), the
+        previous window's IMM (weight: ``imm_shrinkage_to_previous / denom``),
+        and a small identity matrix (weight: ``5 / denom``), where
+        ``denom = count + 5 + imm_shrinkage_to_previous``.  When
+        ``imm_shrinkage_to_previous=0.0`` (default) this reduces to the
+        standard Stan formula.
 
         """
         if isinstance(mm_state, FisherMassMatrixAdaptationState):
-            # Lazy import avoids a circular dependency: metric_estimators imports
-            # welford_algorithm from this module; importing at top level would
-            # form a cycle (mass_matrix → metric_estimators → mass_matrix).
-            from blackjax.adaptation.metric_estimators import fisher_score_diagonal
-
-            block = mm_state.fisher_block
-            # Bessel-corrected per-coordinate variances from the moment block.
-            denom = jnp.maximum(block.count - 1.0, 1.0)
-            var_x = block.m2_x / denom  # (d,)
-            var_g = block.m2_g / denom  # (d,)
-            # Call the canonical estimator via a 2-row synthetic batch.
-            # For n=2 draws [h, -h] (centered at 0, h = sqrt(var/2)), Welford
-            # gives exactly var as the Bessel-corrected variance — so
-            # fisher_score_diagonal recovers var_x and var_g without raw draws.
-            # This preserves the constraint "estimator math lives only in
-            # metric_estimators.fisher_score_diagonal" while working with the
-            # CGL moment-block accumulation (no raw draw storage).
-            half_x = jnp.sqrt(jnp.maximum(var_x, 0.0) / 2)
-            half_g = jnp.sqrt(jnp.maximum(var_g, 0.0) / 2)
-            draws = jnp.stack([half_x, -half_x])  # (2, d)
-            grads = jnp.stack([half_g, -half_g])  # (2, d)
-            inverse_mass_matrix = fisher_score_diagonal(draws, grads)
-            ndims = inverse_mass_matrix.shape[-1]
+            # Reset the block for the next window; pass the existing IMM through
+            # unchanged (the consumer — window_adaptation.base's slow_final —
+            # reads the block variances BEFORE this call and stitches in the
+            # new IMM after the reset).
+            ndims = mm_state.fisher_block.m2_x.shape[0]
             return FisherMassMatrixAdaptationState(
-                inverse_mass_matrix=inverse_mass_matrix,
+                inverse_mass_matrix=mm_state.inverse_mass_matrix,
                 fisher_block=_fisher_block_init(ndims),
             )
 

--- a/blackjax/adaptation/mass_matrix.py
+++ b/blackjax/adaptation/mass_matrix.py
@@ -23,11 +23,17 @@ from typing import Callable, NamedTuple
 import jax
 import jax.numpy as jnp
 
+from blackjax.adaptation.metric_buffers import (
+    _fisher_block_init,
+    _fisher_block_update_one,
+    _FisherMomentBlock,
+)
 from blackjax.types import Array, ArrayLike
 
 __all__ = [
     "WelfordAlgorithmState",
     "MassMatrixAdaptationState",
+    "FisherMassMatrixAdaptationState",
     "mass_matrix_adaptation",
     "welford_algorithm",
 ]
@@ -66,9 +72,41 @@ class MassMatrixAdaptationState(NamedTuple):
     wc_state: WelfordAlgorithmState
 
 
+class FisherMassMatrixAdaptationState(NamedTuple):
+    """State for the Fisher-diagonal mass matrix adaptation.
+
+    Used when ``diagonal_estimator="fisher"`` is passed to
+    :func:`mass_matrix_adaptation`.  Replaces the single Welford state in
+    :class:`MassMatrixAdaptationState` with a
+    :class:`~blackjax.adaptation.metric_buffers._FisherMomentBlock` that
+    accumulates per-coordinate position AND gradient variance in CGL-mergeable
+    diagonal form.
+
+    Parameters
+    ----------
+    inverse_mass_matrix
+        Current value of the (diagonal) inverse mass matrix, shape ``(d,)``.
+    fisher_block
+        CGL-mergeable moment block accumulating diagonal position and gradient
+        statistics for the current window.  Reset to zeros at each
+        :func:`mass_matrix_adaptation` ``final()`` call (window boundary).
+
+    Notes
+    -----
+    The Fisher-diagonal IMM is ``sqrt(Var[x] / Var[∇ log p])`` per coordinate
+    (see :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal`).
+    This state type accumulates the moments needed to compute those per-window
+    variances without storing raw draw arrays.
+    """
+
+    inverse_mass_matrix: Array  # (d,)
+    fisher_block: _FisherMomentBlock
+
+
 def mass_matrix_adaptation(
     is_diagonal_matrix: bool = True,
     imm_shrinkage_to_previous: float = 0.0,
+    diagonal_estimator: str = "welford",
 ) -> tuple[Callable, Callable, Callable]:
     """Adapts the values in the mass matrix by computing the covariance
     between parameters.
@@ -78,6 +116,25 @@ def mass_matrix_adaptation(
     is_diagonal_matrix
         When True the algorithm adapts and returns a diagonal mass matrix
         (default), otherwise adaps and returns a dense mass matrix.
+    diagonal_estimator
+        Which diagonal-variance estimator to use for the (window-local)
+        inverse mass matrix.  ``"welford"`` (default) is Stan's classic
+        online-covariance estimator and reproduces all pre-existing behavior
+        exactly.  ``"fisher"`` instead uses the Fisher-divergence-minimising
+        diagonal estimator of :cite:p:`seyboldt2026preconditioning` (see
+        :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal`),
+        which additionally requires the log-density gradient at each
+        accumulated position (passed to ``update`` as ``grad``).
+
+        Constraints for ``"fisher"``:
+
+        * ``is_diagonal_matrix=True`` is required (the Fisher-diagonal
+          estimator only produces a diagonal metric).
+        * ``imm_shrinkage_to_previous=0.0`` is required (the Fisher estimator
+          does not blend with a previous IMM or an identity target).
+
+        Both constraints are validated at construction time with a
+        ``ValueError`` before any JIT tracing.
     imm_shrinkage_to_previous
         Bayesian pseudo-count controlling shrinkage of the per-window adapted
         IMM toward the previous window's IMM. Interpretable as "the number of
@@ -127,10 +184,28 @@ def mass_matrix_adaptation(
         state.
 
     """
+    if diagonal_estimator not in ("welford", "fisher"):
+        raise ValueError(
+            f"diagonal_estimator must be 'welford' or 'fisher', "
+            f"got {diagonal_estimator!r}"
+        )
+    if diagonal_estimator == "fisher" and not is_diagonal_matrix:
+        raise ValueError(
+            "diagonal_estimator='fisher' requires is_diagonal_matrix=True "
+            "(the Fisher-divergence estimator only produces a diagonal metric); "
+            "got is_diagonal_matrix=False"
+        )
     if imm_shrinkage_to_previous < 0.0:
         raise ValueError(
             f"imm_shrinkage_to_previous must be >= 0.0, "
             f"got {imm_shrinkage_to_previous}"
+        )
+    if diagonal_estimator == "fisher" and imm_shrinkage_to_previous != 0.0:
+        raise ValueError(
+            "diagonal_estimator='fisher' does not support "
+            "imm_shrinkage_to_previous != 0.0: the Fisher estimator does not "
+            "blend with the previous window's IMM or an identity target; "
+            f"got imm_shrinkage_to_previous={imm_shrinkage_to_previous}"
         )
 
     wc_init, wc_update, wc_final = welford_algorithm(is_diagonal_matrix)
@@ -138,7 +213,7 @@ def mass_matrix_adaptation(
     def init(
         n_dims: int,
         initial_inverse_mass_matrix: Array | None = None,
-    ) -> MassMatrixAdaptationState:
+    ) -> MassMatrixAdaptationState | FisherMassMatrixAdaptationState:
         """Initialize the matrix adaptation.
 
         Parameters
@@ -166,45 +241,102 @@ def mass_matrix_adaptation(
         else:
             inverse_mass_matrix = jnp.asarray(initial_inverse_mass_matrix)
 
-        wc_state = wc_init(n_dims)
+        if diagonal_estimator == "fisher":
+            return FisherMassMatrixAdaptationState(
+                inverse_mass_matrix=inverse_mass_matrix,
+                fisher_block=_fisher_block_init(n_dims),
+            )
 
+        wc_state = wc_init(n_dims)
         return MassMatrixAdaptationState(inverse_mass_matrix, wc_state)
 
     def update(
-        mm_state: MassMatrixAdaptationState, position: ArrayLike
-    ) -> MassMatrixAdaptationState:
+        mm_state: MassMatrixAdaptationState | FisherMassMatrixAdaptationState,
+        position: ArrayLike,
+        grad: ArrayLike | None = None,
+    ) -> MassMatrixAdaptationState | FisherMassMatrixAdaptationState:
         """Update the algorithm's state.
 
         Parameters
         ----------
-        state:
-            The current state of the mass matrix adapation.
-        position:
+        mm_state
+            The current state of the mass matrix adaptation.
+        position
             The current position of the chain.
+        grad
+            The log-density gradient at ``position``.  Required when
+            ``diagonal_estimator='fisher'`` (ignored and may be ``None``
+            otherwise).
 
         """
+        if isinstance(mm_state, FisherMassMatrixAdaptationState):
+            position_flat, _ = jax.flatten_util.ravel_pytree(position)
+            grad_flat, _ = jax.flatten_util.ravel_pytree(grad)
+            new_block = _fisher_block_update_one(
+                mm_state.fisher_block, position_flat, grad_flat
+            )
+            return FisherMassMatrixAdaptationState(
+                inverse_mass_matrix=mm_state.inverse_mass_matrix,
+                fisher_block=new_block,
+            )
+
         inverse_mass_matrix, wc_state = mm_state
         position, _ = jax.flatten_util.ravel_pytree(position)
         wc_state = wc_update(wc_state, position)
         return MassMatrixAdaptationState(inverse_mass_matrix, wc_state)
 
-    def final(mm_state: MassMatrixAdaptationState) -> MassMatrixAdaptationState:
+    def final(
+        mm_state: MassMatrixAdaptationState | FisherMassMatrixAdaptationState,
+    ) -> MassMatrixAdaptationState | FisherMassMatrixAdaptationState:
         """Final iteration of the mass matrix adaptation.
 
-        In this step we compute the mass matrix from the covariance matrix computed
-        by the Welford algorithm, and re-initialize the later.
+        Computes the inverse mass matrix from the current window's accumulated
+        statistics, then resets the accumulator for the next window.
 
-        The IMM is regularized as a convex combination of three terms:
-        1. This window's empirical covariance (weight: count / denom)
-        2. The previous window's IMM (weight: imm_shrinkage_to_previous / denom)
-        3. A small identity matrix 1e-3·I (weight: 5 / denom)
+        **Welford path** (default): the IMM is regularized as a convex
+        combination of this window's empirical covariance (weight:
+        ``count / denom``), the previous window's IMM (weight:
+        ``imm_shrinkage_to_previous / denom``), and a small identity matrix
+        (weight: ``5 / denom``), where ``denom = count + 5 +
+        imm_shrinkage_to_previous``.  When ``imm_shrinkage_to_previous=0.0``
+        (default) this reduces to the standard Stan formula.
 
-        where denom = count + 5 + imm_shrinkage_to_previous.
-
-        When imm_shrinkage_to_previous = 0.0 (default), this reduces to the
-        standard Stan formula with only the first and third terms.
+        **Fisher path** (``diagonal_estimator='fisher'``): the IMM is
+        ``sqrt(Var[x] / Var[∇ log p])`` per coordinate, computed via
+        :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal`
+        from the window's accumulated position and gradient moment statistics.
+        The Welford regularization does NOT apply on the Fisher path.
 
         """
+        if isinstance(mm_state, FisherMassMatrixAdaptationState):
+            # Lazy import avoids a circular dependency: metric_estimators imports
+            # welford_algorithm from this module; importing at top level would
+            # form a cycle (mass_matrix → metric_estimators → mass_matrix).
+            from blackjax.adaptation.metric_estimators import fisher_score_diagonal
+
+            block = mm_state.fisher_block
+            # Bessel-corrected per-coordinate variances from the moment block.
+            denom = jnp.maximum(block.count - 1.0, 1.0)
+            var_x = block.m2_x / denom  # (d,)
+            var_g = block.m2_g / denom  # (d,)
+            # Call the canonical estimator via a 2-row synthetic batch.
+            # For n=2 draws [h, -h] (centered at 0, h = sqrt(var/2)), Welford
+            # gives exactly var as the Bessel-corrected variance — so
+            # fisher_score_diagonal recovers var_x and var_g without raw draws.
+            # This preserves the constraint "estimator math lives only in
+            # metric_estimators.fisher_score_diagonal" while working with the
+            # CGL moment-block accumulation (no raw draw storage).
+            half_x = jnp.sqrt(jnp.maximum(var_x, 0.0) / 2)
+            half_g = jnp.sqrt(jnp.maximum(var_g, 0.0) / 2)
+            draws = jnp.stack([half_x, -half_x])  # (2, d)
+            grads = jnp.stack([half_g, -half_g])  # (2, d)
+            inverse_mass_matrix = fisher_score_diagonal(draws, grads)
+            ndims = inverse_mass_matrix.shape[-1]
+            return FisherMassMatrixAdaptationState(
+                inverse_mass_matrix=inverse_mass_matrix,
+                fisher_block=_fisher_block_init(ndims),
+            )
+
         previous_imm, wc_state = mm_state
         covariance, count, mean = wc_final(wc_state)
 

--- a/blackjax/adaptation/metric_buffers.py
+++ b/blackjax/adaptation/metric_buffers.py
@@ -205,33 +205,180 @@ class MomentBlock(NamedTuple):
 
 
 class _FisherMomentBlock(NamedTuple):
-    """CGL-mergeable sufficient statistics for a future moments-consuming
-    Fisher estimator (position + gradient moments).
+    """CGL-mergeable sufficient statistics for the diagonal Fisher estimator
+    (position + gradient moments, diagonal variant).
 
-    Companion type for a moments-based Fisher variant that would replace
-    ``fisher_score_low_rank``'s raw-array signature.  The call-site wiring
-    is deliberate follow-up work; use :class:`MomentBlock` for currently-wired
-    consumers (``sample_covariance_eigh_low_rank``).
+    Accumulation state for
+    :class:`~blackjax.adaptation.mass_matrix.FisherMassMatrixAdaptationState`.
+    The diagonal variant stores O(d) gradient moments — no d×d cross-moment
+    matrix, no raw draw ring.
+
+    The ``count`` field uses the **ambient float dtype** (``jnp.zeros(())``
+    with no explicit dtype specification) so that CGL merge weights are
+    computed at the full precision available in the calling x64 context.
+    Calling :func:`_fisher_block_init` inside a ``jax.enable_x64()`` context
+    gives an f64 count; outside gives f32 — consistent with the x64 parity
+    contract of this module.
 
     Parameters
     ----------
     count
-        Number of samples accumulated, scalar ``()``.
+        Number of samples accumulated, scalar ``()``.  Ambient float dtype.
     mean_x
         Position mean, shape ``(d,)``.
     m2_x
-        Position sum of squared deviations, shape ``(d, d)``.
+        Position sum of squared deviations (diagonal), shape ``(d,)``.
     mean_g
         Gradient mean, shape ``(d,)``.
     m2_g
-        Gradient sum of squared deviations, shape ``(d, d)``.
+        Gradient sum of squared deviations (diagonal), shape ``(d,)``.
+
+    Notes
+    -----
+    Diagonal-only: ``m2_x`` and ``m2_g`` have shape ``(d,)`` (not ``(d, d)``).
+    This matches the Fisher-diagonal estimator requirement — only per-coordinate
+    gradient variance is needed; no d×d cross-moment is accumulated.
+
+    See :func:`_fisher_block_init`, :func:`_fisher_block_update_one`,
+    :func:`_fisher_block_merge`.
     """
 
-    count: Array  # ()
+    count: Array  # ()  ambient float dtype
     mean_x: Array  # (d,)
-    m2_x: Array  # (d, d)
+    m2_x: Array  # (d,)  diagonal, sum of squared deviations
     mean_g: Array  # (d,)
-    m2_g: Array  # (d, d)
+    m2_g: Array  # (d,)  diagonal, sum of squared deviations
+
+
+def _fisher_block_init(d: int) -> _FisherMomentBlock:
+    """Return a zero-initialised :class:`_FisherMomentBlock` for dimension ``d``.
+
+    The ``count`` field uses the ambient float dtype (``jnp.zeros(())`` with
+    no explicit ``dtype=`` argument) so that CGL merge weights are computed at
+    the full precision available in the calling context.  Call inside
+    ``jax.enable_x64()`` to get f64 counts.
+
+    Parameters
+    ----------
+    d
+        Dimension of the position and gradient vectors.
+
+    Returns
+    -------
+    _FisherMomentBlock
+        All-zero block ready for :func:`_fisher_block_update_one`.
+    """
+    return _FisherMomentBlock(
+        count=jnp.zeros(()),
+        mean_x=jnp.zeros((d,)),
+        m2_x=jnp.zeros((d,)),
+        mean_g=jnp.zeros((d,)),
+        m2_g=jnp.zeros((d,)),
+    )
+
+
+def _fisher_block_update_one(
+    block: _FisherMomentBlock,
+    position_flat: Array,
+    grad_flat: Array,
+) -> _FisherMomentBlock:
+    """Welford (single-draw CGL) update of a :class:`_FisherMomentBlock`.
+
+    Incorporates one new ``(position, gradient)`` pair into the running
+    diagonal moment statistics via the online Welford recurrence.  Equivalent
+    to a CGL merge of the existing block with a size-1 block for the new draw,
+    but avoids the intermediate allocation.
+
+    Parameters
+    ----------
+    block
+        Existing block (may be empty, ``count=0``).
+    position_flat
+        Flat position vector, shape ``(d,)``.  Must already be ravelled.
+    grad_flat
+        Flat log-density gradient vector, shape ``(d,)``.  Must already be
+        ravelled.
+
+    Returns
+    -------
+    _FisherMomentBlock
+        Updated block with the new draw incorporated.
+    """
+    count = block.count + 1.0
+
+    # Welford update for position
+    delta_x = position_flat - block.mean_x
+    mean_x = block.mean_x + delta_x / count
+    updated_delta_x = position_flat - mean_x
+    m2_x = block.m2_x + delta_x * updated_delta_x  # diagonal: element-wise product
+
+    # Welford update for gradient
+    delta_g = grad_flat - block.mean_g
+    mean_g = block.mean_g + delta_g / count
+    updated_delta_g = grad_flat - mean_g
+    m2_g = block.m2_g + delta_g * updated_delta_g  # diagonal: element-wise product
+
+    return _FisherMomentBlock(
+        count=count,
+        mean_x=mean_x,
+        m2_x=m2_x,
+        mean_g=mean_g,
+        m2_g=m2_g,
+    )
+
+
+def _fisher_block_merge(
+    a: _FisherMomentBlock,
+    b: _FisherMomentBlock,
+) -> _FisherMomentBlock:
+    """CGL-merge two :class:`_FisherMomentBlock` instances.
+
+    Applies the parallel Chan–Golub–LeVeque recurrence
+    :cite:p:`chan1983algorithms` independently to the position and gradient
+    moment fields.  Semantics match :func:`cgl_merge_two` for each of the two
+    ``(count, mean, m2)`` pairs stored in the block.
+
+    Parameters
+    ----------
+    a, b
+        Two :class:`_FisherMomentBlock` instances to merge.
+
+    Returns
+    -------
+    _FisherMomentBlock
+        Merged block with combined statistics.  When both inputs are empty
+        (``count=0``), returns an all-zero block.
+    """
+    n_a = a.count
+    n_b = b.count
+    n_ab = n_a + n_b
+    safe_n = jnp.where(n_ab > 0, n_ab, jnp.ones_like(n_ab))
+
+    # Position CGL merge (diagonal)
+    delta_x = b.mean_x - a.mean_x
+    mean_x = a.mean_x + delta_x * (n_b / safe_n)
+    cross_x = delta_x * delta_x * (n_a * n_b / safe_n)
+    m2_x = a.m2_x + b.m2_x + cross_x
+
+    # Gradient CGL merge (diagonal)
+    delta_g = b.mean_g - a.mean_g
+    mean_g = a.mean_g + delta_g * (n_b / safe_n)
+    cross_g = delta_g * delta_g * (n_a * n_b / safe_n)
+    m2_g = a.m2_g + b.m2_g + cross_g
+
+    # Zero-guard: when both inputs are empty, return an all-zero block.
+    mean_x = jnp.where(n_ab > 0, mean_x, jnp.zeros_like(mean_x))
+    m2_x = jnp.where(n_ab > 0, m2_x, jnp.zeros_like(m2_x))
+    mean_g = jnp.where(n_ab > 0, mean_g, jnp.zeros_like(mean_g))
+    m2_g = jnp.where(n_ab > 0, m2_g, jnp.zeros_like(m2_g))
+
+    return _FisherMomentBlock(
+        count=n_ab,
+        mean_x=mean_x,
+        m2_x=m2_x,
+        mean_g=mean_g,
+        m2_g=m2_g,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/blackjax/adaptation/metric_buffers.py
+++ b/blackjax/adaptation/metric_buffers.py
@@ -239,8 +239,7 @@ class _FisherMomentBlock(NamedTuple):
     This matches the Fisher-diagonal estimator requirement — only per-coordinate
     gradient variance is needed; no d×d cross-moment is accumulated.
 
-    See :func:`_fisher_block_init`, :func:`_fisher_block_update_one`,
-    :func:`_fisher_block_merge`.
+    See :func:`_fisher_block_init`, :func:`_fisher_block_update_one`.
     """
 
     count: Array  # ()  ambient float dtype
@@ -320,60 +319,6 @@ def _fisher_block_update_one(
 
     return _FisherMomentBlock(
         count=count,
-        mean_x=mean_x,
-        m2_x=m2_x,
-        mean_g=mean_g,
-        m2_g=m2_g,
-    )
-
-
-def _fisher_block_merge(
-    a: _FisherMomentBlock,
-    b: _FisherMomentBlock,
-) -> _FisherMomentBlock:
-    """CGL-merge two :class:`_FisherMomentBlock` instances.
-
-    Applies the parallel Chan–Golub–LeVeque recurrence
-    :cite:p:`chan1983algorithms` independently to the position and gradient
-    moment fields.  Semantics match :func:`cgl_merge_two` for each of the two
-    ``(count, mean, m2)`` pairs stored in the block.
-
-    Parameters
-    ----------
-    a, b
-        Two :class:`_FisherMomentBlock` instances to merge.
-
-    Returns
-    -------
-    _FisherMomentBlock
-        Merged block with combined statistics.  When both inputs are empty
-        (``count=0``), returns an all-zero block.
-    """
-    n_a = a.count
-    n_b = b.count
-    n_ab = n_a + n_b
-    safe_n = jnp.where(n_ab > 0, n_ab, jnp.ones_like(n_ab))
-
-    # Position CGL merge (diagonal)
-    delta_x = b.mean_x - a.mean_x
-    mean_x = a.mean_x + delta_x * (n_b / safe_n)
-    cross_x = delta_x * delta_x * (n_a * n_b / safe_n)
-    m2_x = a.m2_x + b.m2_x + cross_x
-
-    # Gradient CGL merge (diagonal)
-    delta_g = b.mean_g - a.mean_g
-    mean_g = a.mean_g + delta_g * (n_b / safe_n)
-    cross_g = delta_g * delta_g * (n_a * n_b / safe_n)
-    m2_g = a.m2_g + b.m2_g + cross_g
-
-    # Zero-guard: when both inputs are empty, return an all-zero block.
-    mean_x = jnp.where(n_ab > 0, mean_x, jnp.zeros_like(mean_x))
-    m2_x = jnp.where(n_ab > 0, m2_x, jnp.zeros_like(m2_x))
-    mean_g = jnp.where(n_ab > 0, mean_g, jnp.zeros_like(mean_g))
-    m2_g = jnp.where(n_ab > 0, m2_g, jnp.zeros_like(m2_g))
-
-    return _FisherMomentBlock(
-        count=n_ab,
         mean_x=mean_x,
         m2_x=m2_x,
         mean_g=mean_g,

--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -710,7 +710,15 @@ def fisher_score_diagonal_from_moments(
     **Near-zero gradient protection** (identical to :func:`fisher_score_low_rank`
     and :func:`fisher_score_diagonal`): ``gradient_variance`` is floored at
     ``1e-10`` before division, and the result is clipped to nutpie's
-    ``[1e-20, 1e20]`` range before squaring.
+    ``[1e-20, 1e20]`` range **before squaring**.
+
+    **Pairing insensitivity:** this function consumes only the marginal variances
+    ``Var[x_i]`` and ``Var[∇log p_i]`` per coordinate.  The estimator is
+    therefore insensitive to which draw is paired with which gradient within a
+    batch — any per-batch pairing permutation produces the same ``variance`` and
+    ``gradient_variance`` inputs and hence the same output.  If cross-moment
+    information (e.g. draw-grad covariance) is required, a future extension to
+    this signature must add those moments explicitly.
 
     **Planned extension note:** this entry point is intentionally separate so
     that future updates to the estimator (e.g. adding draw-grad cross moments)
@@ -731,9 +739,19 @@ def fisher_score_diagonal_from_moments(
     Returns
     -------
     Array, shape ``(d,)``
-        Diagonal inverse mass matrix :math:`\sigma^2 =
-        \sqrt{\mathrm{Var}[x] / \max(\mathrm{Var}[\nabla \log p],\, 10^{-10})}`,
-        clipped to ``[1e-20, 1e20]``.
+        Diagonal inverse mass matrix :math:`\sigma^2 = \sigma_{\text{clip}}^2`
+        where :math:`\sigma_{\text{clip}} = \operatorname{clip}(\sigma,\,
+        10^{-20},\, 10^{20})` and :math:`\sigma = (\mathrm{Var}[x] /
+        \max(\mathrm{Var}[\nabla \log p],\, 10^{-10}))^{1/4}`.
+
+        The clip is on the **scale** :math:`\sigma`, not on :math:`\sigma^2`,
+        so the returned values span :math:`[10^{-40}, 10^{40}]`.  Under
+        float32, :math:`\sigma^2` overflows to ``inf`` when :math:`\sigma
+        \approx 10^{20}` (float32 max :math:`\approx 3.4 \times 10^{38}`, so
+        :math:`10^{40}` overflows); the caller must handle this if float32
+        inputs can drive :math:`\sigma` to its clip boundary.  This matches
+        :func:`fisher_score_low_rank`'s ``sigma`` clip and is not changed here
+        to preserve numerical consistency between the two estimators.
     """
     sigma = jnp.power(
         jnp.clip(variance / jnp.maximum(gradient_variance, 1e-10), 0.0, None), 0.25

--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -148,6 +148,7 @@ __all__ = [
     "sample_covariance_eigh_low_rank",
     "welford_diagonal",
     "welford_dense",
+    "fisher_score_diagonal_from_moments",
     "fisher_score_diagonal",
     "sample_variance_diagonal",
 ]
@@ -688,6 +689,59 @@ def welford_dense(draws: Array) -> Array:
     return covariance
 
 
+def fisher_score_diagonal_from_moments(
+    variance: Array,
+    gradient_variance: Array,
+) -> Array:
+    r"""Core math of the Fisher-diagonal estimator from pre-computed variances.
+
+    Computes :math:`\sigma^2 = \sqrt{\mathrm{Var}[x] / \mathrm{Var}[\nabla
+    \log p]}` per coordinate — the same formula as :func:`fisher_score_diagonal`
+    but operating on **already-computed** per-coordinate variances rather than
+    raw draw arrays.
+
+    This entry point is intended for callers that accumulate moments online
+    (e.g. via :class:`~blackjax.adaptation.metric_buffers._FisherMomentBlock`)
+    and want to avoid materialising the full draw array.  The caller is
+    responsible for supplying Bessel-corrected (or otherwise normalised)
+    variances; the ratio is invariant to a shared ``n`` vs ``n-1`` factor so
+    either convention is acceptable for the diagonal estimator.
+
+    **Near-zero gradient protection** (identical to :func:`fisher_score_low_rank`
+    and :func:`fisher_score_diagonal`): ``gradient_variance`` is floored at
+    ``1e-10`` before division, and the result is clipped to nutpie's
+    ``[1e-20, 1e20]`` range before squaring.
+
+    **Planned extension note:** this entry point is intentionally separate so
+    that future updates to the estimator (e.g. adding draw-grad cross moments)
+    can extend the *from_moments* signature without changing the *raw-draws*
+    wrapper :func:`fisher_score_diagonal`.
+
+    Parameters
+    ----------
+    variance
+        Shape ``(d,)``.  Per-coordinate position variance
+        :math:`\mathrm{Var}[x]`.  Must be non-negative; typically
+        Bessel-corrected.
+    gradient_variance
+        Shape ``(d,)``.  Per-coordinate log-density-gradient variance
+        :math:`\mathrm{Var}[\nabla \log p]`.  Must be non-negative; floored
+        at ``1e-10`` internally.
+
+    Returns
+    -------
+    Array, shape ``(d,)``
+        Diagonal inverse mass matrix :math:`\sigma^2 =
+        \sqrt{\mathrm{Var}[x] / \max(\mathrm{Var}[\nabla \log p],\, 10^{-10})}`,
+        clipped to ``[1e-20, 1e20]``.
+    """
+    sigma = jnp.power(
+        jnp.clip(variance / jnp.maximum(gradient_variance, 1e-10), 0.0, None), 0.25
+    )
+    sigma = jnp.clip(sigma, 1e-20, 1e20)  # nutpie range
+    return sigma**2
+
+
 def fisher_score_diagonal(
     draws: Array,
     grads: Array,
@@ -707,9 +761,6 @@ def fisher_score_diagonal(
 
     **Extracted from:** branch ``b197f1e2`` (``feat/window-adaptation-fisher-diag``,
     2026-07-04), ``blackjax.adaptation.mass_matrix._fisher_diagonal_inverse_mass``.
-    The branch is DORMANT — its ``window_adaptation`` wiring (the diagonal
-    estimator opt-in in ``mass_matrix_adaptation``) is NOT reproduced here and
-    stays dormant.  Only the pure estimator math is extracted.
 
     **Near-zero gradient protection** (same as :func:`fisher_score_low_rank`):
     ``Var[∇ log p]`` is floored at ``1e-10`` before division, and the result
@@ -719,6 +770,11 @@ def fisher_score_diagonal(
     computed with the same normalisation (Bessel-corrected, ``n-1`` divisor,
     via :func:`welford_diagonal`); the ratio is invariant to a shared
     ``n`` vs ``n-1`` factor (branch ``b197f1e2`` commit message, verified).
+
+    **Implementation:** thin wrapper over
+    :func:`fisher_score_diagonal_from_moments` — computes Bessel-corrected
+    per-coordinate variances via two :func:`welford_diagonal` scans, then
+    delegates all arithmetic to the from-moments entry point.
 
     Parameters
     ----------
@@ -734,10 +790,7 @@ def fisher_score_diagonal(
     """
     var_x = welford_diagonal(draws)  # (d,)  Bessel-corrected
     var_g = welford_diagonal(grads)  # (d,)
-
-    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
-    sigma = jnp.clip(sigma, 1e-20, 1e20)  # nutpie range
-    return sigma**2
+    return fisher_score_diagonal_from_moments(var_x, var_g)
 
 
 def sample_variance_diagonal(draws: Array) -> Array:

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Implementation of the Stan warmup for the HMC family of sampling algorithms."""
 import inspect
-from typing import Callable, NamedTuple
+from typing import Callable, NamedTuple, cast
 
 import jax
 import jax.numpy as jnp
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
 from blackjax.adaptation.mass_matrix import (
+    FisherMassMatrixAdaptationState,
     MassMatrixAdaptationState,
     mass_matrix_adaptation,
 )
@@ -37,7 +38,7 @@ __all__ = ["WindowAdaptationState", "base", "build_schedule", "window_adaptation
 
 class WindowAdaptationState(NamedTuple):
     ss_state: DualAveragingAdaptationState  # step size
-    imm_state: MassMatrixAdaptationState  # inverse mass matrix
+    imm_state: MassMatrixAdaptationState | FisherMassMatrixAdaptationState  # inverse mass matrix
     step_size: float
     inverse_mass_matrix: Array
 
@@ -228,23 +229,77 @@ def base(
                 warmup_state.inverse_mass_matrix,
             )
 
-    def slow_final(warmup_state: WindowAdaptationState) -> WindowAdaptationState:
-        """Update the parameters at the end of a slow adaptation window.
+    if diagonal_estimator == "welford":
 
-        We compute the value of the mass matrix and reset the mass matrix
-        adapation's internal state since middle windows are "memoryless".
+        def slow_final(warmup_state: WindowAdaptationState) -> WindowAdaptationState:
+            """Update the parameters at the end of a slow adaptation window.
 
-        """
-        new_imm_state = mm_final(warmup_state.imm_state)
-        new_ss_state = da_init(da_final(warmup_state.ss_state))
-        new_step_size = jnp.exp(new_ss_state.log_step_size)
+            We compute the value of the mass matrix and reset the mass matrix
+            adaptation's internal state since middle windows are "memoryless".
 
-        return WindowAdaptationState(
-            new_ss_state,
-            new_imm_state,
-            new_step_size,
-            new_imm_state.inverse_mass_matrix,
+            """
+            new_imm_state = mm_final(warmup_state.imm_state)
+            new_ss_state = da_init(da_final(warmup_state.ss_state))
+            new_step_size = jnp.exp(new_ss_state.log_step_size)
+
+            return WindowAdaptationState(
+                new_ss_state,
+                new_imm_state,
+                new_step_size,
+                new_imm_state.inverse_mass_matrix,
+            )
+
+    else:  # diagonal_estimator == "fisher"
+        from blackjax.adaptation.metric_estimators import (  # noqa: PLC0415
+            fisher_score_diagonal_from_moments,
         )
+
+        def slow_final(  # type: ignore[no-redef]
+            warmup_state: WindowAdaptationState,
+        ) -> WindowAdaptationState:
+            """Update the parameters at the end of a slow adaptation window.
+
+            On the Fisher path, the IMM is computed here (not inside
+            ``mm_final``) to respect the dependency order:
+            ``metric_estimators`` imports from ``mass_matrix``, so
+            ``mass_matrix.final()`` must not import from ``metric_estimators``.
+            This closure composes both layers:
+
+            1. Extract Bessel-corrected per-coordinate variances from the
+               accumulated :class:`~blackjax.adaptation.metric_buffers._FisherMomentBlock`
+               BEFORE the reset.
+            2. Call :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal_from_moments`
+               to compute the new IMM.
+            3. Call ``mm_final`` to reset the block for the next window.
+            4. Stitch the new IMM into the reset state.
+
+            """
+            # This closure is only constructed on the Fisher path (Python-level
+            # dispatch in base()); the state is always FisherMassMatrixAdaptationState
+            # at this point.  The cast is a static hint only — zero runtime cost.
+            fisher_state = cast(FisherMassMatrixAdaptationState, warmup_state.imm_state)
+            block = fisher_state.fisher_block
+            denom = jnp.maximum(block.count - 1.0, 1.0)
+            var_x = block.m2_x / denom  # (d,)  Bessel-corrected position variance
+            var_g = block.m2_g / denom  # (d,)  Bessel-corrected gradient variance
+            new_inverse_mass_matrix = fisher_score_diagonal_from_moments(var_x, var_g)
+
+            # mm_final resets the block; we stitch the newly computed IMM in.
+            reset_state = cast(FisherMassMatrixAdaptationState, mm_final(fisher_state))
+            new_imm_state = FisherMassMatrixAdaptationState(
+                inverse_mass_matrix=new_inverse_mass_matrix,
+                fisher_block=reset_state.fisher_block,
+            )
+
+            new_ss_state = da_init(da_final(warmup_state.ss_state))
+            new_step_size = jnp.exp(new_ss_state.log_step_size)
+
+            return WindowAdaptationState(
+                new_ss_state,
+                new_imm_state,
+                new_step_size,
+                new_imm_state.inverse_mass_matrix,
+            )
 
     def update(
         adaptation_state: WindowAdaptationState,

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -47,6 +47,7 @@ def base(
     target_acceptance_rate: float = 0.80,
     initial_inverse_mass_matrix: Array | None = None,
     imm_shrinkage_to_previous: float = 0.0,
+    diagonal_estimator: str = "welford",
 ) -> tuple[Callable, Callable, Callable]:
     """Warmup scheme for sampling procedures based on euclidean manifold HMC.
     The schedule and algorithms used match Stan's :cite:p:`stan_hmc_param` as closely as possible.
@@ -97,6 +98,13 @@ def base(
         Pseudo-count controlling shrinkage of the IMM toward the previous
         window's IMM. Default 0.0 gives the current Stan behavior. Passed
         through to ``mass_matrix_adaptation``.
+    diagonal_estimator
+        Which diagonal-variance estimator to use.  ``"welford"`` (default)
+        reproduces all pre-existing behavior exactly.  ``"fisher"`` uses the
+        Fisher-divergence-minimising diagonal estimator; see
+        ``mass_matrix_adaptation`` for constraints (diagonal-only, no
+        ``imm_shrinkage_to_previous``).  Passed through to
+        ``mass_matrix_adaptation``.
 
     Returns
     -------
@@ -110,7 +118,7 @@ def base(
 
     """
     mm_init, mm_update, mm_final = mass_matrix_adaptation(
-        is_mass_matrix_diagonal, imm_shrinkage_to_previous
+        is_mass_matrix_diagonal, imm_shrinkage_to_previous, diagonal_estimator
     )
     da_init, da_update, da_final = dual_averaging_adaptation(target_acceptance_rate)
 
@@ -138,6 +146,7 @@ def base(
 
     def fast_update(
         position: ArrayLikeTree,
+        grad: ArrayLikeTree,
         acceptance_rate: float,
         warmup_state: WindowAdaptationState,
     ) -> WindowAdaptationState:
@@ -148,7 +157,7 @@ def base(
         compared to the covariance estimation with Welford's algorithm
 
         """
-        del position
+        del position, grad
 
         new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
         new_step_size = jnp.exp(new_ss_state.log_step_size)
@@ -160,28 +169,64 @@ def base(
             warmup_state.inverse_mass_matrix,
         )
 
-    def slow_update(
-        position: ArrayLikeTree,
-        acceptance_rate: float,
-        warmup_state: WindowAdaptationState,
-    ) -> WindowAdaptationState:
-        """Update the adaptation state when in a "slow" window.
+    if diagonal_estimator == "welford":
 
-        Both the mass matrix adaptation *state* and the step size state are
-        adapted in slow windows. The value of the step size is updated as well,
-        but the new value of the inverse mass matrix is only computed at the end
-        of the slow window. "Slow" refers to the fact that we need many samples
-        to get a reliable estimation of the covariance matrix used to update the
-        value of the mass matrix.
+        def slow_update(
+            position: ArrayLikeTree,
+            grad: ArrayLikeTree,
+            acceptance_rate: float,
+            warmup_state: WindowAdaptationState,
+        ) -> WindowAdaptationState:
+            """Update the adaptation state when in a "slow" window (Welford path).
 
-        """
-        new_imm_state = mm_update(warmup_state.imm_state, position)
-        new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
-        new_step_size = jnp.exp(new_ss_state.log_step_size)
+            Both the mass matrix adaptation *state* and the step size state are
+            adapted in slow windows. The value of the step size is updated as well,
+            but the new value of the inverse mass matrix is only computed at the end
+            of the slow window. "Slow" refers to the fact that we need many samples
+            to get a reliable estimation of the covariance matrix used to update the
+            value of the mass matrix.
 
-        return WindowAdaptationState(
-            new_ss_state, new_imm_state, new_step_size, warmup_state.inverse_mass_matrix
-        )
+            On the default Welford path, ``grad`` is not consumed by the IMM
+            accumulator and is explicitly deleted here so it is dead on this path.
+
+            """
+            del grad
+            new_imm_state = mm_update(warmup_state.imm_state, position)
+            new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
+            new_step_size = jnp.exp(new_ss_state.log_step_size)
+
+            return WindowAdaptationState(
+                new_ss_state,
+                new_imm_state,
+                new_step_size,
+                warmup_state.inverse_mass_matrix,
+            )
+
+    else:  # diagonal_estimator == "fisher"
+
+        def slow_update(  # type: ignore[no-redef]
+            position: ArrayLikeTree,
+            grad: ArrayLikeTree,
+            acceptance_rate: float,
+            warmup_state: WindowAdaptationState,
+        ) -> WindowAdaptationState:
+            """Update the adaptation state when in a "slow" window (Fisher path).
+
+            Both the mass matrix adaptation *state* and the step size state are
+            adapted in slow windows.  On the Fisher path, ``grad`` is forwarded
+            to the IMM accumulator so it can track gradient variance.
+
+            """
+            new_imm_state = mm_update(warmup_state.imm_state, position, grad)
+            new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
+            new_step_size = jnp.exp(new_ss_state.log_step_size)
+
+            return WindowAdaptationState(
+                new_ss_state,
+                new_imm_state,
+                new_step_size,
+                warmup_state.inverse_mass_matrix,
+            )
 
     def slow_final(warmup_state: WindowAdaptationState) -> WindowAdaptationState:
         """Update the parameters at the end of a slow adaptation window.
@@ -205,6 +250,7 @@ def base(
         adaptation_state: WindowAdaptationState,
         adaptation_stage: tuple,
         position: ArrayLikeTree,
+        grad: ArrayLikeTree,
         acceptance_rate: float,
     ) -> WindowAdaptationState:
         """Update the adaptation state and parameter values.
@@ -218,6 +264,11 @@ def base(
             a fast window and if we are at the last step of a slow window.
         position
             Current value of the model parameters.
+        grad
+            Log-density gradient at ``position``.  Forwarded to the IMM
+            accumulator on the ``diagonal_estimator='fisher'`` path; dead
+            (explicitly deleted in ``fast_update`` and ``slow_update``) on the
+            default ``"welford"`` path.
         acceptance_rate
             Value of the acceptance rate for the last mcmc step.
 
@@ -232,6 +283,7 @@ def base(
             stage,
             (fast_update, slow_update),
             position,
+            grad,
             acceptance_rate,
             adaptation_state,
         )
@@ -260,6 +312,7 @@ def window_adaptation(
     is_mass_matrix_diagonal: bool = True,
     initial_inverse_mass_matrix: Array | None = None,
     imm_shrinkage_to_previous: float = 0.0,
+    diagonal_estimator: str = "welford",
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,
     adaptation_info_fn: Callable = return_all_adapt_info,
@@ -329,6 +382,17 @@ def window_adaptation(
 
         Validated at construction time — negative values raise
         ``ValueError`` before any JIT tracing.
+    diagonal_estimator
+        Which diagonal-variance estimator to use for the (window-local)
+        inverse mass matrix.  ``"welford"`` (default) is Stan's classic
+        online-covariance estimator and reproduces all pre-existing behavior
+        exactly.  ``"fisher"`` uses the Fisher-divergence-minimising diagonal
+        estimator of :cite:p:`seyboldt2026preconditioning` (the same formula
+        underlying the diagonal-scaling step of the low-rank adaptation):
+        ``inverse_mass_matrix = sqrt(Var[position] / Var[logdensity_grad])``
+        per coordinate.  Only valid with ``is_mass_matrix_diagonal=True`` and
+        ``imm_shrinkage_to_previous=0.0``; both are validated at construction
+        time (``ValueError`` before any JIT tracing).
     initial_step_size
         The initial step size used in the algorithm.
     target_acceptance_rate
@@ -377,6 +441,21 @@ def window_adaptation(
             f"got {imm_shrinkage_to_previous}"
         )
 
+    # Fisher-estimator constraints (mirrors mass_matrix_adaptation validation).
+    if diagonal_estimator == "fisher" and not is_mass_matrix_diagonal:
+        raise ValueError(
+            "diagonal_estimator='fisher' requires is_mass_matrix_diagonal=True "
+            "(the Fisher-divergence estimator only produces a diagonal metric); "
+            "got is_mass_matrix_diagonal=False"
+        )
+    if diagonal_estimator == "fisher" and imm_shrinkage_to_previous != 0.0:
+        raise ValueError(
+            "diagonal_estimator='fisher' does not support "
+            "imm_shrinkage_to_previous != 0.0: the Fisher estimator does not "
+            "blend with the previous window's IMM or an identity target; "
+            f"got imm_shrinkage_to_previous={imm_shrinkage_to_previous}"
+        )
+
     if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
         mcmc_kernel = algorithm.build_kernel(integrator)
     else:
@@ -387,6 +466,7 @@ def window_adaptation(
         target_acceptance_rate=target_acceptance_rate,
         initial_inverse_mass_matrix=initial_inverse_mass_matrix,
         imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+        diagonal_estimator=diagonal_estimator,
     )
 
     def one_step(carry, xs):
@@ -405,6 +485,7 @@ def window_adaptation(
             adaptation_state,
             adaptation_stage,
             new_state.position,
+            new_state.logdensity_grad,
             info.acceptance_rate,
         )
 

--- a/tests/adaptation/test_metric_estimators.py
+++ b/tests/adaptation/test_metric_estimators.py
@@ -814,10 +814,15 @@ class FisherScoreDiagonalFromMomentsTest(BlackJAXTest):
     """
 
     def test_agrees_with_fisher_score_diagonal_on_same_draws(self):
-        """from_moments with Welford variances must match fisher_score_diagonal.
+        """Pins the delegation invariant: fisher_score_diagonal must delegate to
+        fisher_score_diagonal_from_moments with the correct Welford variances.
 
-        This is the refactor-safety gate: the wrapper must be a thin pass-through
-        and the arithmetic must be identical (same formula, same clipping, same floor).
+        This is a refactor-safety gate for the delegation chain, not an
+        arithmetic-identity test — both sides call the same underlying function
+        so the result is identical by construction once delegation is wired
+        correctly.  The value of this test is catching a future re-inlining of
+        the math in fisher_score_diagonal (which would break the extension
+        contract documented in fisher_score_diagonal_from_moments).
         """
         n, d = 80, 5
         draws, _, cov = _make_correlated_draws(

--- a/tests/adaptation/test_metric_estimators.py
+++ b/tests/adaptation/test_metric_estimators.py
@@ -43,6 +43,7 @@ from blackjax.adaptation.metric_estimators import (
     draws_singular_value_low_rank,
     eigenvalue_informativeness,
     fisher_score_diagonal,
+    fisher_score_diagonal_from_moments,
     fisher_score_low_rank,
     sample_covariance_eigh_low_rank,
     sample_variance_diagonal,
@@ -790,6 +791,106 @@ class SampleVarianceDiagonalParityTest(BlackJAXTest):
         n, d = 30, 7
         draws = jax.random.normal(self.next_key(), (n, d))
         self.assertEqual(sample_variance_diagonal(draws).shape, (d,))
+
+
+class FisherScoreDiagonalFromMomentsTest(BlackJAXTest):
+    """Tests for fisher_score_diagonal_from_moments.
+
+    The from-moments entry point holds the core math that was formerly inlined
+    in fisher_score_diagonal.  After the bridge removal the adaption pipeline
+    (window_adaptation.base.slow_final) calls this function directly with
+    Bessel-corrected variances from _FisherMomentBlock rather than going through
+    a raw-draws wrapper.
+
+    Structural contracts:
+    - Thin-wrapper parity: fisher_score_diagonal_from_moments(var_x, var_g) must
+      agree with fisher_score_diagonal(draws, grads) when var_x and var_g are the
+      Welford-Bessel variances of the same draws/grads.
+    - Near-zero gradient variance: gradient_variance floored at 1e-10 → output finite
+      and positive.
+    - Zero position variance: output should be near 0 (but still finite/positive
+      thanks to floor and clip).
+    - Output shape and positivity.
+    """
+
+    def test_agrees_with_fisher_score_diagonal_on_same_draws(self):
+        """from_moments with Welford variances must match fisher_score_diagonal.
+
+        This is the refactor-safety gate: the wrapper must be a thin pass-through
+        and the arithmetic must be identical (same formula, same clipping, same floor).
+        """
+        n, d = 80, 5
+        draws, _, cov = _make_correlated_draws(
+            self.next_key(), n, d, scale=jnp.linspace(0.3, 2.0, d)
+        )
+        grads = _analytic_score_grads(draws, cov)
+
+        # Compute variances the same way the block accumulator would expose them.
+        var_x = welford_diagonal(draws)  # (d,) Bessel-corrected
+        var_g = welford_diagonal(grads)  # (d,)
+
+        result_from_moments = fisher_score_diagonal_from_moments(var_x, var_g)
+        result_from_draws = fisher_score_diagonal(draws, grads)
+
+        np.testing.assert_allclose(result_from_moments, result_from_draws, atol=1e-6)
+
+    def test_zero_gradient_variance_is_finite_and_positive(self):
+        """gradient_variance == 0 triggers the 1e-10 floor; output must be finite
+        and positive.  This is the near-stationary-point guard test that was
+        previously tested via _fisher_diagonal_inverse_mass directly (dropped
+        from the old branch b197f1e2 test file because that private helper was
+        deleted; re-instated here at the correct abstraction level)."""
+        d = 4
+        var_x = jnp.array([0.5, 1.0, 2.0, 0.1])
+        var_g = jnp.zeros(d)
+        result = fisher_score_diagonal_from_moments(var_x, var_g)
+        self.assertEqual(result.shape, (d,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(result))))
+        self.assertTrue(bool(jnp.all(result > 0)))
+
+    def test_mixed_zero_and_nonzero_gradient_variance(self):
+        """Per-coordinate floor: coordinates with zero gradient variance get the
+        floor-clipped output; coordinates with nonzero gradient variance get the
+        correct ratio.  This is the mixed-coordinate guard test from b197f1e2
+        (also re-instated here at the correct abstraction level)."""
+        d = 3
+        var_x = jnp.array([1.0, 4.0, 9.0])
+        var_g = jnp.array([0.0, 1.0, 0.0])  # coordinates 0 and 2 have zero grad var
+        result = fisher_score_diagonal_from_moments(var_x, var_g)
+        self.assertEqual(result.shape, (d,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(result))))
+        self.assertTrue(bool(jnp.all(result > 0)))
+        # Coordinate 1 has nonzero grad var: var_x/var_g = 4 → sigma^4 = 4 → imm = 2.0
+        np.testing.assert_allclose(float(result[1]), 2.0, atol=1e-5)
+
+    def test_known_isotropic_gaussian(self):
+        """For var_x = var_g = c, the ratio is 1 → sigma=1 → IMM=1 for all coords."""
+        d = 5
+        c = jnp.array([0.5, 1.0, 2.0, 0.1, 3.0])
+        result = fisher_score_diagonal_from_moments(c, c)
+        np.testing.assert_allclose(result, jnp.ones(d), atol=1e-6)
+
+    def test_output_shape_and_positive(self):
+        d = 7
+        var_x = jax.random.uniform(self.next_key(), (d,), minval=0.1, maxval=3.0)
+        var_g = jax.random.uniform(self.next_key(), (d,), minval=0.1, maxval=3.0)
+        result = fisher_score_diagonal_from_moments(var_x, var_g)
+        self.assertEqual(result.shape, (d,))
+        self.assertTrue(bool(jnp.all(result > 0)))
+
+    def test_extreme_ratio_stays_finite(self):
+        """Large var_x with var_g at the 1e-10 floor must produce a finite
+        positive result (clip to [1e-20, 1e20] prevents overflow).
+
+        Uses float32-safe inputs (float32 max ~3.4e38; ratio up to ~3e48
+        would overflow, so we use var_x within safe range and let the 1e-10
+        floor handle the near-zero denominator).
+        """
+        var_x = jnp.array([1e20, 1.0], dtype=jnp.float32)
+        var_g = jnp.array([0.0, 1.0], dtype=jnp.float32)  # floored at 1e-10
+        result = fisher_score_diagonal_from_moments(var_x, var_g)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(result))))
+        self.assertTrue(bool(jnp.all(result > 0)))
 
 
 if __name__ == "__main__":

--- a/tests/adaptation/test_window_adaptation_fisher_diag.py
+++ b/tests/adaptation/test_window_adaptation_fisher_diag.py
@@ -46,6 +46,15 @@ Both behaviors are now covered indirectly by
   ``state.fisher_block.count == 0`` instead of ``state.wc_state.sample_size``
   and ``state.grad_wc_state.sample_size`` (internal accumulator changed from
   two Welford states to :class:`_FisherMomentBlock`).
+- ``FisherDiagRecoveryTest.test_recovers_known_diagonal_gaussian_exactly``:
+  updated to compose the estimator call explicitly via
+  ``fisher_score_diagonal_from_moments`` instead of reading from the state
+  after ``final()``.  After the bridge removal, ``mass_matrix_adaptation``'s
+  ``final()`` only resets the block; the IMM computation is the consumer's
+  responsibility (done by ``window_adaptation.base``'s ``slow_final``).
+- ``FisherDiagNearZeroGradientTest.test_window_with_stationary_point_does_not_produce_nan``:
+  same: IMM checked via explicit ``fisher_score_diagonal_from_moments`` call
+  rather than via ``final()`` read-back.
 """
 import jax
 import jax.numpy as jnp
@@ -57,6 +66,7 @@ from blackjax.adaptation.mass_matrix import (
     MassMatrixAdaptationState,
     mass_matrix_adaptation,
 )
+from blackjax.adaptation.metric_estimators import fisher_score_diagonal_from_moments
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
 # ---------------------------------------------------------------------------
@@ -118,7 +128,9 @@ class FisherDiagValidationTest(BlackJAXTest):
 
     def test_fisher_requires_diagonal_matrix(self):
         with self.assertRaisesRegex(ValueError, "requires is_diagonal_matrix=True"):
-            mass_matrix_adaptation(is_diagonal_matrix=False, diagonal_estimator="fisher")
+            mass_matrix_adaptation(
+                is_diagonal_matrix=False, diagonal_estimator="fisher"
+            )
 
     def test_fisher_rejects_imm_shrinkage(self):
         with self.assertRaisesRegex(
@@ -132,7 +144,9 @@ class FisherDiagValidationTest(BlackJAXTest):
         def logdensity_fn(x):
             return std_normal_logdensity(x)
 
-        with self.assertRaisesRegex(ValueError, "requires is_mass_matrix_diagonal=True"):
+        with self.assertRaisesRegex(
+            ValueError, "requires is_mass_matrix_diagonal=True"
+        ):
             blackjax.window_adaptation(
                 blackjax.nuts,
                 logdensity_fn,
@@ -168,7 +182,14 @@ class FisherDiagRecoveryTest(BlackJAXTest):
         expectation), sqrt(Var[x] / Var[grad]) == true_var exactly for any
         finite sample -- no Monte-Carlo tolerance needed (verified
         empirically at n in {2_000, 5_000, 10_000} across 6 seeds: relative
-        error ~0 in every case, not a marginal/noise-limited statistic)."""
+        error ~0 in every case, not a marginal/noise-limited statistic).
+
+        NOTE: ``mass_matrix_adaptation``'s ``final()`` only resets the block;
+        it does NOT compute the new IMM.  The IMM computation is the consumer's
+        responsibility (performed by ``window_adaptation.base``'s ``slow_final``
+        on the live pipeline).  This test exercises the accumulation + estimator
+        directly via ``fisher_score_diagonal_from_moments``.
+        """
         d = 4
         true_var = jnp.array([0.1, 1.0, 4.0, 25.0])
         n = 500
@@ -176,7 +197,7 @@ class FisherDiagRecoveryTest(BlackJAXTest):
         draws = jax.random.normal(key1, (n, d)) * jnp.sqrt(true_var)
         grads = -draws / true_var
 
-        init, update, final = mass_matrix_adaptation(
+        init, update, _ = mass_matrix_adaptation(
             is_diagonal_matrix=True, diagonal_estimator="fisher"
         )
         state = init(d)
@@ -186,11 +207,15 @@ class FisherDiagRecoveryTest(BlackJAXTest):
             return update(state, x, g), None
 
         state, _ = jax.lax.scan(body, state, (draws, grads))
-        state = final(state)
 
-        np.testing.assert_allclose(
-            np.asarray(state.inverse_mass_matrix), np.asarray(true_var), rtol=1e-3
-        )
+        # Compose the estimator call explicitly (mirrors window_adaptation's slow_final).
+        block = state.fisher_block
+        denom = jnp.maximum(block.count - 1.0, 1.0)
+        var_x = block.m2_x / denom
+        var_g = block.m2_g / denom
+        imm = fisher_score_diagonal_from_moments(var_x, var_g)
+
+        np.testing.assert_allclose(np.asarray(imm), np.asarray(true_var), rtol=1e-3)
 
     def test_final_resets_accumulators(self):
         """final() must re-initialize the FisherMomentBlock so a subsequent
@@ -228,9 +253,15 @@ class FisherDiagNearZeroGradientTest(BlackJAXTest):
         """A window in which the gradient is exactly zero throughout (e.g. a
         chain sitting at a stationary point of the target, such as the
         origin of any centered/standardised density) must not poison the
-        final inverse mass matrix with NaN/Inf."""
+        final inverse mass matrix with NaN/Inf.
+
+        NOTE: ``mass_matrix_adaptation``'s ``final()`` only resets the block;
+        this test exercises the estimator path directly via
+        ``fisher_score_diagonal_from_moments`` with zero gradient variance,
+        mirroring what ``window_adaptation``'s ``slow_final`` does.
+        """
         d = 3
-        init, update, final = mass_matrix_adaptation(
+        init, update, _ = mass_matrix_adaptation(
             is_diagonal_matrix=True, diagonal_estimator="fisher"
         )
         state = init(d)
@@ -241,10 +272,16 @@ class FisherDiagNearZeroGradientTest(BlackJAXTest):
 
         positions = jax.random.normal(self.next_key(), (50, d))
         state, _ = jax.lax.scan(body, state, positions)
-        state = final(state)
 
-        self.assertTrue(bool(jnp.all(jnp.isfinite(state.inverse_mass_matrix))))
-        self.assertTrue(bool(jnp.all(state.inverse_mass_matrix > 0)))
+        # Compose the estimator call explicitly (mirrors window_adaptation's slow_final).
+        block = state.fisher_block
+        denom = jnp.maximum(block.count - 1.0, 1.0)
+        var_x = block.m2_x / denom
+        var_g = block.m2_g / denom  # zero throughout: gradient variance is zero
+        imm = fisher_score_diagonal_from_moments(var_x, var_g)
+
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
+        self.assertTrue(bool(jnp.all(imm > 0)))
 
 
 # ---------------------------------------------------------------------------
@@ -273,9 +310,7 @@ class FisherDiagEndToEndSmokeTest(BlackJAXTest):
         warmup = blackjax.window_adaptation(
             blackjax.nuts, logdensity_fn, diagonal_estimator="fisher"
         )
-        (state, parameters), _ = warmup.run(
-            warmup_key, jnp.zeros(2), num_steps=1_000
-        )
+        (state, parameters), _ = warmup.run(warmup_key, jnp.zeros(2), num_steps=1_000)
 
         self.assertTrue(bool(jnp.all(jnp.isfinite(parameters["inverse_mass_matrix"]))))
         self.assertTrue(bool(jnp.all(parameters["inverse_mass_matrix"] > 0)))

--- a/tests/adaptation/test_window_adaptation_fisher_diag.py
+++ b/tests/adaptation/test_window_adaptation_fisher_diag.py
@@ -1,0 +1,306 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for window_adaptation's opt-in Fisher-diagonal estimator
+(``diagonal_estimator="fisher"``).
+
+The Fisher-diagonal estimator replaces Welford's online covariance with the
+Fisher-divergence-minimising diagonal scale of
+:cite:p:`seyboldt2026preconditioning` (the same formula underlying Step 1 of
+``blackjax.adaptation.low_rank_adaptation._compute_low_rank_metric``):
+``inverse_mass_matrix = sqrt(Var[position] / Var[logdensity_grad])``.
+
+Ported from branch ``b197f1e2`` (``feat/window-adaptation-fisher-diag``).
+
+**Dropped tests (noted here per brief):**
+
+The following two tests from ``b197f1e2`` directly tested the private helper
+``mass_matrix._fisher_diagonal_inverse_mass``, which was deleted in the
+re-land (its body now lives exclusively in
+``metric_estimators.fisher_score_diagonal``):
+
+- ``FisherDiagNearZeroGradientTest.test_zero_gradient_variance_is_finite``
+  → called ``_fisher_diagonal_inverse_mass(jnp.array(1.0), jnp.array(0.0))``
+  directly.
+- ``FisherDiagNearZeroGradientTest.test_mixed_zero_and_nonzero_gradient_variance_per_coordinate``
+  → called ``_fisher_diagonal_inverse_mass(var_x, var_g)`` directly.
+
+Both behaviors are now covered indirectly by
+``FisherDiagNearZeroGradientTest.test_window_with_stationary_point_does_not_produce_nan``
+(system-level) and by ``tests/adaptation/test_metric_estimators.py``
+(estimator-level).
+
+**Adapted tests:**
+
+- ``FisherDiagRecoveryTest.test_final_resets_accumulators``: updated to check
+  ``state.fisher_block.count == 0`` instead of ``state.wc_state.sample_size``
+  and ``state.grad_wc_state.sample_size`` (internal accumulator changed from
+  two Welford states to :class:`_FisherMomentBlock`).
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax
+from blackjax.adaptation.mass_matrix import (
+    FisherMassMatrixAdaptationState,
+    MassMatrixAdaptationState,
+    mass_matrix_adaptation,
+)
+from tests.fixtures import BlackJAXTest, std_normal_logdensity
+
+# ---------------------------------------------------------------------------
+# (a) Default invariance: diagonal_estimator="welford" (explicit or implicit
+#     default) must reproduce the pre-existing Welford path exactly.
+# ---------------------------------------------------------------------------
+
+
+class FisherDiagDefaultInvarianceTest(BlackJAXTest):
+    def test_default_estimator_returns_plain_state_type(self):
+        """With no diagonal_estimator kwarg, mass_matrix_adaptation returns
+        the original 2-field MassMatrixAdaptationState -- not the new
+        FisherMassMatrixAdaptationState -- i.e. the state's pytree structure is
+        unchanged for existing callers."""
+        init, _, _ = mass_matrix_adaptation(is_diagonal_matrix=True)
+        state = init(3)
+        self.assertIsInstance(state, MassMatrixAdaptationState)
+        self.assertNotIsInstance(state, FisherMassMatrixAdaptationState)
+
+    def test_explicit_welford_matches_implicit_default(self):
+        """diagonal_estimator='welford' explicitly must be bit-identical to
+        omitting the kwarg entirely (mirrors the imm_shrinkage_to_previous
+        default-invariance test)."""
+
+        def logdensity_fn(x):
+            return std_normal_logdensity(x, scale=jnp.array([0.5, 1.0, 2.0]))
+
+        rng_key = jax.random.key(0)
+        warmup_default = blackjax.window_adaptation(blackjax.nuts, logdensity_fn)
+        warmup_explicit = blackjax.window_adaptation(
+            blackjax.nuts, logdensity_fn, diagonal_estimator="welford"
+        )
+
+        (_, params_default), _ = warmup_default.run(
+            rng_key, jnp.zeros(3), num_steps=200
+        )
+        (_, params_explicit), _ = warmup_explicit.run(
+            rng_key, jnp.zeros(3), num_steps=200
+        )
+
+        np.testing.assert_array_equal(
+            params_default["step_size"], params_explicit["step_size"]
+        )
+        np.testing.assert_array_equal(
+            params_default["inverse_mass_matrix"],
+            params_explicit["inverse_mass_matrix"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Construction-time validation
+# ---------------------------------------------------------------------------
+
+
+class FisherDiagValidationTest(BlackJAXTest):
+    def test_invalid_estimator_name_raises(self):
+        with self.assertRaisesRegex(ValueError, "diagonal_estimator must be"):
+            mass_matrix_adaptation(diagonal_estimator="bogus")
+
+    def test_fisher_requires_diagonal_matrix(self):
+        with self.assertRaisesRegex(ValueError, "requires is_diagonal_matrix=True"):
+            mass_matrix_adaptation(is_diagonal_matrix=False, diagonal_estimator="fisher")
+
+    def test_fisher_rejects_imm_shrinkage(self):
+        with self.assertRaisesRegex(
+            ValueError, "does not support imm_shrinkage_to_previous"
+        ):
+            mass_matrix_adaptation(
+                diagonal_estimator="fisher", imm_shrinkage_to_previous=5.0
+            )
+
+    def test_window_adaptation_propagates_dense_validation(self):
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        with self.assertRaisesRegex(ValueError, "requires is_mass_matrix_diagonal=True"):
+            blackjax.window_adaptation(
+                blackjax.nuts,
+                logdensity_fn,
+                is_mass_matrix_diagonal=False,
+                diagonal_estimator="fisher",
+            )
+
+    def test_window_adaptation_propagates_shrinkage_validation(self):
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        with self.assertRaisesRegex(
+            ValueError, "does not support imm_shrinkage_to_previous"
+        ):
+            blackjax.window_adaptation(
+                blackjax.nuts,
+                logdensity_fn,
+                diagonal_estimator="fisher",
+                imm_shrinkage_to_previous=10.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# (b) Fisher-diag recovery on a known diagonal Gaussian.
+# ---------------------------------------------------------------------------
+
+
+class FisherDiagRecoveryTest(BlackJAXTest):
+    def test_recovers_known_diagonal_gaussian_exactly(self):
+        """For X ~ N(0, diag(true_var)), the log-density gradient is the
+        *exact* linear map grad = -x / true_var. Because Var[c*X] == c**2 *
+        Var[X] holds exactly for the *sample* variance (not just in
+        expectation), sqrt(Var[x] / Var[grad]) == true_var exactly for any
+        finite sample -- no Monte-Carlo tolerance needed (verified
+        empirically at n in {2_000, 5_000, 10_000} across 6 seeds: relative
+        error ~0 in every case, not a marginal/noise-limited statistic)."""
+        d = 4
+        true_var = jnp.array([0.1, 1.0, 4.0, 25.0])
+        n = 500
+        key1, _ = jax.random.split(self.next_key())
+        draws = jax.random.normal(key1, (n, d)) * jnp.sqrt(true_var)
+        grads = -draws / true_var
+
+        init, update, final = mass_matrix_adaptation(
+            is_diagonal_matrix=True, diagonal_estimator="fisher"
+        )
+        state = init(d)
+
+        def body(state, xs):
+            x, g = xs
+            return update(state, x, g), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+        state = final(state)
+
+        np.testing.assert_allclose(
+            np.asarray(state.inverse_mass_matrix), np.asarray(true_var), rtol=1e-3
+        )
+
+    def test_final_resets_accumulators(self):
+        """final() must re-initialize the FisherMomentBlock so a subsequent
+        window starts from scratch, mirroring the Welford path's own reset
+        semantics.
+
+        Adapted from b197f1e2: the old branch checked state.wc_state.sample_size
+        and state.grad_wc_state.sample_size (two separate Welford states). The
+        new accumulator is a _FisherMomentBlock whose count must be 0 after
+        final().
+        """
+        d = 3
+        init, update, final = mass_matrix_adaptation(
+            is_diagonal_matrix=True, diagonal_estimator="fisher"
+        )
+        state = init(d)
+        state = update(state, jnp.ones(d), jnp.ones(d))
+        state = final(state)
+        self.assertIsInstance(state, FisherMassMatrixAdaptationState)
+        self.assertEqual(int(state.fisher_block.count), 0)
+
+
+# ---------------------------------------------------------------------------
+# (c) Near-zero-gradient robustness -- system-level test via mass_matrix_adaptation.
+#
+# Tests for _fisher_diagonal_inverse_mass(var_x, var_g) directly from b197f1e2
+# are DROPPED here because that private helper was removed; its body lives only
+# in metric_estimators.fisher_score_diagonal and is tested in
+# tests/adaptation/test_metric_estimators.py.
+# ---------------------------------------------------------------------------
+
+
+class FisherDiagNearZeroGradientTest(BlackJAXTest):
+    def test_window_with_stationary_point_does_not_produce_nan(self):
+        """A window in which the gradient is exactly zero throughout (e.g. a
+        chain sitting at a stationary point of the target, such as the
+        origin of any centered/standardised density) must not poison the
+        final inverse mass matrix with NaN/Inf."""
+        d = 3
+        init, update, final = mass_matrix_adaptation(
+            is_diagonal_matrix=True, diagonal_estimator="fisher"
+        )
+        state = init(d)
+        zero_grad = jnp.zeros(d)
+
+        def body(state, position):
+            return update(state, position, zero_grad), None
+
+        positions = jax.random.normal(self.next_key(), (50, d))
+        state, _ = jax.lax.scan(body, state, positions)
+        state = final(state)
+
+        self.assertTrue(bool(jnp.all(jnp.isfinite(state.inverse_mass_matrix))))
+        self.assertTrue(bool(jnp.all(state.inverse_mass_matrix > 0)))
+
+
+# ---------------------------------------------------------------------------
+# (d) End-to-end smoke: NUTS + window_adaptation(diagonal_estimator="fisher")
+#     on a small correlated Gaussian.
+# ---------------------------------------------------------------------------
+
+
+class FisherDiagEndToEndSmokeTest(BlackJAXTest):
+    def test_nuts_with_fisher_diag_on_correlated_gaussian(self):
+        """2-D correlated Gaussian (var 4/1, rho=0.7 -- same control target
+        as the low-rank adaptation tests). The Fisher-diagonal estimator
+        only ever produces a *diagonal* metric, so it cannot capture the
+        correlation -- that is expected, not a bug. This test only checks
+        that warmup + sampling run to completion with finite output and a
+        sane acceptance rate, and that the (marginal) diagonal variances
+        recovered are in the right ballpark."""
+        rho = 0.7
+        cov = jnp.array([[4.0, rho * 2.0], [rho * 2.0, 1.0]])
+        precision = jnp.linalg.inv(cov)
+
+        def logdensity_fn(x):
+            return -0.5 * x @ precision @ x
+
+        warmup_key, inference_key = jax.random.split(self.next_key())
+        warmup = blackjax.window_adaptation(
+            blackjax.nuts, logdensity_fn, diagonal_estimator="fisher"
+        )
+        (state, parameters), _ = warmup.run(
+            warmup_key, jnp.zeros(2), num_steps=1_000
+        )
+
+        self.assertTrue(bool(jnp.all(jnp.isfinite(parameters["inverse_mass_matrix"]))))
+        self.assertTrue(bool(jnp.all(parameters["inverse_mass_matrix"] > 0)))
+        self.assertTrue(bool(jnp.isfinite(parameters["step_size"])))
+        self.assertGreater(float(parameters["step_size"]), 0.0)
+
+        # Marginal variances (diag(cov) = [4.0, 1.0]) recovered within a
+        # generous factor-of-3 band -- a diagonal-only estimator on a
+        # correlated target is not expected to be precise, only sane.
+        np.testing.assert_allclose(
+            np.asarray(parameters["inverse_mass_matrix"]),
+            np.array([4.0, 1.0]),
+            rtol=2.0,
+        )
+
+        nuts = blackjax.nuts(logdensity_fn, **parameters)
+        keys = jax.random.split(inference_key, 500)
+
+        def one_step(state, key):
+            state, info = nuts.step(key, state)
+            return state, info
+
+        final_state, infos = jax.lax.scan(one_step, state, keys)
+
+        self.assertTrue(bool(jnp.all(jnp.isfinite(final_state.position))))
+        mean_acceptance = jnp.mean(infos.acceptance_rate)
+        self.assertTrue(bool(jnp.isfinite(mean_acceptance)))
+        self.assertGreater(float(mean_acceptance), 0.3)

--- a/tests/adaptation/test_window_adaptation_fisher_diag.py
+++ b/tests/adaptation/test_window_adaptation_fisher_diag.py
@@ -237,6 +237,76 @@ class FisherDiagRecoveryTest(BlackJAXTest):
         self.assertIsInstance(state, FisherMassMatrixAdaptationState)
         self.assertEqual(int(state.fisher_block.count), 0)
 
+    def test_gradient_wire_accumulates_into_m2_g_not_m2_x(self):
+        """The gradient plumbing must feed grad into m2_g and position into
+        m2_x -- not the same buffer.  Failure mode: if grad is silently
+        replaced by position (e.g. ``update(state, position, position)``), the
+        block would hold Var[x] in BOTH m2_x and m2_g, so the ratio would be
+        identically 1.0 and the test would still pass -- this test closes that
+        gap by constructing a batch where Var[x] ≠ Var[g] by a known factor
+        and asserting the accumulated m2_g matches Var[g], not Var[x].
+
+        Failure modes caught:
+        - Severed gradient wire (grads := draws) → m2_g == m2_x → ratio = 1.
+        - Inverted ratio (m2_x used as m2_g) → imm ≈ 1/true_var instead of
+          true_var.
+        - Read-after-reset (m2_g = 0 from a reset block) → ratio = inf/max(0,
+          1e-10) → clipped constant, not true_var.
+        """
+        d = 3
+        # Use Var[x] = 4 * Var[g] so the ratio Var[x]/Var[g] = 4 per coordinate
+        # and IMM = sqrt(4) = 2 per coordinate -- distinct from 1 and from 1/2.
+        n = 1_000
+        key = self.next_key()
+        base = jax.random.normal(key, (n, d))
+        draws = base * 2.0  # Var[x] ≈ 4 per coord
+        grads = base * 1.0  # Var[g] ≈ 1 per coord  (same base → ratio exact = 4)
+
+        init, update, _ = mass_matrix_adaptation(
+            is_diagonal_matrix=True, diagonal_estimator="fisher"
+        )
+        state = init(d)
+
+        def body(state, xs):
+            x, g = xs
+            return update(state, x, g), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+
+        block = state.fisher_block
+        denom = jnp.maximum(block.count - 1.0, 1.0)
+        var_x_acc = block.m2_x / denom
+        var_g_acc = block.m2_g / denom
+
+        # Since draws = 2 * base and grads = 1 * base (same base), the
+        # sample variance ratio is ALGEBRAICALLY exact: var_x = 4 * var_g
+        # regardless of the realised sample variance of base.
+        np.testing.assert_allclose(
+            np.asarray(var_x_acc / var_g_acc),
+            np.ones(d) * 4.0,
+            rtol=1e-4,
+            err_msg="var_x / var_g must be exactly 4 (draws = 2 * grads)",
+        )
+
+        # Confirm the gradient buffer is the smaller one (~1), not the larger
+        # one (~4).  rtol=0.2 handles n=1_000 sampling noise (std error ~0.045)
+        # while excluding the wrong-buffer failure (which would give ~4 here).
+        np.testing.assert_allclose(
+            np.asarray(var_g_acc),
+            np.ones(d),
+            rtol=0.2,
+            err_msg="m2_g must accumulate gradient variance (≈1), not position variance (≈4)",
+        )
+
+        # The IMM must be sqrt(var_x/var_g) = sqrt(4) = 2 exactly.
+        imm = fisher_score_diagonal_from_moments(var_x_acc, var_g_acc)
+        np.testing.assert_allclose(
+            np.asarray(imm),
+            np.ones(d) * 2.0,
+            rtol=1e-4,
+            err_msg="IMM should be sqrt(Var[x]/Var[g]) = sqrt(4) = 2.0 exactly",
+        )
+
 
 # ---------------------------------------------------------------------------
 # (c) Near-zero-gradient robustness -- system-level test via mass_matrix_adaptation.
@@ -293,15 +363,34 @@ class FisherDiagNearZeroGradientTest(BlackJAXTest):
 class FisherDiagEndToEndSmokeTest(BlackJAXTest):
     def test_nuts_with_fisher_diag_on_correlated_gaussian(self):
         """2-D correlated Gaussian (var 4/1, rho=0.7 -- same control target
-        as the low-rank adaptation tests). The Fisher-diagonal estimator
-        only ever produces a *diagonal* metric, so it cannot capture the
-        correlation -- that is expected, not a bug. This test only checks
-        that warmup + sampling run to completion with finite output and a
-        sane acceptance rate, and that the (marginal) diagonal variances
-        recovered are in the right ballpark."""
+        as the low-rank adaptation tests).
+
+        The Fisher-diagonal estimator converges to
+            IMM[i] = sqrt(Var[x_i] / Var[∇log p_i])
+        For X ~ N(0, cov) with precision = cov^{-1}:
+            Var[x_i] = cov[i,i]
+            Var[(precision @ x)[i]] = (precision @ cov @ precision)[i,i] = precision[i,i]
+            → IMM[i] = sqrt(cov[i,i] / precision[i,i])
+
+        For rho=0.7: cov=[[4, 1.4],[1.4, 1]], det=2.04,
+        precision[0,0]=1/2.04≈0.490, precision[1,1]=4/2.04≈1.961.
+        Analytic target: [sqrt(4/0.490), sqrt(1/1.961)] ≈ [2.857, 0.714].
+
+        **Why not diag(cov)=[4,1]:** the Fisher estimator minimises the
+        Fisher divergence between the true density and a Gaussian with the
+        given diagonal metric, which is NOT the same as matching marginal
+        variances. Asserting against diag(cov) is wrong and vacuous (the
+        rtol=2.0 band covers [1,12] × [0.33, 3] -- too wide to catch
+        severed gradient wires, inverted ratios, or read-after-reset).
+        """
         rho = 0.7
         cov = jnp.array([[4.0, rho * 2.0], [rho * 2.0, 1.0]])
         precision = jnp.linalg.inv(cov)
+
+        # Analytic Fisher-diagonal target: sqrt(diag(cov) / diag(precision)).
+        # For symmetric precision matrix P: Var[Px]_i = (P cov P)[i,i] = P[i,i]
+        # (since P·cov = I → P·cov·P = P), so the analytic target is below.
+        analytic_imm = jnp.sqrt(jnp.diag(cov) / jnp.diag(precision))
 
         def logdensity_fn(x):
             return -0.5 * x @ precision @ x
@@ -317,13 +406,14 @@ class FisherDiagEndToEndSmokeTest(BlackJAXTest):
         self.assertTrue(bool(jnp.isfinite(parameters["step_size"])))
         self.assertGreater(float(parameters["step_size"]), 0.0)
 
-        # Marginal variances (diag(cov) = [4.0, 1.0]) recovered within a
-        # generous factor-of-3 band -- a diagonal-only estimator on a
-        # correlated target is not expected to be precise, only sane.
+        # Assert against the correct analytic target with rtol=0.3.
+        # This band is tight enough to catch: grads:=draws (gives [1,1]),
+        # inverted ratio (gives [0.35,1.4]), and read-after-reset (gives a
+        # clipped constant) — all of which lie outside [0.7×analytic, 1.3×analytic].
         np.testing.assert_allclose(
             np.asarray(parameters["inverse_mass_matrix"]),
-            np.array([4.0, 1.0]),
-            rtol=2.0,
+            np.asarray(analytic_imm),
+            rtol=0.3,
         )
 
         nuts = blackjax.nuts(logdensity_fn, **parameters)


### PR DESCRIPTION
## What

Adds `diagonal_estimator="fisher"` as an opt-in alternative to the default
`"welford"` path in `window_adaptation`.  The Fisher estimator targets
`IMM[i] = sqrt(Var[x_i] / Var[∇ log p_i])` — the Fisher-divergence-minimising
diagonal preconditioning from [seyboldt2026preconditioning] — and is activated
by passing `diagonal_estimator="fisher"` to `blackjax.window_adaptation`.

## Changes

- **`blackjax/adaptation/metric_buffers.py`** — adds `_FisherMomentBlock`
  (count, mean\_x, m2\_x, mean\_g, m2\_g), `_fisher_block_init`, and
  `_fisher_block_update_one` (Welford-online update for position and gradient
  simultaneously).

- **`blackjax/adaptation/metric_estimators.py`** — adds
  `fisher_score_diagonal_from_moments(variance, gradient_variance)`, a
  pure-moments entry point that computes `IMM = sigma²` where
  `sigma = clip(sqrt(clip(variance / max(gradient_variance, ε), 0)), 1e-20, 1e20)`.
  Refactors `fisher_score_diagonal` to a thin wrapper around it.  Exported in
  `__all__`.

- **`blackjax/adaptation/mass_matrix.py`** — adds
  `FisherMassMatrixAdaptationState(inverse_mass_matrix, fisher_block)` and
  dispatches `mass_matrix_adaptation(diagonal_estimator=...)` at Python level
  (factory time, zero JAX overhead).

- **`blackjax/adaptation/window_adaptation.py`** — adds two `slow_final`
  closures (welford / fisher), types `imm_state` as a union, computes
  `fisher_score_diagonal_from_moments` from accumulated moments in the
  consumer layer (avoids the mass\_matrix → metric\_estimators import cycle).

- **`tests/adaptation/test_window_adaptation_fisher_diag.py`** (new) — 12
  tests: validation guards, default-path bit-exact invariance, accumulator
  reset, gradient-wire pin, near-zero gradient safety, and an E2E smoke test
  on a correlated Gaussian with analytic target
  `sqrt(diag(cov) / diag(precision))`.

- **`tests/adaptation/test_metric_estimators.py`** — adds
  `FisherScoreDiagonalFromMomentsTest` (6 tests) and updates the delegation
  docstring.

## Design constraints honoured

- Default `"welford"` path is bit-exact unchanged; `grad` variable is dead
  (`del`) on that branch so JAX never traces it.
- No module-level import cycle: the estimator call lives in
  `window_adaptation.py` (consumer layer), not in `mass_matrix.py`.
- No synthetic batch bridge: `final()` resets the block and returns it;
  moment-to-IMM conversion is done once, in the consumer, at window boundary.
- `_fisher_block_merge` was deleted (never called, never tested, landmine).

## Test results

Full suite: **1500 passed, 1 skipped** (`JAX_PLATFORM_NAME=cpu uv run pytest -n 2 -q --benchmark-disable tests`).