### PR TITLE
Add a staged warmup engine with a metric-recipe registry

### DIFF
--- a/blackjax/__init__.py
+++ b/blackjax/__init__.py
@@ -11,6 +11,7 @@ from .adaptation.mclmc_adaptation import mclmc_find_L_and_step_size
 from .adaptation.mclmc_lrd_adaptation import mclmc_lrd_warmup
 from .adaptation.meads_adaptation import meads_adaptation
 from .adaptation.pathfinder_adaptation import pathfinder_adaptation
+from .adaptation.staged_adaptation import staged_adaptation
 from .adaptation.window_adaptation import window_adaptation
 from .base import SamplingAlgorithm, VIAlgorithm
 from .diagnostics import effective_sample_size as ess
@@ -280,6 +281,7 @@ __all__ = [
     "multinomial_hmc",  # backward-compatible alias for mhmc
     "dynamic_hmc",  # backward-compatible alias for dhmc
     "barker_proposal",  # backward-compatible alias for barker
+    "staged_adaptation",  # composable staged warmup engine
     "window_adaptation",  # mcmc adaptation
     "window_adaptation_low_rank",
     "meads_adaptation",

--- a/blackjax/adaptation/mass_matrix.py
+++ b/blackjax/adaptation/mass_matrix.py
@@ -99,7 +99,8 @@ class FisherMassMatrixAdaptationState(NamedTuple):
     This state type accumulates the moments needed to compute those per-window
     variances without storing raw draw arrays.  The IMM computation is
     deliberately NOT performed inside ``mass_matrix_adaptation``'s ``final()``
-    — it is composed by the consumer (:func:`~blackjax.adaptation.window_adaptation.base`)
+    — it is composed by the consumer
+    (:func:`~blackjax.adaptation.metric_recipes._build_fisher_diag_core`)
     to avoid a circular import between this module and ``metric_estimators``.
     """
 
@@ -307,8 +308,9 @@ def mass_matrix_adaptation(
         This separation avoids a circular import
         (``metric_estimators`` imports ``welford_algorithm`` from this module,
         so this module must not import from ``metric_estimators``).
-        :func:`~blackjax.adaptation.window_adaptation.base` composes the
-        estimator call in its ``slow_final`` closure for the Fisher path.
+        :func:`~blackjax.adaptation.metric_recipes._build_fisher_diag_core`
+        composes the estimator call in its ``final`` closure for the Fisher
+        path.
 
         **Welford path**: the IMM is regularized as a convex combination of
         this window's empirical covariance (weight: ``count / denom``), the
@@ -321,7 +323,7 @@ def mass_matrix_adaptation(
         """
         if isinstance(mm_state, FisherMassMatrixAdaptationState):
             # Reset the block for the next window; pass the existing IMM through
-            # unchanged (the consumer — window_adaptation.base's slow_final —
+            # unchanged (the consumer — metric_recipes._build_fisher_diag_core.final —
             # reads the block variances BEFORE this call and stitches in the
             # new IMM after the reset).
             ndims = mm_state.fisher_block.m2_x.shape[0]

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -13,6 +13,30 @@
 # limitations under the License.
 """Metric recipes and the embeddable MetricCore protocol for staged_adaptation.
 
+Available recipes
+-----------------
+Pass any of the following string names as the ``metric=`` argument to
+:func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`:
+
+- ``"welford_diag"`` — Stan-default diagonal Welford estimator; reproduces
+  :func:`~blackjax.adaptation.window_adaptation.window_adaptation` exactly.
+- ``"welford_dense"`` — Dense Welford covariance, same Stan schedule.
+- ``"fisher_diag"`` — Fisher-divergence-minimising diagonal estimator
+  (situational; requires position *and* gradient samples; see registry
+  provenance note for operational guidance).
+
+Usage::
+
+    # String sugar (registry lookup):
+    wu = staged_adaptation(nuts, logdensity_fn, metric="welford_diag")
+
+    # Recipe constructor (testability / custom configuration):
+    from blackjax.adaptation.metric_recipes import REGISTRY
+    core = REGISTRY["welford_diag"].build_core(imm_shrinkage_to_previous=5.0)
+    wu = staged_adaptation(nuts, logdensity_fn, metric=core)
+
+Design
+------
 A :class:`MetricRecipe` declares an (estimator, buffer, representation,
 support_gate) tuple with construction-time validation of the coupling
 contract (``needs ⊆ provides`` and ``emits == representation``): incompatible
@@ -33,24 +57,6 @@ Layer doctrine:
   adapted metric, so the step-size and metric adaptation are decoupled.  A
   ``diag_reference`` accessor will be added in the low-rank slice where this
   independence no longer holds.
-
-Registry (this slice):
-
-- ``"welford_diag"`` — Stan-default; reproduces :func:`window_adaptation`
-  exactly.
-- ``"welford_dense"`` — dense covariance, same Stan schedule.
-- ``"fisher_diag"`` — Fisher-divergence-minimising diagonal estimator;
-  situational; see registry provenance note for operational guidance.
-
-Usage::
-
-    # String sugar (registry lookup):
-    wu = staged_adaptation(nuts, logdensity_fn, metric="welford_diag")
-
-    # Recipe constructor (testability / custom configuration):
-    from blackjax.adaptation.metric_recipes import REGISTRY
-    core = REGISTRY["welford_diag"].build_core(imm_shrinkage_to_previous=5.0)
-    wu = staged_adaptation(nuts, logdensity_fn, metric=core)
 
 Notes
 -----

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -1,0 +1,467 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Metric recipes and the embeddable MetricCore protocol for staged_adaptation.
+
+A :class:`MetricRecipe` declares an (estimator, buffer, representation,
+support_gate) tuple with construction-time validation of the coupling
+contract (``needs ⊆ provides`` and ``emits == representation``): incompatible
+combos fail at Python level with a clear message, never inside traced code.
+
+A :class:`MetricCore` is the embeddable mass-matrix adaptation component —
+the separable piece that the staged_adaptation engine hosts.  Step-size
+dual averaging and the stage schedule are HOST-layer concerns; this core
+handles only the inverse-mass-matrix estimation.
+
+Layer doctrine:
+
+- The METRIC CORE (:class:`MetricCore`) handles mass-matrix tuning only.
+- Step-size adaptation and the stage schedule live in the HOST
+  (:mod:`~blackjax.adaptation.staged_adaptation`).
+- Step-size proxy independence: for diag/dense representations (this slice),
+  the dual-averaging acceptance-rate proxy is not an eigenvalue proxy of the
+  adapted metric, so the step-size and metric adaptation are decoupled.  A
+  ``diag_reference`` accessor will be added in the low-rank slice where this
+  independence no longer holds.
+
+Registry (this slice):
+
+- ``"welford_diag"`` — Stan-default; reproduces :func:`window_adaptation`
+  exactly.
+- ``"welford_dense"`` — dense covariance, same Stan schedule.
+- ``"fisher_diag"`` — Fisher-divergence-minimising diagonal estimator;
+  situational; see registry provenance note for operational guidance.
+
+Usage::
+
+    # String sugar (registry lookup):
+    wu = staged_adaptation(nuts, logdensity_fn, metric="welford_diag")
+
+    # Recipe constructor (testability / custom configuration):
+    from blackjax.adaptation.metric_recipes import REGISTRY
+    core = REGISTRY["welford_diag"].build_core(imm_shrinkage_to_previous=5.0)
+    wu = staged_adaptation(nuts, logdensity_fn, metric=core)
+
+Notes
+-----
+The :class:`MetricRecipe` schema (field types) is provisional:
+estimator/buffer/support_gate are currently string tags.  Future slices will
+replace these with proper constructor objects once the schema is stable across
+all recipe families.  Import directly from ``blackjax.adaptation.metric_recipes``
+— :class:`MetricRecipe` is not exported at the ``blackjax`` top level.
+"""
+import dataclasses
+from typing import Callable, NamedTuple
+
+import jax.numpy as jnp
+
+from blackjax.adaptation.mass_matrix import (
+    FisherMassMatrixAdaptationState,
+    MassMatrixAdaptationState,
+    mass_matrix_adaptation,
+)
+from blackjax.adaptation.metric_estimators import fisher_score_diagonal_from_moments
+from blackjax.types import Array, ArrayLikeTree
+
+__all__ = [
+    "MetricCore",
+    "MetricRecipe",
+    "REGISTRY",
+    "lookup_recipe",
+]
+
+
+# ---------------------------------------------------------------------------
+# MetricCore — the embeddable init/update/final protocol
+# ---------------------------------------------------------------------------
+
+
+class MetricCore(NamedTuple):
+    """Embeddable mass-matrix adaptation core: init/update/final protocol.
+
+    A NamedTuple-of-callables (house style) bundling the three operations that
+    together constitute mass-matrix adaptation.  The engine hosts this core;
+    step-size adaptation and the stage schedule remain in the host layer.
+
+    This core is hostable by warmups that declare no intrinsic metric adaptation
+    scheme (i.e. the metric core can be swapped without changing the host's step-
+    size or schedule logic).  It is NOT wired into MEADS, whose fold-based metric
+    is co-designed with its damping and step rules and cannot be factored out.
+
+    Parameters
+    ----------
+    init : Callable
+        ``(n_dims: int) -> MetricCoreState``.  Creates the initial mass-matrix
+        adaptation state.  Closes over ``initial_inverse_mass_matrix`` and
+        ``imm_shrinkage_to_previous`` when constructed via
+        :meth:`MetricRecipe.build_core`.
+    update : Callable
+        ``(state, position: ArrayLikeTree, grad: ArrayLikeTree | None) -> MetricCoreState``.
+        Accumulates one sample.  For welford-path recipes ``grad`` is accepted
+        (interface uniformity) but ignored.
+    final : Callable
+        ``(state) -> MetricCoreState``.  Called at each slow-window boundary:
+        computes the new inverse mass matrix, writes it to
+        ``state.inverse_mass_matrix``, resets the accumulator.  The host
+        reads ``new_state.inverse_mass_matrix`` for the next window.
+
+    Notes
+    -----
+    ``MetricCoreState`` is one of
+    :class:`~blackjax.adaptation.mass_matrix.MassMatrixAdaptationState` or
+    :class:`~blackjax.adaptation.mass_matrix.FisherMassMatrixAdaptationState` —
+    the existing in-tree types; this core is a thin protocol wrapper, not a
+    re-implementation.
+    """
+
+    init: Callable
+    update: Callable
+    final: Callable
+
+
+# ---------------------------------------------------------------------------
+# MetricRecipe — frozen dataclass with construction-time validation
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class MetricRecipe:
+    """Configuration bundle for a mass-matrix adaptation recipe.
+
+    Declares an (estimator, buffer, representation, support_gate) tuple with
+    construction-time validation of the coupling contract (``needs ⊆ provides``
+    and ``emits == representation``): incompatible combos fail at Python level
+    with a clear message, never inside traced code.
+
+    .. note::
+
+        **Schema is provisional.**  The field types for ``estimator``,
+        ``buffer``, and ``support_gate`` are string tags; future slices will
+        replace these with proper constructor objects once the schema is stable
+        across all recipe families.  This class is not exported at the
+        ``blackjax`` top level — import directly from
+        ``blackjax.adaptation.metric_recipes``.
+
+    Parameters
+    ----------
+    representation
+        The inverse-mass-matrix representation this recipe produces.
+        Slice-1 values: ``"diag"`` (1D array) or ``"dense"`` (2D array).
+    estimator
+        String tag for the estimator function family.
+        Slice-1 values: ``"welford"``, ``"fisher_diag"``.
+    buffer
+        String tag for the buffer/data-feeding policy.
+        Slice-1 value: ``"reset_window"``.
+    support_gate
+        String tag for the support gate, or ``None`` (slice-1 default — no
+        gating beyond the estimator's intrinsic validation).
+    needs
+        ``frozenset[str]`` declaring what data the estimator requires from the
+        buffer.  Validated at construction: ``needs ⊆ provides``.
+        Slice-1 values: ``frozenset({"positions"})`` or
+        ``frozenset({"positions", "gradients"})``.
+    provides
+        ``frozenset[str]`` declaring what data the buffer provides.
+    emits
+        Representation tag this estimator emits.  Validated at construction:
+        ``emits == representation``.
+    provenance
+        Human-readable guidance string, stamped with benchmark evidence where
+        available.
+    """
+
+    representation: str
+    estimator: str
+    buffer: str
+    support_gate: str | None
+    needs: frozenset
+    provides: frozenset
+    emits: str
+    provenance: str
+
+    def __post_init__(self) -> None:
+        """Validate coupling contract at construction time."""
+        if not self.needs <= self.provides:
+            missing = sorted(self.needs - self.provides)
+            raise ValueError(
+                f"MetricRecipe coupling violation: estimator needs {missing} "
+                f"but the buffer only provides {sorted(self.provides)}. "
+                f"Choose a buffer that provides the missing data, or choose a "
+                f"compatible estimator that does not need {missing}."
+            )
+        if self.emits != self.representation:
+            raise ValueError(
+                f"MetricRecipe coupling violation: estimator emits {self.emits!r} "
+                f"but recipe declares representation {self.representation!r}. "
+                f"Choose an estimator whose emits tag matches the declared "
+                f"representation, or update representation to {self.emits!r}."
+            )
+
+    def build_core(
+        self,
+        *,
+        imm_shrinkage_to_previous: float = 0.0,
+        initial_inverse_mass_matrix: Array | None = None,
+    ) -> MetricCore:
+        """Build an embeddable :class:`MetricCore` from this recipe.
+
+        Parameters
+        ----------
+        imm_shrinkage_to_previous
+            Pseudo-count controlling shrinkage of the per-window IMM toward the
+            previous window's IMM.  Default ``0.0`` (Stan vanilla, no
+            persistence).  Forwarded to
+            :func:`~blackjax.adaptation.mass_matrix.mass_matrix_adaptation`.
+            Not supported for ``"fisher_diag"`` (``ValueError`` there per
+            ``mass_matrix_adaptation``'s validation).
+        initial_inverse_mass_matrix
+            Optional seed array for the initial inverse mass matrix.  ``None``
+            (default) uses the standard identity initialisation (``ones(d)``
+            for diagonal, ``identity(d)`` for dense).
+
+        Returns
+        -------
+        MetricCore
+            Embeddable init/update/final bundle ready for the engine.
+
+        Raises
+        ------
+        ValueError
+            If the estimator tag is not supported by this slice.
+        """
+        if self.estimator == "welford":
+            is_diagonal = self.representation == "diag"
+            return _build_welford_core(
+                is_diagonal=is_diagonal,
+                imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+                initial_inverse_mass_matrix=initial_inverse_mass_matrix,
+            )
+        elif self.estimator == "fisher_diag":
+            return _build_fisher_diag_core(
+                initial_inverse_mass_matrix=initial_inverse_mass_matrix,
+            )
+        else:
+            raise ValueError(
+                f"Unknown estimator tag {self.estimator!r} in MetricRecipe.build_core. "
+                f"Slice-1 supports 'welford' and 'fisher_diag'."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Private core builders
+# ---------------------------------------------------------------------------
+
+
+def _build_welford_core(
+    *,
+    is_diagonal: bool,
+    imm_shrinkage_to_previous: float,
+    initial_inverse_mass_matrix: Array | None,
+) -> MetricCore:
+    """Build a MetricCore wrapping the Welford (Stan-default) estimator path.
+
+    Delegates to :func:`~blackjax.adaptation.mass_matrix.mass_matrix_adaptation`
+    with ``diagonal_estimator='welford'``.  The MetricCore ``final()`` calls
+    ``mm_final`` directly — same reduction order, same arithmetic, bit-exact.
+
+    Parameters
+    ----------
+    is_diagonal
+        ``True`` for diagonal (``welford_diag``), ``False`` for dense
+        (``welford_dense``).
+    imm_shrinkage_to_previous
+        Forwarded to ``mass_matrix_adaptation``.
+    initial_inverse_mass_matrix
+        Optional seed IMM; closed over in ``init``.
+    """
+    mm_init, mm_update, mm_final = mass_matrix_adaptation(
+        is_diagonal_matrix=is_diagonal,
+        imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+        diagonal_estimator="welford",
+    )
+
+    def init(n_dims: int) -> MassMatrixAdaptationState:
+        return mm_init(n_dims, initial_inverse_mass_matrix)
+
+    def update(
+        state: MassMatrixAdaptationState,
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree | None = None,
+    ) -> MassMatrixAdaptationState:
+        # grad is accepted for interface uniformity but ignored by mm_update
+        # on the welford path (mm_update only reads grad for
+        # FisherMassMatrixAdaptationState — checked via isinstance at trace time).
+        return mm_update(state, position, grad)
+
+    def final(state: MassMatrixAdaptationState) -> MassMatrixAdaptationState:
+        # Directly calls mm_final: same Welford reduction, same regularization
+        # formula — bit-exact vs the current window_adaptation.base() path.
+        return mm_final(state)
+
+    return MetricCore(init=init, update=update, final=final)
+
+
+def _build_fisher_diag_core(
+    *,
+    initial_inverse_mass_matrix: Array | None,
+) -> MetricCore:
+    """Build a MetricCore wrapping the Fisher-diagonal estimator path.
+
+    Delegates to :func:`~blackjax.adaptation.mass_matrix.mass_matrix_adaptation`
+    with ``diagonal_estimator='fisher'`` for ``init`` and ``update``.  The
+    ``final()`` below composes the IMM computation and block reset — logic
+    that cannot live inside ``mass_matrix_adaptation.final()`` due to a
+    circular import (``metric_estimators`` imports ``welford_algorithm``
+    from ``mass_matrix``).
+
+    .. note::
+
+        **Twin implementation alert (stitch #1 of 2).**  The Fisher IMM
+        computation + block-reset stitch in ``final()`` is also present in
+        :func:`~blackjax.adaptation.window_adaptation.base`'s ``slow_final``
+        closure (fisher path).  These two copies must stay in sync until
+        ``base()``'s disposition is decided (retire or rewire through the
+        engine).  See the comment at the matching site in
+        ``window_adaptation.base``.
+
+    Parameters
+    ----------
+    initial_inverse_mass_matrix
+        Optional seed IMM; closed over in ``init``.
+    """
+    mm_init, mm_update, mm_final = mass_matrix_adaptation(
+        is_diagonal_matrix=True,
+        imm_shrinkage_to_previous=0.0,
+        diagonal_estimator="fisher",
+    )
+
+    def init(n_dims: int) -> FisherMassMatrixAdaptationState:
+        return mm_init(n_dims, initial_inverse_mass_matrix)
+
+    def update(
+        state: FisherMassMatrixAdaptationState,
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree | None = None,
+    ) -> FisherMassMatrixAdaptationState:
+        return mm_update(state, position, grad)
+
+    def final(state: FisherMassMatrixAdaptationState) -> FisherMassMatrixAdaptationState:
+        # Stitch #1 of 2: Fisher IMM computation + block reset.
+        # Twin copy: window_adaptation.base()'s slow_final (fisher path).
+        # Consolidation deferred until base() disposition is decided.
+        block = state.fisher_block
+        denom = jnp.maximum(block.count - 1.0, 1.0)
+        var_x = block.m2_x / denom  # (d,) Bessel-corrected position variance
+        var_g = block.m2_g / denom  # (d,) Bessel-corrected gradient variance
+        new_inverse_mass_matrix = fisher_score_diagonal_from_moments(var_x, var_g)
+        # mm_final resets the block for the next window.
+        reset_state = mm_final(state)
+        return FisherMassMatrixAdaptationState(
+            inverse_mass_matrix=new_inverse_mass_matrix,
+            fisher_block=reset_state.fisher_block,
+        )
+
+    return MetricCore(init=init, update=update, final=final)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+REGISTRY: dict[str, MetricRecipe] = {
+    "welford_diag": MetricRecipe(
+        representation="diag",
+        estimator="welford",
+        buffer="reset_window",
+        support_gate=None,
+        needs=frozenset({"positions"}),
+        provides=frozenset({"positions"}),
+        emits="diag",
+        provenance=(
+            "Stan-default diagonal Welford covariance estimator. "
+            "Reproduces window_adaptation exact behavior (bit-exact via the same "
+            "mass_matrix.welford_algorithm reduction). Use as the baseline recipe."
+        ),
+    ),
+    "welford_dense": MetricRecipe(
+        representation="dense",
+        estimator="welford",
+        buffer="reset_window",
+        support_gate=None,
+        needs=frozenset({"positions"}),
+        provides=frozenset({"positions"}),
+        emits="dense",
+        provenance=(
+            "Dense Welford covariance estimator (Stan-style reset-window schedule, "
+            "no low-rank compression). Appropriate when d is small enough to afford "
+            "O(d^2) storage and the full correlation structure matters."
+        ),
+    ),
+    "fisher_diag": MetricRecipe(
+        representation="diag",
+        estimator="fisher_diag",
+        buffer="reset_window",
+        support_gate=None,
+        needs=frozenset({"positions", "gradients"}),
+        provides=frozenset({"positions", "gradients"}),
+        emits="diag",
+        provenance=(
+            "Fisher-divergence-minimising diagonal estimator "
+            "(Seyboldt 2026, arXiv:2603.18845, §3.1). "
+            "Inverse mass matrix: sigma^2 = sqrt(Var[x] / Var[grad log p]) per coordinate. "
+            "Situational benefit for concentrated-anisotropy hierarchical geometry "
+            "(~1.3-1.7x min-ESS/grad improvement measured 2026-07-13); "
+            "degrades on well-conditioned GLM and diffuse AR(1) geometry "
+            "(~0.6-0.7x). Not a default. "
+            "Operational warning: degradation carries no R-hat/divergence signature "
+            "(healthy flags while effective-samples-per-gradient halves) — gate "
+            "estimator swaps on ESS-per-gradient, not health flags."
+        ),
+    ),
+}
+
+
+def lookup_recipe(name: str) -> MetricRecipe:
+    """Look up a named recipe from the :data:`REGISTRY`.
+
+    Parameters
+    ----------
+    name
+        Registry key.  Current slice-1 names:
+
+        - ``"welford_diag"`` (default; reproduces ``window_adaptation`` exactly)
+        - ``"welford_dense"``
+        - ``"fisher_diag"``
+
+    Returns
+    -------
+    MetricRecipe
+        The registered recipe for ``name``.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not in the registry, with a sorted list of known names.
+        Pass a :class:`MetricRecipe` or :class:`MetricCore` directly for
+        custom or experimental recipes that are not registry-stamped.
+    """
+    if name not in REGISTRY:
+        known = sorted(REGISTRY.keys())
+        raise ValueError(
+            f"Unknown metric recipe {name!r}. "
+            f"Known registry names: {known}. "
+            f"Pass a MetricRecipe or MetricCore constructor directly for "
+            f"custom recipes not yet in the registry."
+        )
+    return REGISTRY[name]

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -312,7 +312,7 @@ def _build_welford_core(
 
     def final(state: MassMatrixAdaptationState) -> MassMatrixAdaptationState:
         # Directly calls mm_final: same Welford reduction, same regularization
-        # formula — bit-exact vs the current window_adaptation.base() path.
+        # formula as window_adaptation.base()'s slow_final (welford path).
         return mm_final(state)
 
     return MetricCore(init=init, update=update, final=final)
@@ -330,16 +330,6 @@ def _build_fisher_diag_core(
     that cannot live inside ``mass_matrix_adaptation.final()`` due to a
     circular import (``metric_estimators`` imports ``welford_algorithm``
     from ``mass_matrix``).
-
-    .. note::
-
-        **Twin implementation alert (stitch #1 of 2).**  The Fisher IMM
-        computation + block-reset stitch in ``final()`` is also present in
-        :func:`~blackjax.adaptation.window_adaptation.base`'s ``slow_final``
-        closure (fisher path).  These two copies must stay in sync until
-        ``base()``'s disposition is decided (retire or rewire through the
-        engine).  See the comment at the matching site in
-        ``window_adaptation.base``.
 
     Parameters
     ----------
@@ -365,9 +355,7 @@ def _build_fisher_diag_core(
     def final(
         state: FisherMassMatrixAdaptationState,
     ) -> FisherMassMatrixAdaptationState:
-        # Stitch #1 of 2: Fisher IMM computation + block reset.
-        # Twin copy: window_adaptation.base()'s slow_final (fisher path).
-        # Consolidation deferred until base() disposition is decided.
+        # Fisher IMM computation + block reset: the only stitch site.
         block = state.fisher_block
         denom = jnp.maximum(block.count - 1.0, 1.0)
         var_x = block.m2_x / denom  # (d,) Bessel-corrected position variance

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -356,7 +356,9 @@ def _build_fisher_diag_core(
     ) -> FisherMassMatrixAdaptationState:
         return mm_update(state, position, grad)
 
-    def final(state: FisherMassMatrixAdaptationState) -> FisherMassMatrixAdaptationState:
+    def final(
+        state: FisherMassMatrixAdaptationState,
+    ) -> FisherMassMatrixAdaptationState:
         # Stitch #1 of 2: Fisher IMM computation + block reset.
         # Twin copy: window_adaptation.base()'s slow_final (fisher path).
         # Consolidation deferred until base() disposition is decided.
@@ -417,16 +419,21 @@ REGISTRY: dict[str, MetricRecipe] = {
         provides=frozenset({"positions", "gradients"}),
         emits="diag",
         provenance=(
-            "Fisher-divergence-minimising diagonal estimator "
-            "(Seyboldt 2026, arXiv:2603.18845, §3.1). "
-            "Inverse mass matrix: sigma^2 = sqrt(Var[x] / Var[grad log p]) per coordinate. "
-            "Situational benefit for concentrated-anisotropy hierarchical geometry "
-            "(~1.3-1.7x min-ESS/grad improvement measured 2026-07-13); "
-            "degrades on well-conditioned GLM and diffuse AR(1) geometry "
-            "(~0.6-0.7x). Not a default. "
-            "Operational warning: degradation carries no R-hat/divergence signature "
-            "(healthy flags while effective-samples-per-gradient halves) — gate "
-            "estimator swaps on ESS-per-gradient, not health flags."
+            "Situational estimator, not a default. "
+            "Helps concentrated-anisotropy hierarchical geometry "
+            "(~1.3–1.7x effective-samples-per-gradient); "
+            "degrades well-conditioned targets with correlated coordinate blocks "
+            "(~0.6–0.7x). "
+            "Mechanism: for near-Gaussian posteriors this estimator equals the "
+            "Welford diagonal shrunk by sqrt(1 - R_i^2) per coordinate "
+            "(the marginal-to-conditional precision pull); without an off-diagonal "
+            "correction the shrink under-explores correlated coordinates, raising "
+            "the slowest-mode variance. "
+            "Risk boundary: correlated blocks (R^2 >= ~0.5) on an already "
+            "well-conditioned target with no rank-k correction. "
+            "Degradation carries no R-hat/divergence signature — gate estimator "
+            "choices on effective-samples-per-gradient, not health flags. "
+            "Validated 2026-07-13."
         ),
     ),
 }
@@ -462,6 +469,6 @@ def lookup_recipe(name: str) -> MetricRecipe:
             f"Unknown metric recipe {name!r}. "
             f"Known registry names: {known}. "
             f"Pass a MetricRecipe or MetricCore constructor directly for "
-            f"custom recipes not yet in the registry."
+            f"custom recipes that have not been registered."
         )
     return REGISTRY[name]

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -483,8 +483,8 @@ def staged_adaptation(
         metric_core = metric
     else:
         raise TypeError(
-            f"staged_adaptation: metric must be a str, MetricRecipe, or MetricCore; "
-            f"got {type(metric).__name__}. "
+            f"staged_adaptation: metric must be a str, MetricRecipe, or MetricCore "
+            f"(got {type(metric).__name__}). "
             f"Pass a registry name (e.g. 'welford_diag') or construct a "
             f"MetricRecipe or MetricCore directly."
         )

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -1,0 +1,557 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Staged warmup adaptation engine for the HMC family.
+
+This module provides the :func:`staged_adaptation` engine and the
+:func:`build_schedule` function (previously in ``window_adaptation.py``;
+re-exported from there for backward compatibility).
+
+Architecture (layer doctrine)
+------------------------------
+- :class:`StagedAdaptationState` — the scan-carry for the warmup.
+- :func:`_make_engine` — builds the HOST: stage schedule dispatching +
+  step-size dual averaging + metric core hooks.  Only the MetricCore protocol
+  crosses the host/core boundary.
+- :func:`staged_adaptation` — public entry point; accepts a recipe name, a
+  :class:`~blackjax.adaptation.metric_recipes.MetricRecipe`, or a pre-built
+  :class:`~blackjax.adaptation.metric_recipes.MetricCore`.
+
+The metric core (:class:`~blackjax.adaptation.metric_recipes.MetricCore`) is
+the separable, embeddable component — its init/update/final protocol runs on
+the engine's clock (Stan window schedule for slice 1).  Step-size dual
+averaging lives in the HOST layer (this module), not in the core.
+
+``WindowAdaptationState`` in :mod:`~blackjax.adaptation.window_adaptation`
+is defined as ``WindowAdaptationState = StagedAdaptationState``.  Both names
+refer to the same class object; ``isinstance`` checks using either name continue
+to work.
+
+Notes
+-----
+``build_schedule`` is defined here (the canonical location) and re-exported
+from ``window_adaptation`` for backward compatibility.  Import it from either
+module; the object is identical.
+"""
+import inspect
+from typing import Any, Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+import blackjax.mcmc as mcmc
+from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
+from blackjax.adaptation.metric_recipes import MetricCore, MetricRecipe, lookup_recipe
+from blackjax.adaptation.step_size import (
+    DualAveragingAdaptationState,
+    dual_averaging_adaptation,
+)
+from blackjax.base import AdaptationAlgorithm
+from blackjax.types import Array, ArrayLikeTree, PRNGKey
+from blackjax.util import pytree_size
+
+__all__ = [
+    "StagedAdaptationState",
+    "build_schedule",
+    "staged_adaptation",
+]
+
+
+# ---------------------------------------------------------------------------
+# State type (canonical definition; aliased as WindowAdaptationState in
+# window_adaptation.py)
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationState(NamedTuple):
+    """Scan-carry state for the staged adaptation engine.
+
+    Field names intentionally mirror the previous
+    ``WindowAdaptationState`` fields so that any downstream code accessing
+    adaptation info by field name (``.ss_state``, ``.imm_state``, …)
+    continues to work without modification.
+
+    ``WindowAdaptationState`` in :mod:`blackjax.adaptation.window_adaptation`
+    is an alias of this type (``WindowAdaptationState = StagedAdaptationState``);
+    both names refer to the same NamedTuple class object, so ``isinstance``
+    checks using either name are equivalent.
+
+    Parameters
+    ----------
+    ss_state
+        Current state of the dual-averaging step-size adaptation.
+    imm_state
+        Current mass-matrix adaptation core state.  One of
+        :class:`~blackjax.adaptation.mass_matrix.MassMatrixAdaptationState`
+        or :class:`~blackjax.adaptation.mass_matrix.FisherMassMatrixAdaptationState`.
+        Typed ``Any`` here to avoid a hard dependency on the concrete types;
+        the MetricCore protocol guarantees the right type at construction time.
+    step_size
+        Current (exponential-space) step-size estimate; read by the MCMC kernel
+        at every scan step.
+    inverse_mass_matrix
+        Current inverse mass matrix; updated at each slow-window boundary and
+        read by the MCMC kernel at every scan step.
+    """
+
+    ss_state: DualAveragingAdaptationState
+    imm_state: Any  # MassMatrixAdaptationState | FisherMassMatrixAdaptationState
+    step_size: float
+    inverse_mass_matrix: Array
+
+
+# ---------------------------------------------------------------------------
+# Engine internals
+# ---------------------------------------------------------------------------
+
+
+def _make_engine(
+    metric_core: MetricCore,
+    *,
+    target_acceptance_rate: float,
+) -> tuple[Callable, Callable, Callable]:
+    """Build the (init, update, final) triple for the staged adaptation HOST.
+
+    This is the low-level engine constructor.  Step-size dual averaging and
+    the stage-dispatch logic live here; mass-matrix adaptation is fully
+    delegated to ``metric_core``.
+
+    Parameters
+    ----------
+    metric_core
+        Pre-built :class:`~blackjax.adaptation.metric_recipes.MetricCore`
+        (init/update/final bundle for the inverse mass matrix).
+    target_acceptance_rate
+        Target acceptance rate for dual-averaging step-size adaptation.
+
+    Returns
+    -------
+    init
+        ``(position, initial_step_size) -> StagedAdaptationState``
+    update
+        ``(adaptation_state, adaptation_stage, position, grad, acceptance_rate)
+        -> StagedAdaptationState``
+    final
+        ``(warmup_state) -> (step_size, inverse_mass_matrix)``
+    """
+    da_init, da_update, da_final = dual_averaging_adaptation(target_acceptance_rate)
+
+    def init(
+        position: ArrayLikeTree, initial_step_size: float
+    ) -> StagedAdaptationState:
+        n_dims = pytree_size(position)
+        imm_state = metric_core.init(n_dims)
+        ss_state = da_init(initial_step_size)
+        return StagedAdaptationState(
+            ss_state,
+            imm_state,
+            initial_step_size,
+            imm_state.inverse_mass_matrix,
+        )
+
+    def fast_update(
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree,
+        acceptance_rate: float,
+        ws: StagedAdaptationState,
+    ) -> StagedAdaptationState:
+        """Update adaptation state during a fast (step-size-only) window."""
+        del position, grad
+        new_ss = da_update(ws.ss_state, acceptance_rate)
+        new_step_size = jnp.exp(new_ss.log_step_size)
+        return StagedAdaptationState(
+            new_ss, ws.imm_state, new_step_size, ws.inverse_mass_matrix
+        )
+
+    def slow_update(
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree,
+        acceptance_rate: float,
+        ws: StagedAdaptationState,
+    ) -> StagedAdaptationState:
+        """Update adaptation state during a slow (step-size + mass-matrix) window.
+
+        Delegates mass-matrix accumulation to ``metric_core.update``.  For
+        welford-path cores, ``grad`` is accepted for interface uniformity but
+        is not consumed by the underlying estimator (the ``isinstance`` dispatch
+        inside ``mass_matrix_adaptation.update`` resolves at JAX trace time).
+        For fisher-path cores, ``grad`` is forwarded to the Fisher-block
+        accumulator.
+        """
+        new_metric_st = metric_core.update(ws.imm_state, position, grad)
+        new_ss = da_update(ws.ss_state, acceptance_rate)
+        new_step_size = jnp.exp(new_ss.log_step_size)
+        return StagedAdaptationState(
+            new_ss, new_metric_st, new_step_size, ws.inverse_mass_matrix
+        )
+
+    def slow_final(ws: StagedAdaptationState) -> StagedAdaptationState:
+        """Finalize a slow window: recompute IMM and re-initialise step-size DA.
+
+        Delegates IMM computation and window-buffer reset to
+        ``metric_core.final``.  The new inverse mass matrix is read from
+        ``new_metric_st.inverse_mass_matrix`` and stored in the returned state
+        for the MCMC kernel to use in the next window.
+        """
+        new_metric_st = metric_core.final(ws.imm_state)
+        new_ss = da_init(da_final(ws.ss_state))
+        new_step_size = jnp.exp(new_ss.log_step_size)
+        return StagedAdaptationState(
+            new_ss,
+            new_metric_st,
+            new_step_size,
+            new_metric_st.inverse_mass_matrix,
+        )
+
+    def update(
+        adaptation_state: StagedAdaptationState,
+        adaptation_stage: tuple,
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree,
+        acceptance_rate: float,
+    ) -> StagedAdaptationState:
+        """Dispatch one warmup step to the correct fast/slow update.
+
+        Parameters
+        ----------
+        adaptation_state
+            Current warmup state (the scan carry).
+        adaptation_stage
+            ``(stage_label, is_middle_window_end)`` pair from the schedule.
+            ``stage_label`` is ``0`` (fast) or ``1`` (slow).
+            ``is_middle_window_end`` is ``True`` on the last step of a slow
+            window, triggering ``slow_final``.
+        position
+            Current MCMC position.
+        grad
+            Log-density gradient at ``position``.
+        acceptance_rate
+            Metropolis acceptance rate from the last MCMC step.
+
+        Returns
+        -------
+        StagedAdaptationState
+            Updated warmup state.
+        """
+        stage, is_middle_window_end = adaptation_stage
+
+        ws = jax.lax.switch(
+            stage,
+            (fast_update, slow_update),
+            position,
+            grad,
+            acceptance_rate,
+            adaptation_state,
+        )
+
+        ws = jax.lax.cond(
+            is_middle_window_end,
+            slow_final,
+            lambda x: x,
+            ws,
+        )
+
+        return ws
+
+    def final(ws: StagedAdaptationState) -> tuple[float, Array]:
+        """Return the final step size and inverse mass matrix after warmup."""
+        step_size = jnp.exp(ws.ss_state.log_step_size_avg)
+        inverse_mass_matrix = ws.imm_state.inverse_mass_matrix
+        return step_size, inverse_mass_matrix
+
+    return init, update, final
+
+
+# ---------------------------------------------------------------------------
+# Build schedule (canonical location; re-exported from window_adaptation.py)
+# ---------------------------------------------------------------------------
+
+
+def build_schedule(
+    num_steps: int,
+    initial_buffer_size: int = 75,
+    final_buffer_size: int = 50,
+    first_window_size: int = 25,
+) -> list[tuple[int, bool]]:
+    """Return the schedule for Stan's warmup.
+
+    The schedule below is intended to be as close as possible to Stan's :cite:p:`stan_hmc_param`.
+    The warmup period is split into three stages:
+
+    1. An initial fast interval to reach the typical set. Only the step size is
+    adapted in this window.
+    2. "Slow" parameters that require global information (typically covariance)
+    are estimated in a series of expanding intervals with no memory; the step
+    size is re-initialized at the end of each window. Each window is twice the
+    size of the preceding window.
+    3. A final fast interval during which the step size is adapted using the
+    computed mass matrix.
+
+    Schematically:
+
+    ```
+    +---------+---+------+------------+------------------------+------+
+    |  fast   | s | slow |   slow     |        slow            | fast |
+    +---------+---+------+------------+------------------------+------+
+    ```
+
+    The distinction slow/fast comes from the speed at which the algorithms
+    converge to a stable value; in the common case, estimation of covariance
+    requires more steps than dual averaging to give an accurate value. See :cite:p:`stan_hmc_param`
+    for a more detailed explanation.
+
+    Fast intervals are given the label 0 and slow intervals the label 1.
+
+    Parameters
+    ----------
+    num_steps: int
+        The number of warmup steps to perform.
+    initial_buffer_size: int
+        The width of the initial fast adaptation interval.
+    first_window_size: int
+        The width of the first slow adaptation interval.
+    final_buffer_size: int
+        The width of the final fast adaptation interval.
+
+    Returns
+    -------
+    A list of tuples (window_label, is_middle_window_end).
+
+    """
+    schedule = []
+
+    # Give up on mass matrix adaptation when the number of warmup steps is too small.
+    if num_steps < 20:
+        schedule += [(0, False)] * num_steps
+    else:
+        # When the number of warmup steps is smaller that the sum of the provided (or default)
+        # window sizes we need to resize the different windows.
+        if initial_buffer_size + first_window_size + final_buffer_size > num_steps:
+            initial_buffer_size = int(0.15 * num_steps)
+            final_buffer_size = int(0.1 * num_steps)
+            first_window_size = num_steps - initial_buffer_size - final_buffer_size
+
+        # First stage: adaptation of fast parameters
+        schedule += [(0, False)] * (initial_buffer_size - 1)
+        schedule.append((0, False))
+
+        # Second stage: adaptation of slow parameters in successive windows
+        # doubling in size.
+        final_buffer_start = num_steps - final_buffer_size
+
+        next_window_size = first_window_size
+        next_window_start = initial_buffer_size
+        while next_window_start < final_buffer_start:
+            current_start, current_size = next_window_start, next_window_size
+            if 3 * current_size <= final_buffer_start - current_start:
+                next_window_size = 2 * current_size
+            else:
+                current_size = final_buffer_start - current_start
+            next_window_start = current_start + current_size
+            schedule += [(1, False)] * (next_window_start - 1 - current_start)
+            schedule.append((1, True))
+
+        # Last stage: adaptation of fast parameters
+        schedule += [(0, False)] * (num_steps - 1 - final_buffer_start)
+        schedule.append((0, False))
+
+    schedule = jnp.array(schedule)
+
+    return schedule
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def staged_adaptation(
+    algorithm,
+    logdensity_fn: Callable,
+    metric: str | MetricRecipe | MetricCore = "welford_diag",
+    *,
+    imm_shrinkage_to_previous: float = 0.0,
+    initial_inverse_mass_matrix: Array | None = None,
+    initial_step_size: float = 1.0,
+    target_acceptance_rate: float = 0.80,
+    adaptation_info_fn: Callable = return_all_adapt_info,
+    integrator=mcmc.integrators.velocity_verlet,
+    **extra_parameters,
+) -> AdaptationAlgorithm:
+    """Adapt the step size and inverse mass matrix for HMC-family algorithms.
+
+    The :func:`staged_adaptation` engine implements the same Stan warmup
+    schedule as :func:`~blackjax.adaptation.window_adaptation.window_adaptation`
+    but exposes a composable :class:`~blackjax.adaptation.metric_recipes.MetricCore`
+    interface for the mass-matrix adaptation component.  The step-size dual-averaging
+    and the stage schedule live in the HOST (this function); the mass-matrix
+    estimation is fully delegated to the ``metric`` argument.
+
+    Parameters
+    ----------
+    algorithm
+        An algorithm from the HMC family (e.g. :data:`blackjax.nuts`,
+        :data:`blackjax.hmc`).  The algorithm's ``build_kernel`` method is
+        inspected to decide whether to pass an integrator.
+    logdensity_fn
+        The log density probability density function to sample.
+    metric
+        The mass-matrix adaptation specification.  Accepts:
+
+        - **str** — a registry name (``"welford_diag"`` (default),
+          ``"welford_dense"``, ``"fisher_diag"``); looked up via
+          :func:`~blackjax.adaptation.metric_recipes.lookup_recipe` and built
+          with ``imm_shrinkage_to_previous`` and ``initial_inverse_mass_matrix``.
+        - :class:`~blackjax.adaptation.metric_recipes.MetricRecipe` — built
+          with ``imm_shrinkage_to_previous`` and ``initial_inverse_mass_matrix``.
+        - :class:`~blackjax.adaptation.metric_recipes.MetricCore` — used
+          directly as-is; ``imm_shrinkage_to_previous`` and
+          ``initial_inverse_mass_matrix`` are ignored (closed over in the core).
+    imm_shrinkage_to_previous
+        Pseudo-count controlling shrinkage of the per-window IMM toward the
+        previous window's IMM (Bayesian persistence).  Default ``0.0``
+        reproduces Stan's per-window-reset behavior exactly.  Ignored when
+        ``metric`` is a :class:`~blackjax.adaptation.metric_recipes.MetricCore`.
+    initial_inverse_mass_matrix
+        Optional seed array for the initial inverse mass matrix.  Ignored when
+        ``metric`` is a :class:`~blackjax.adaptation.metric_recipes.MetricCore`.
+    initial_step_size
+        Step size used to seed the dual-averaging adaptation.
+    target_acceptance_rate
+        Target Metropolis acceptance rate for step-size adaptation.  Default
+        ``0.80`` (Stan default).
+    adaptation_info_fn
+        Function to select the adaptation info returned at each step.  See
+        :func:`~blackjax.adaptation.base.return_all_adapt_info` and
+        :func:`~blackjax.adaptation.base.get_filter_adapt_info_fn`.  By default
+        all information is saved — this can result in excessive memory usage
+        if the information is unused.
+    integrator
+        The symplectic integrator passed to ``algorithm.build_kernel``; only
+        used if ``build_kernel`` accepts arguments.  Defaults to
+        :func:`~blackjax.mcmc.integrators.velocity_verlet`.
+    **extra_parameters
+        Additional parameters forwarded to the MCMC kernel at every step, e.g.
+        ``num_integration_steps`` for HMC.
+
+    Returns
+    -------
+    AdaptationAlgorithm
+        An :class:`~blackjax.base.AdaptationAlgorithm` wrapping a ``run``
+        function with signature ``(rng_key, position, num_steps=1000)`` that
+        returns ``(AdaptationResults, info)``.
+
+    Notes
+    -----
+    Wrap ``warmup.run(...)`` in :func:`blackjax.progress_bar` to display a
+    progress bar, e.g. ``with blackjax.progress_bar(): warmup.run(...)``.
+
+    See Also
+    --------
+    blackjax.adaptation.window_adaptation.window_adaptation :
+        Thin compatibility shim over this engine; preserves the old parameter
+        interface exactly.
+    blackjax.adaptation.metric_recipes.REGISTRY :
+        Registry of named :class:`~blackjax.adaptation.metric_recipes.MetricRecipe`
+        objects for the ``metric`` string argument.
+    """
+    # Resolve the metric argument to a MetricCore.
+    if isinstance(metric, str):
+        recipe = lookup_recipe(metric)
+        metric_core = recipe.build_core(
+            imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+            initial_inverse_mass_matrix=initial_inverse_mass_matrix,
+        )
+    elif isinstance(metric, MetricRecipe):
+        metric_core = metric.build_core(
+            imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+            initial_inverse_mass_matrix=initial_inverse_mass_matrix,
+        )
+    elif isinstance(metric, MetricCore):
+        # The core is pre-built; imm_shrinkage_to_previous and
+        # initial_inverse_mass_matrix are ignored (already closed over).
+        metric_core = metric
+    else:
+        raise TypeError(
+            f"staged_adaptation: metric must be a str, MetricRecipe, or MetricCore; "
+            f"got {type(metric).__name__}. "
+            f"Pass a registry name (e.g. 'welford_diag') or construct a "
+            f"MetricRecipe or MetricCore directly."
+        )
+
+    if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
+        mcmc_kernel = algorithm.build_kernel(integrator)
+    else:
+        mcmc_kernel = algorithm.build_kernel()
+
+    adapt_init, adapt_step, adapt_final = _make_engine(
+        metric_core,
+        target_acceptance_rate=target_acceptance_rate,
+    )
+
+    def one_step(carry, xs):
+        _, rng_key, adaptation_stage = xs
+        state, adaptation_state = carry
+
+        new_state, info = mcmc_kernel(
+            rng_key,
+            state,
+            logdensity_fn,
+            adaptation_state.step_size,
+            adaptation_state.inverse_mass_matrix,
+            **extra_parameters,
+        )
+        new_adaptation_state = adapt_step(
+            adaptation_state,
+            adaptation_stage,
+            new_state.position,
+            new_state.logdensity_grad,
+            info.acceptance_rate,
+        )
+
+        return (
+            (new_state, new_adaptation_state),
+            adaptation_info_fn(new_state, info, new_adaptation_state),
+        )
+
+    def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
+        init_state = algorithm.init(position, logdensity_fn)
+        init_adaptation_state = adapt_init(position, initial_step_size)
+
+        start_state = (init_state, init_adaptation_state)
+        keys = jax.random.split(rng_key, num_steps)
+        schedule = build_schedule(num_steps)
+        last_state, info = jax.lax.scan(
+            one_step,
+            start_state,
+            (jnp.arange(num_steps), keys, schedule),
+        )
+
+        last_chain_state, last_warmup_state, *_ = last_state
+
+        step_size, inverse_mass_matrix = adapt_final(last_warmup_state)
+        parameters = {
+            "step_size": step_size,
+            "inverse_mass_matrix": inverse_mass_matrix,
+            **extra_parameters,
+        }
+
+        return (
+            AdaptationResults(
+                last_chain_state,
+                parameters,
+            ),
+            info,
+        )
+
+    return AdaptationAlgorithm(run)

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -11,36 +11,53 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Implementation of the Stan warmup for the HMC family of sampling algorithms."""
-import inspect
-from typing import Callable, NamedTuple, cast
+"""Implementation of the Stan warmup for the HMC family of sampling algorithms.
+
+The public surface of this module is unchanged.  Internally, :func:`window_adaptation`
+is now a thin compatibility shim over :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`;
+:func:`build_schedule` is defined in :mod:`blackjax.adaptation.staged_adaptation` and
+re-exported here for backward compatibility.
+
+:data:`WindowAdaptationState` is an alias for
+:class:`~blackjax.adaptation.staged_adaptation.StagedAdaptationState`; both names
+refer to the same class object so ``isinstance`` checks using either name continue
+to work without modification.
+
+The :func:`base` function is retained unchanged for downstream code that calls it
+directly.  It is dead inside the :func:`window_adaptation` entry point
+(the shim goes through :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`
+instead) but remains exported and tested.
+"""
+from typing import Callable, cast
 
 import jax
 import jax.numpy as jnp
 
 import blackjax.mcmc as mcmc
-from blackjax.adaptation.base import AdaptationResults, return_all_adapt_info
+from blackjax.adaptation.base import return_all_adapt_info
 from blackjax.adaptation.mass_matrix import (
     FisherMassMatrixAdaptationState,
-    MassMatrixAdaptationState,
     mass_matrix_adaptation,
 )
-from blackjax.adaptation.step_size import (
-    DualAveragingAdaptationState,
-    dual_averaging_adaptation,
+from blackjax.adaptation.metric_recipes import lookup_recipe
+from blackjax.adaptation.staged_adaptation import (
+    build_schedule,  # canonical definition in staged_adaptation; re-exported here
 )
+from blackjax.adaptation.staged_adaptation import (
+    StagedAdaptationState,
+    staged_adaptation,
+)
+from blackjax.adaptation.step_size import dual_averaging_adaptation
 from blackjax.base import AdaptationAlgorithm
-from blackjax.types import Array, ArrayLikeTree, PRNGKey
+from blackjax.types import Array, ArrayLikeTree
 from blackjax.util import pytree_size
 
 __all__ = ["WindowAdaptationState", "base", "build_schedule", "window_adaptation"]
 
-
-class WindowAdaptationState(NamedTuple):
-    ss_state: DualAveragingAdaptationState  # step size
-    imm_state: MassMatrixAdaptationState | FisherMassMatrixAdaptationState  # inverse mass matrix
-    step_size: float
-    inverse_mass_matrix: Array
+# WindowAdaptationState is the canonical name for StagedAdaptationState in this
+# module.  They are the SAME class object: isinstance(x, WindowAdaptationState)
+# is identical to isinstance(x, StagedAdaptationState).
+WindowAdaptationState = StagedAdaptationState
 
 
 def base(
@@ -73,7 +90,7 @@ def base(
     Schematically:
 
     +---------+---+------+------------+------------------------+------+
-    |  fast   | s | slow |   slow     |        slow            | fast |
+    |  fast   | s | slow |   slow     |        slow            |  fast |
     +---------+---+------+------------+------------------------+------+
     |1        |2  |3     |3           |3                       |3     |
     +---------+---+------+------------+------------------------+------+
@@ -273,6 +290,15 @@ def base(
             3. Call ``mm_final`` to reset the block for the next window.
             4. Stitch the new IMM into the reset state.
 
+            .. note::
+
+                **Twin implementation alert (stitch #2 of 2).**  This Fisher
+                stitch is also present in
+                :func:`~blackjax.adaptation.metric_recipes._build_fisher_diag_core`'s
+                ``final()`` closure (MetricCore path).  These two copies must
+                stay in sync until ``base()``'s disposition is decided (retire
+                or rewire through the engine).
+
             """
             # This closure is only constructed on the Fisher path (Python-level
             # dispatch in base()); the state is always FisherMassMatrixAdaptationState
@@ -359,6 +385,17 @@ def base(
         return step_size, inverse_mass_matrix
 
     return init, update, final
+
+
+def _pick_recipe_name(*, is_mass_matrix_diagonal: bool, diagonal_estimator: str) -> str:
+    """Map the old (is_mass_matrix_diagonal, diagonal_estimator) params to a
+    metric recipe registry name.  Used by the :func:`window_adaptation` shim."""
+    if diagonal_estimator == "fisher":
+        return "fisher_diag"
+    elif is_mass_matrix_diagonal:
+        return "welford_diag"
+    else:
+        return "welford_dense"
 
 
 def window_adaptation(
@@ -467,6 +504,11 @@ def window_adaptation(
 
     Notes
     -----
+    This function is a thin compatibility shim over
+    :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`.  The
+    public interface and return type are frozen; no breaking changes will be
+    made in this module.
+
     Wrap ``warmup.run(...)`` in :func:`blackjax.progress_bar` to display a
     progress bar, e.g. ``with blackjax.progress_bar(): warmup.run(...)``.
 
@@ -511,165 +553,25 @@ def window_adaptation(
             f"got imm_shrinkage_to_previous={imm_shrinkage_to_previous}"
         )
 
-    if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
-        mcmc_kernel = algorithm.build_kernel(integrator)
-    else:
-        mcmc_kernel = algorithm.build_kernel()
-
-    adapt_init, adapt_step, adapt_final = base(
-        is_mass_matrix_diagonal,
-        target_acceptance_rate=target_acceptance_rate,
-        initial_inverse_mass_matrix=initial_inverse_mass_matrix,
-        imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+    # Map the old parameter names to a registered MetricRecipe and build
+    # a MetricCore (pre-builds the core so staged_adaptation sees a MetricCore
+    # directly and skips the lookup step).
+    recipe_name = _pick_recipe_name(
+        is_mass_matrix_diagonal=is_mass_matrix_diagonal,
         diagonal_estimator=diagonal_estimator,
     )
+    metric_core = lookup_recipe(recipe_name).build_core(
+        imm_shrinkage_to_previous=imm_shrinkage_to_previous,
+        initial_inverse_mass_matrix=initial_inverse_mass_matrix,
+    )
 
-    def one_step(carry, xs):
-        _, rng_key, adaptation_stage = xs
-        state, adaptation_state = carry
-
-        new_state, info = mcmc_kernel(
-            rng_key,
-            state,
-            logdensity_fn,
-            adaptation_state.step_size,
-            adaptation_state.inverse_mass_matrix,
-            **extra_parameters,
-        )
-        new_adaptation_state = adapt_step(
-            adaptation_state,
-            adaptation_stage,
-            new_state.position,
-            new_state.logdensity_grad,
-            info.acceptance_rate,
-        )
-
-        return (
-            (new_state, new_adaptation_state),
-            adaptation_info_fn(new_state, info, new_adaptation_state),
-        )
-
-    def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
-        init_state = algorithm.init(position, logdensity_fn)
-        init_adaptation_state = adapt_init(position, initial_step_size)
-
-        start_state = (init_state, init_adaptation_state)
-        keys = jax.random.split(rng_key, num_steps)
-        schedule = build_schedule(num_steps)
-        last_state, info = jax.lax.scan(
-            one_step,
-            start_state,
-            (jnp.arange(num_steps), keys, schedule),
-        )
-
-        last_chain_state, last_warmup_state, *_ = last_state
-
-        step_size, inverse_mass_matrix = adapt_final(last_warmup_state)
-        parameters = {
-            "step_size": step_size,
-            "inverse_mass_matrix": inverse_mass_matrix,
-            **extra_parameters,
-        }
-
-        return (
-            AdaptationResults(
-                last_chain_state,
-                parameters,
-            ),
-            info,
-        )
-
-    return AdaptationAlgorithm(run)
-
-
-def build_schedule(
-    num_steps: int,
-    initial_buffer_size: int = 75,
-    final_buffer_size: int = 50,
-    first_window_size: int = 25,
-) -> list[tuple[int, bool]]:
-    """Return the schedule for Stan's warmup.
-
-    The schedule below is intended to be as close as possible to Stan's :cite:p:`stan_hmc_param`.
-    The warmup period is split into three stages:
-
-    1. An initial fast interval to reach the typical set. Only the step size is
-    adapted in this window.
-    2. "Slow" parameters that require global information (typically covariance)
-    are estimated in a series of expanding intervals with no memory; the step
-    size is re-initialized at the end of each window. Each window is twice the
-    size of the preceding window.
-    3. A final fast interval during which the step size is adapted using the
-    computed mass matrix.
-
-    Schematically:
-
-    ```
-    +---------+---+------+------------+------------------------+------+
-    |  fast   | s | slow |   slow     |        slow            | fast |
-    +---------+---+------+------------+------------------------+------+
-    ```
-
-    The distinction slow/fast comes from the speed at which the algorithms
-    converge to a stable value; in the common case, estimation of covariance
-    requires more steps than dual averaging to give an accurate value. See :cite:p:`stan_hmc_param`
-    for a more detailed explanation.
-
-    Fast intervals are given the label 0 and slow intervals the label 1.
-
-    Parameters
-    ----------
-    num_steps: int
-        The number of warmup steps to perform.
-    initial_buffer: int
-        The width of the initial fast adaptation interval.
-    first_window_size: int
-        The width of the first slow adaptation interval.
-    final_buffer_size: int
-        The width of the final fast adaptation interval.
-
-    Returns
-    -------
-    A list of tuples (window_label, is_middle_window_end).
-
-    """
-    schedule = []
-
-    # Give up on mass matrix adaptation when the number of warmup steps is too small.
-    if num_steps < 20:
-        schedule += [(0, False)] * num_steps
-    else:
-        # When the number of warmup steps is smaller that the sum of the provided (or default)
-        # window sizes we need to resize the different windows.
-        if initial_buffer_size + first_window_size + final_buffer_size > num_steps:
-            initial_buffer_size = int(0.15 * num_steps)
-            final_buffer_size = int(0.1 * num_steps)
-            first_window_size = num_steps - initial_buffer_size - final_buffer_size
-
-        # First stage: adaptation of fast parameters
-        schedule += [(0, False)] * (initial_buffer_size - 1)
-        schedule.append((0, False))
-
-        # Second stage: adaptation of slow parameters in successive windows
-        # doubling in size.
-        final_buffer_start = num_steps - final_buffer_size
-
-        next_window_size = first_window_size
-        next_window_start = initial_buffer_size
-        while next_window_start < final_buffer_start:
-            current_start, current_size = next_window_start, next_window_size
-            if 3 * current_size <= final_buffer_start - current_start:
-                next_window_size = 2 * current_size
-            else:
-                current_size = final_buffer_start - current_start
-            next_window_start = current_start + current_size
-            schedule += [(1, False)] * (next_window_start - 1 - current_start)
-            schedule.append((1, True))
-
-        # Last stage: adaptation of fast parameters
-        schedule += [(0, False)] * (num_steps - 1 - final_buffer_start)
-        schedule.append((0, False))
-
-    schedule = jnp.array(schedule)
-
-    return schedule
+    return staged_adaptation(
+        algorithm,
+        logdensity_fn,
+        metric=metric_core,
+        initial_step_size=initial_step_size,
+        target_acceptance_rate=target_acceptance_rate,
+        adaptation_info_fn=adaptation_info_fn,
+        integrator=integrator,
+        **extra_parameters,
+    )

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -23,23 +23,20 @@ re-exported here for backward compatibility.
 refer to the same class object so ``isinstance`` checks using either name continue
 to work without modification.
 
-The :func:`base` function is retained for downstream code that calls it directly.
-It is not exercised by the :func:`window_adaptation` shim (which delegates to
-:func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`), but it is
-exported and covered by ``BaseFisherStitchDirectTest`` in
-``tests/adaptation/test_window_adaptation_fisher_diag.py``.
+The :func:`base` function is retained at its released API for downstream code that
+calls it directly.  It is not exercised by the :func:`window_adaptation` shim (which
+delegates to :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`).
+Fisher-diagonal adaptation is accessible via
+``staged_adaptation(metric="fisher_diag")`` only.
 """
-from typing import Callable, cast
+from typing import Callable
 
 import jax
 import jax.numpy as jnp
 
 import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import return_all_adapt_info
-from blackjax.adaptation.mass_matrix import (
-    FisherMassMatrixAdaptationState,
-    mass_matrix_adaptation,
-)
+from blackjax.adaptation.mass_matrix import mass_matrix_adaptation
 from blackjax.adaptation.metric_recipes import lookup_recipe
 from blackjax.adaptation.staged_adaptation import (
     build_schedule,  # canonical definition in staged_adaptation; re-exported here
@@ -66,7 +63,6 @@ def base(
     target_acceptance_rate: float = 0.80,
     initial_inverse_mass_matrix: Array | None = None,
     imm_shrinkage_to_previous: float = 0.0,
-    diagonal_estimator: str = "welford",
 ) -> tuple[Callable, Callable, Callable]:
     """Warmup scheme for sampling procedures based on euclidean manifold HMC.
     The schedule and algorithms used match Stan's :cite:p:`stan_hmc_param` as closely as possible.
@@ -91,7 +87,7 @@ def base(
     Schematically:
 
     +---------+---+------+------------+------------------------+------+
-    |  fast   | s | slow |   slow     |        slow            |  fast |
+    |  fast   | s | slow |   slow     |        slow            | fast |
     +---------+---+------+------------+------------------------+------+
     |1        |2  |3     |3           |3                       |3     |
     +---------+---+------+------------+------------------------+------+
@@ -117,13 +113,6 @@ def base(
         Pseudo-count controlling shrinkage of the IMM toward the previous
         window's IMM. Default 0.0 gives the current Stan behavior. Passed
         through to ``mass_matrix_adaptation``.
-    diagonal_estimator
-        Which diagonal-variance estimator to use.  ``"welford"`` (default)
-        reproduces all pre-existing behavior exactly.  ``"fisher"`` uses the
-        Fisher-divergence-minimising diagonal estimator; see
-        ``mass_matrix_adaptation`` for constraints (diagonal-only, no
-        ``imm_shrinkage_to_previous``).  Passed through to
-        ``mass_matrix_adaptation``.
 
     Returns
     -------
@@ -137,7 +126,7 @@ def base(
 
     """
     mm_init, mm_update, mm_final = mass_matrix_adaptation(
-        is_mass_matrix_diagonal, imm_shrinkage_to_previous, diagonal_estimator
+        is_mass_matrix_diagonal, imm_shrinkage_to_previous
     )
     da_init, da_update, da_final = dual_averaging_adaptation(target_acceptance_rate)
 
@@ -165,7 +154,6 @@ def base(
 
     def fast_update(
         position: ArrayLikeTree,
-        grad: ArrayLikeTree,
         acceptance_rate: float,
         warmup_state: WindowAdaptationState,
     ) -> WindowAdaptationState:
@@ -176,7 +164,7 @@ def base(
         compared to the covariance estimation with Welford's algorithm
 
         """
-        del position, grad
+        del position
 
         new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
         new_step_size = jnp.exp(new_ss_state.log_step_size)
@@ -188,151 +176,51 @@ def base(
             warmup_state.inverse_mass_matrix,
         )
 
-    if diagonal_estimator == "welford":
+    def slow_update(
+        position: ArrayLikeTree,
+        acceptance_rate: float,
+        warmup_state: WindowAdaptationState,
+    ) -> WindowAdaptationState:
+        """Update the adaptation state when in a "slow" window.
 
-        def slow_update(
-            position: ArrayLikeTree,
-            grad: ArrayLikeTree,
-            acceptance_rate: float,
-            warmup_state: WindowAdaptationState,
-        ) -> WindowAdaptationState:
-            """Update the adaptation state when in a "slow" window (Welford path).
+        Both the mass matrix adaptation *state* and the step size state are
+        adapted in slow windows. The value of the step size is updated as well,
+        but the new value of the inverse mass matrix is only computed at the end
+        of the slow window. "Slow" refers to the fact that we need many samples
+        to get a reliable estimation of the covariance matrix used to update the
+        value of the mass matrix.
 
-            Both the mass matrix adaptation *state* and the step size state are
-            adapted in slow windows. The value of the step size is updated as well,
-            but the new value of the inverse mass matrix is only computed at the end
-            of the slow window. "Slow" refers to the fact that we need many samples
-            to get a reliable estimation of the covariance matrix used to update the
-            value of the mass matrix.
+        """
+        new_imm_state = mm_update(warmup_state.imm_state, position)
+        new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
+        new_step_size = jnp.exp(new_ss_state.log_step_size)
 
-            On the default Welford path, ``grad`` is not consumed by the IMM
-            accumulator and is explicitly deleted here so it is dead on this path.
-
-            """
-            del grad
-            new_imm_state = mm_update(warmup_state.imm_state, position)
-            new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
-            new_step_size = jnp.exp(new_ss_state.log_step_size)
-
-            return WindowAdaptationState(
-                new_ss_state,
-                new_imm_state,
-                new_step_size,
-                warmup_state.inverse_mass_matrix,
-            )
-
-    else:  # diagonal_estimator == "fisher"
-
-        def slow_update(  # type: ignore[no-redef]
-            position: ArrayLikeTree,
-            grad: ArrayLikeTree,
-            acceptance_rate: float,
-            warmup_state: WindowAdaptationState,
-        ) -> WindowAdaptationState:
-            """Update the adaptation state when in a "slow" window (Fisher path).
-
-            Both the mass matrix adaptation *state* and the step size state are
-            adapted in slow windows.  On the Fisher path, ``grad`` is forwarded
-            to the IMM accumulator so it can track gradient variance.
-
-            """
-            new_imm_state = mm_update(warmup_state.imm_state, position, grad)
-            new_ss_state = da_update(warmup_state.ss_state, acceptance_rate)
-            new_step_size = jnp.exp(new_ss_state.log_step_size)
-
-            return WindowAdaptationState(
-                new_ss_state,
-                new_imm_state,
-                new_step_size,
-                warmup_state.inverse_mass_matrix,
-            )
-
-    if diagonal_estimator == "welford":
-
-        def slow_final(warmup_state: WindowAdaptationState) -> WindowAdaptationState:
-            """Update the parameters at the end of a slow adaptation window.
-
-            We compute the value of the mass matrix and reset the mass matrix
-            adaptation's internal state since middle windows are "memoryless".
-
-            """
-            new_imm_state = mm_final(warmup_state.imm_state)
-            new_ss_state = da_init(da_final(warmup_state.ss_state))
-            new_step_size = jnp.exp(new_ss_state.log_step_size)
-
-            return WindowAdaptationState(
-                new_ss_state,
-                new_imm_state,
-                new_step_size,
-                new_imm_state.inverse_mass_matrix,
-            )
-
-    else:  # diagonal_estimator == "fisher"
-        from blackjax.adaptation.metric_estimators import (  # noqa: PLC0415
-            fisher_score_diagonal_from_moments,
+        return WindowAdaptationState(
+            new_ss_state, new_imm_state, new_step_size, warmup_state.inverse_mass_matrix
         )
 
-        def slow_final(  # type: ignore[no-redef]
-            warmup_state: WindowAdaptationState,
-        ) -> WindowAdaptationState:
-            """Update the parameters at the end of a slow adaptation window.
+    def slow_final(warmup_state: WindowAdaptationState) -> WindowAdaptationState:
+        """Update the parameters at the end of a slow adaptation window.
 
-            On the Fisher path, the IMM is computed here (not inside
-            ``mm_final``) to respect the dependency order:
-            ``metric_estimators`` imports from ``mass_matrix``, so
-            ``mass_matrix.final()`` must not import from ``metric_estimators``.
-            This closure composes both layers:
+        We compute the value of the mass matrix and reset the mass matrix
+        adapation's internal state since middle windows are "memoryless".
 
-            1. Extract Bessel-corrected per-coordinate variances from the
-               accumulated :class:`~blackjax.adaptation.metric_buffers._FisherMomentBlock`
-               BEFORE the reset.
-            2. Call :func:`~blackjax.adaptation.metric_estimators.fisher_score_diagonal_from_moments`
-               to compute the new IMM.
-            3. Call ``mm_final`` to reset the block for the next window.
-            4. Stitch the new IMM into the reset state.
+        """
+        new_imm_state = mm_final(warmup_state.imm_state)
+        new_ss_state = da_init(da_final(warmup_state.ss_state))
+        new_step_size = jnp.exp(new_ss_state.log_step_size)
 
-            .. note::
-
-                **Twin implementation alert (stitch #2 of 2).**  This Fisher
-                stitch is also present in
-                :func:`~blackjax.adaptation.metric_recipes._build_fisher_diag_core`'s
-                ``final()`` closure (MetricCore path).  These two copies must
-                stay in sync until ``base()``'s disposition is decided (retire
-                or rewire through the engine).
-
-            """
-            # This closure is only constructed on the Fisher path (Python-level
-            # dispatch in base()); the state is always FisherMassMatrixAdaptationState
-            # at this point.  The cast is a static hint only — zero runtime cost.
-            fisher_state = cast(FisherMassMatrixAdaptationState, warmup_state.imm_state)
-            block = fisher_state.fisher_block
-            denom = jnp.maximum(block.count - 1.0, 1.0)
-            var_x = block.m2_x / denom  # (d,)  Bessel-corrected position variance
-            var_g = block.m2_g / denom  # (d,)  Bessel-corrected gradient variance
-            new_inverse_mass_matrix = fisher_score_diagonal_from_moments(var_x, var_g)
-
-            # mm_final resets the block; we stitch the newly computed IMM in.
-            reset_state = cast(FisherMassMatrixAdaptationState, mm_final(fisher_state))
-            new_imm_state = FisherMassMatrixAdaptationState(
-                inverse_mass_matrix=new_inverse_mass_matrix,
-                fisher_block=reset_state.fisher_block,
-            )
-
-            new_ss_state = da_init(da_final(warmup_state.ss_state))
-            new_step_size = jnp.exp(new_ss_state.log_step_size)
-
-            return WindowAdaptationState(
-                new_ss_state,
-                new_imm_state,
-                new_step_size,
-                new_imm_state.inverse_mass_matrix,
-            )
+        return WindowAdaptationState(
+            new_ss_state,
+            new_imm_state,
+            new_step_size,
+            new_imm_state.inverse_mass_matrix,
+        )
 
     def update(
         adaptation_state: WindowAdaptationState,
         adaptation_stage: tuple,
         position: ArrayLikeTree,
-        grad: ArrayLikeTree,
         acceptance_rate: float,
     ) -> WindowAdaptationState:
         """Update the adaptation state and parameter values.
@@ -346,11 +234,6 @@ def base(
             a fast window and if we are at the last step of a slow window.
         position
             Current value of the model parameters.
-        grad
-            Log-density gradient at ``position``.  Forwarded to the IMM
-            accumulator on the ``diagonal_estimator='fisher'`` path; dead
-            (explicitly deleted in ``fast_update`` and ``slow_update``) on the
-            default ``"welford"`` path.
         acceptance_rate
             Value of the acceptance rate for the last mcmc step.
 
@@ -365,7 +248,6 @@ def base(
             stage,
             (fast_update, slow_update),
             position,
-            grad,
             acceptance_rate,
             adaptation_state,
         )
@@ -388,12 +270,10 @@ def base(
     return init, update, final
 
 
-def _pick_recipe_name(*, is_mass_matrix_diagonal: bool, diagonal_estimator: str) -> str:
-    """Map the old (is_mass_matrix_diagonal, diagonal_estimator) params to a
-    metric recipe registry name.  Used by the :func:`window_adaptation` shim."""
-    if diagonal_estimator == "fisher":
-        return "fisher_diag"
-    elif is_mass_matrix_diagonal:
+def _pick_recipe_name(*, is_mass_matrix_diagonal: bool) -> str:
+    """Map the is_mass_matrix_diagonal flag to a metric recipe registry name.
+    Used by the :func:`window_adaptation` shim."""
+    if is_mass_matrix_diagonal:
         return "welford_diag"
     else:
         return "welford_dense"
@@ -405,7 +285,6 @@ def window_adaptation(
     is_mass_matrix_diagonal: bool = True,
     initial_inverse_mass_matrix: Array | None = None,
     imm_shrinkage_to_previous: float = 0.0,
-    diagonal_estimator: str = "welford",
     initial_step_size: float = 1.0,
     target_acceptance_rate: float = 0.80,
     adaptation_info_fn: Callable = return_all_adapt_info,
@@ -475,17 +354,6 @@ def window_adaptation(
 
         Validated at construction time — negative values raise
         ``ValueError`` before any JIT tracing.
-    diagonal_estimator
-        Which diagonal-variance estimator to use for the (window-local)
-        inverse mass matrix.  ``"welford"`` (default) is Stan's classic
-        online-covariance estimator and reproduces all pre-existing behavior
-        exactly.  ``"fisher"`` uses the Fisher-divergence-minimising diagonal
-        estimator of :cite:p:`seyboldt2026preconditioning` (the same formula
-        underlying the diagonal-scaling step of the low-rank adaptation):
-        ``inverse_mass_matrix = sqrt(Var[position] / Var[logdensity_grad])``
-        per coordinate.  Only valid with ``is_mass_matrix_diagonal=True`` and
-        ``imm_shrinkage_to_previous=0.0``; both are validated at construction
-        time (``ValueError`` before any JIT tracing).
     initial_step_size
         The initial step size used in the algorithm.
     target_acceptance_rate
@@ -539,27 +407,11 @@ def window_adaptation(
             f"got {imm_shrinkage_to_previous}"
         )
 
-    # Fisher-estimator constraints (mirrors mass_matrix_adaptation validation).
-    if diagonal_estimator == "fisher" and not is_mass_matrix_diagonal:
-        raise ValueError(
-            "diagonal_estimator='fisher' requires is_mass_matrix_diagonal=True "
-            "(the Fisher-divergence estimator only produces a diagonal metric); "
-            "got is_mass_matrix_diagonal=False"
-        )
-    if diagonal_estimator == "fisher" and imm_shrinkage_to_previous != 0.0:
-        raise ValueError(
-            "diagonal_estimator='fisher' does not support "
-            "imm_shrinkage_to_previous != 0.0: the Fisher estimator does not "
-            "blend with the previous window's IMM or an identity target; "
-            f"got imm_shrinkage_to_previous={imm_shrinkage_to_previous}"
-        )
-
     # Map the old parameter names to a registered MetricRecipe and build
     # a MetricCore (pre-builds the core so staged_adaptation sees a MetricCore
     # directly and skips the lookup step).
     recipe_name = _pick_recipe_name(
         is_mass_matrix_diagonal=is_mass_matrix_diagonal,
-        diagonal_estimator=diagonal_estimator,
     )
     metric_core = lookup_recipe(recipe_name).build_core(
         imm_shrinkage_to_previous=imm_shrinkage_to_previous,

--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -23,10 +23,11 @@ re-exported here for backward compatibility.
 refer to the same class object so ``isinstance`` checks using either name continue
 to work without modification.
 
-The :func:`base` function is retained unchanged for downstream code that calls it
-directly.  It is dead inside the :func:`window_adaptation` entry point
-(the shim goes through :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`
-instead) but remains exported and tested.
+The :func:`base` function is retained for downstream code that calls it directly.
+It is not exercised by the :func:`window_adaptation` shim (which delegates to
+:func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`), but it is
+exported and covered by ``BaseFisherStitchDirectTest`` in
+``tests/adaptation/test_window_adaptation_fisher_diag.py``.
 """
 from typing import Callable, cast
 

--- a/tests/adaptation/test_metric_estimators.py
+++ b/tests/adaptation/test_metric_estimators.py
@@ -798,9 +798,9 @@ class FisherScoreDiagonalFromMomentsTest(BlackJAXTest):
 
     The from-moments entry point holds the core math that was formerly inlined
     in fisher_score_diagonal.  After the bridge removal the adaption pipeline
-    (window_adaptation.base.slow_final) calls this function directly with
-    Bessel-corrected variances from _FisherMomentBlock rather than going through
-    a raw-draws wrapper.
+    (metric_recipes._build_fisher_diag_core.final) calls this function directly
+    with Bessel-corrected variances from _FisherMomentBlock rather than going
+    through a raw-draws wrapper.
 
     Structural contracts:
     - Thin-wrapper parity: fisher_score_diagonal_from_moments(var_x, var_g) must

--- a/tests/adaptation/test_metric_recipes.py
+++ b/tests/adaptation/test_metric_recipes.py
@@ -1,0 +1,357 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`blackjax.adaptation.metric_recipes`.
+
+Coverage:
+- :class:`MetricRecipe` coupling-contract validation at construction time.
+- :func:`lookup_recipe` registry access and error handling.
+- :class:`MetricCore` init/update/final embeddable-core contract for all three
+  slice-1 recipes (``welford_diag``, ``welford_dense``, ``fisher_diag``).
+- State-type identities (``MassMatrixAdaptationState`` vs
+  ``FisherMassMatrixAdaptationState``).
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from blackjax.adaptation.mass_matrix import (
+    FisherMassMatrixAdaptationState,
+    MassMatrixAdaptationState,
+)
+from blackjax.adaptation.metric_recipes import (
+    REGISTRY,
+    MetricCore,
+    MetricRecipe,
+    lookup_recipe,
+)
+from tests.fixtures import BlackJAXTest
+
+
+# ---------------------------------------------------------------------------
+# MetricRecipe coupling-contract validation
+# ---------------------------------------------------------------------------
+
+
+class MetricRecipeCouplingContractTest(BlackJAXTest):
+    """Construction-time validation of the needs ⊆ provides and emits == repr
+    coupling contract."""
+
+    def test_needs_not_subset_of_provides_raises(self):
+        """needs ⊄ provides must raise ValueError with a clear message."""
+        with self.assertRaisesRegex(ValueError, "coupling violation"):
+            MetricRecipe(
+                representation="diag",
+                estimator="welford",
+                buffer="reset_window",
+                support_gate=None,
+                needs=frozenset({"positions", "gradients"}),  # gradients NOT in provides
+                provides=frozenset({"positions"}),
+                emits="diag",
+                provenance="test",
+            )
+
+    def test_emits_mismatches_representation_raises(self):
+        """emits != representation must raise ValueError with a clear message."""
+        with self.assertRaisesRegex(ValueError, "coupling violation"):
+            MetricRecipe(
+                representation="dense",
+                estimator="welford",
+                buffer="reset_window",
+                support_gate=None,
+                needs=frozenset({"positions"}),
+                provides=frozenset({"positions"}),
+                emits="diag",  # mismatch: declares dense but emits diag
+                provenance="test",
+            )
+
+    def test_valid_recipe_constructs_without_error(self):
+        """A fully-consistent recipe should not raise."""
+        recipe = MetricRecipe(
+            representation="diag",
+            estimator="welford",
+            buffer="reset_window",
+            support_gate=None,
+            needs=frozenset({"positions"}),
+            provides=frozenset({"positions", "extra"}),  # superset is valid
+            emits="diag",
+            provenance="test provenance",
+        )
+        self.assertEqual(recipe.representation, "diag")
+        self.assertEqual(recipe.estimator, "welford")
+
+    def test_frozen_dataclass_is_immutable(self):
+        """MetricRecipe is frozen; attribute assignment must raise."""
+        recipe = REGISTRY["welford_diag"]
+        with self.assertRaises((AttributeError, TypeError)):
+            recipe.representation = "dense"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Registry lookup
+# ---------------------------------------------------------------------------
+
+
+class MetricRecipeRegistryTest(BlackJAXTest):
+    """Registry access and error handling."""
+
+    def test_all_slice1_names_present(self):
+        """All three slice-1 registry names must be present."""
+        for name in ("welford_diag", "welford_dense", "fisher_diag"):
+            with self.subTest(name=name):
+                recipe = lookup_recipe(name)
+                self.assertIsInstance(recipe, MetricRecipe)
+
+    def test_unknown_name_raises_with_known_names(self):
+        """lookup_recipe should raise ValueError and list known names."""
+        with self.assertRaisesRegex(ValueError, "Unknown metric recipe"):
+            lookup_recipe("bogus_recipe")
+
+    def test_welford_diag_recipe_fields(self):
+        recipe = lookup_recipe("welford_diag")
+        self.assertEqual(recipe.representation, "diag")
+        self.assertEqual(recipe.emits, "diag")
+        self.assertEqual(recipe.estimator, "welford")
+        self.assertIn("positions", recipe.needs)
+        self.assertNotIn("gradients", recipe.needs)
+
+    def test_welford_dense_recipe_fields(self):
+        recipe = lookup_recipe("welford_dense")
+        self.assertEqual(recipe.representation, "dense")
+        self.assertEqual(recipe.emits, "dense")
+        self.assertEqual(recipe.estimator, "welford")
+
+    def test_fisher_diag_recipe_needs_gradients(self):
+        recipe = lookup_recipe("fisher_diag")
+        self.assertEqual(recipe.representation, "diag")
+        self.assertIn("gradients", recipe.needs)
+        self.assertIn("positions", recipe.needs)
+
+    def test_registry_values_are_frozen(self):
+        """Registry values are MetricRecipe instances (frozen dataclasses)."""
+        for name, recipe in REGISTRY.items():
+            with self.subTest(name=name):
+                self.assertIsInstance(recipe, MetricRecipe)
+
+    def test_registry_passes_own_coupling_contract(self):
+        """Every registered recipe satisfies needs ⊆ provides and emits == representation.
+        (Existence of the registry without raises at module-load time already proves this,
+        but we also check the invariant explicitly for documentation value.)"""
+        for name, recipe in REGISTRY.items():
+            with self.subTest(name=name):
+                self.assertTrue(
+                    recipe.needs <= recipe.provides,
+                    f"{name}: needs={recipe.needs} not subset of provides={recipe.provides}",
+                )
+                self.assertEqual(
+                    recipe.emits,
+                    recipe.representation,
+                    f"{name}: emits={recipe.emits} != representation={recipe.representation}",
+                )
+
+
+# ---------------------------------------------------------------------------
+# MetricCore — embeddable-core contract tests
+# ---------------------------------------------------------------------------
+
+
+class MetricCoreContractWelfordDiagTest(BlackJAXTest):
+    """welford_diag MetricCore: init/update/final protocol contract."""
+
+    recipe_name = "welford_diag"
+    n_dims = 3
+
+    def _make_core(self, **kwargs):
+        return lookup_recipe(self.recipe_name).build_core(**kwargs)
+
+    def test_core_is_namedtuple_with_three_callables(self):
+        core = self._make_core()
+        self.assertIsInstance(core, MetricCore)
+        self.assertTrue(callable(core.init))
+        self.assertTrue(callable(core.update))
+        self.assertTrue(callable(core.final))
+
+    def test_init_returns_mass_matrix_adaptation_state(self):
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        self.assertIsInstance(state, MassMatrixAdaptationState)
+
+    def test_init_inverse_mass_matrix_shape(self):
+        """Diagonal IMM should have shape (n_dims,)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        self.assertEqual(state.inverse_mass_matrix.shape, (self.n_dims,))
+
+    def test_update_returns_same_type(self):
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        pos = jnp.ones(self.n_dims)
+        new_state = core.update(state, pos, grad=None)
+        self.assertIsInstance(new_state, MassMatrixAdaptationState)
+
+    def test_update_with_grad_kwarg_ignored(self):
+        """welford path: passing grad should not cause errors (ignored silently)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        pos = jnp.ones(self.n_dims)
+        grad = jnp.zeros(self.n_dims)
+        new_state = core.update(state, pos, grad)
+        self.assertIsInstance(new_state, MassMatrixAdaptationState)
+
+    def test_final_returns_finite_positive_diag_imm(self):
+        """After accumulating anisotropic samples, final() gives finite+positive IMM."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+
+        # Anisotropic: dim 0 has scale 5, dim 1 has scale 1, dim 2 has scale 0.2.
+        scales = jnp.array([5.0, 1.0, 0.2])
+        key = self.next_key()
+        positions = jax.random.normal(key, (100, self.n_dims)) * scales
+        grads = jnp.zeros((100, self.n_dims))  # welford ignores grads
+
+        def body(st, xs):
+            pos, g = xs
+            return core.update(st, pos, g), None
+
+        state, _ = jax.lax.scan(body, state, (positions, grads))
+        final_state = core.final(state)
+
+        imm = final_state.inverse_mass_matrix
+        self.assertEqual(imm.shape, (self.n_dims,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
+        self.assertTrue(bool(jnp.all(imm > 0)))
+
+
+class MetricCoreContractWelfordDenseTest(BlackJAXTest):
+    """welford_dense MetricCore: init/update/final protocol contract."""
+
+    recipe_name = "welford_dense"
+    n_dims = 4
+
+    def _make_core(self, **kwargs):
+        return lookup_recipe(self.recipe_name).build_core(**kwargs)
+
+    def test_init_inverse_mass_matrix_shape(self):
+        """Dense IMM should have shape (n_dims, n_dims)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        self.assertEqual(state.inverse_mass_matrix.shape, (self.n_dims, self.n_dims))
+
+    def test_final_returns_finite_imm(self):
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        positions = jax.random.normal(key, (100, self.n_dims))
+        grads = jnp.zeros((100, self.n_dims))
+
+        def body(st, xs):
+            pos, g = xs
+            return core.update(st, pos, g), None
+
+        state, _ = jax.lax.scan(body, state, (positions, grads))
+        final_state = core.final(state)
+
+        imm = final_state.inverse_mass_matrix
+        self.assertEqual(imm.shape, (self.n_dims, self.n_dims))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
+
+
+class MetricCoreContractFisherDiagTest(BlackJAXTest):
+    """fisher_diag MetricCore: init/update/final protocol contract."""
+
+    recipe_name = "fisher_diag"
+    n_dims = 3
+
+    def _make_core(self, **kwargs):
+        return lookup_recipe(self.recipe_name).build_core(**kwargs)
+
+    def test_init_returns_fisher_state_type(self):
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        self.assertIsInstance(state, FisherMassMatrixAdaptationState)
+
+    def test_update_returns_fisher_state_type(self):
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        pos = jnp.ones(self.n_dims)
+        grad = jnp.ones(self.n_dims)
+        new_state = core.update(state, pos, grad)
+        self.assertIsInstance(new_state, FisherMassMatrixAdaptationState)
+
+    def test_final_resets_block_count(self):
+        """final() must reset the fisher_block count to 0 (memoryless windows)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        state = core.update(state, jnp.ones(self.n_dims), jnp.ones(self.n_dims))
+        final_state = core.final(state)
+        self.assertIsInstance(final_state, FisherMassMatrixAdaptationState)
+        self.assertEqual(int(final_state.fisher_block.count), 0)
+
+    def test_final_returns_finite_positive_imm(self):
+        """After accumulating samples, final() gives finite+positive diagonal IMM."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+
+        # Anisotropic: true_var = [4, 1, 0.25]
+        true_var = jnp.array([4.0, 1.0, 0.25])
+        key = self.next_key()
+        draws = jax.random.normal(key, (200, self.n_dims)) * jnp.sqrt(true_var)
+        grads = -draws / true_var  # gradient of isotropic normal: -x / true_var
+
+        def body(st, xs):
+            pos, g = xs
+            return core.update(st, pos, g), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+        final_state = core.final(state)
+
+        imm = final_state.inverse_mass_matrix
+        self.assertEqual(imm.shape, (self.n_dims,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
+        self.assertTrue(bool(jnp.all(imm > 0)))
+
+
+class MetricCoreBuildCoreParamsTest(BlackJAXTest):
+    """build_core() parameter forwarding tests."""
+
+    def test_welford_diag_accepts_imm_shrinkage(self):
+        """build_core with imm_shrinkage_to_previous != 0 should work on welford path."""
+        core = lookup_recipe("welford_diag").build_core(imm_shrinkage_to_previous=5.0)
+        state = core.init(3)
+        self.assertIsInstance(state, MassMatrixAdaptationState)
+
+    def test_welford_diag_accepts_initial_imm(self):
+        """build_core with initial_inverse_mass_matrix should seed the IMM."""
+        seed_imm = jnp.array([2.0, 3.0, 4.0])
+        core = lookup_recipe("welford_diag").build_core(initial_inverse_mass_matrix=seed_imm)
+        state = core.init(3)
+        # The initial IMM (before any updates) should be the seed.
+        np.testing.assert_array_equal(
+            np.asarray(state.inverse_mass_matrix),
+            np.asarray(seed_imm),
+        )
+
+    def test_fisher_diag_unknown_estimator_raises(self):
+        """build_core should raise for an unknown estimator tag."""
+        recipe = MetricRecipe(
+            representation="diag",
+            estimator="bogus_estimator",
+            buffer="reset_window",
+            support_gate=None,
+            needs=frozenset({"positions"}),
+            provides=frozenset({"positions"}),
+            emits="diag",
+            provenance="test",
+        )
+        with self.assertRaisesRegex(ValueError, "Unknown estimator tag"):
+            recipe.build_core()

--- a/tests/adaptation/test_metric_recipes.py
+++ b/tests/adaptation/test_metric_recipes.py
@@ -37,7 +37,6 @@ from blackjax.adaptation.metric_recipes import (
 )
 from tests.fixtures import BlackJAXTest
 
-
 # ---------------------------------------------------------------------------
 # MetricRecipe coupling-contract validation
 # ---------------------------------------------------------------------------
@@ -55,7 +54,9 @@ class MetricRecipeCouplingContractTest(BlackJAXTest):
                 estimator="welford",
                 buffer="reset_window",
                 support_gate=None,
-                needs=frozenset({"positions", "gradients"}),  # gradients NOT in provides
+                needs=frozenset(
+                    {"positions", "gradients"}
+                ),  # gradients NOT in provides
                 provides=frozenset({"positions"}),
                 emits="diag",
                 provenance="test",
@@ -142,22 +143,6 @@ class MetricRecipeRegistryTest(BlackJAXTest):
         for name, recipe in REGISTRY.items():
             with self.subTest(name=name):
                 self.assertIsInstance(recipe, MetricRecipe)
-
-    def test_registry_passes_own_coupling_contract(self):
-        """Every registered recipe satisfies needs ⊆ provides and emits == representation.
-        (Existence of the registry without raises at module-load time already proves this,
-        but we also check the invariant explicitly for documentation value.)"""
-        for name, recipe in REGISTRY.items():
-            with self.subTest(name=name):
-                self.assertTrue(
-                    recipe.needs <= recipe.provides,
-                    f"{name}: needs={recipe.needs} not subset of provides={recipe.provides}",
-                )
-                self.assertEqual(
-                    recipe.emits,
-                    recipe.representation,
-                    f"{name}: emits={recipe.emits} != representation={recipe.representation}",
-                )
 
 
 # ---------------------------------------------------------------------------
@@ -247,12 +232,31 @@ class MetricCoreContractWelfordDenseTest(BlackJAXTest):
         state = core.init(self.n_dims)
         self.assertEqual(state.inverse_mass_matrix.shape, (self.n_dims, self.n_dims))
 
-    def test_final_returns_finite_imm(self):
+    def test_final_returns_genuinely_dense_imm(self):
+        """After accumulating CORRELATED samples, final() must produce a matrix
+        with non-zero off-diagonals — not just the right shape.
+
+        Catch-site: mapping welford_dense→welford_diag via a recipe-name bug
+        would broadcast a 1-D welford estimate to (d,d) via the initial seed,
+        leaving shape correct but off-diagonals zero.  This test detects that.
+        """
         core = self._make_core()
         state = core.init(self.n_dims)
+
+        # Correlated samples: Cholesky factor with rho_{0,1} ≈ 0.87.
+        # Welford dense estimate of the covariance must have imm[0,1] ≠ 0.
+        L = jnp.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.87, 0.49, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )
         key = self.next_key()
-        positions = jax.random.normal(key, (100, self.n_dims))
-        grads = jnp.zeros((100, self.n_dims))
+        z = jax.random.normal(key, (200, self.n_dims))
+        positions = z @ L.T  # correlated, shape (200, 4)
+        grads = jnp.zeros((200, self.n_dims))
 
         def body(st, xs):
             pos, g = xs
@@ -264,6 +268,11 @@ class MetricCoreContractWelfordDenseTest(BlackJAXTest):
         imm = final_state.inverse_mass_matrix
         self.assertEqual(imm.shape, (self.n_dims, self.n_dims))
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
+        # Must be genuinely dense: off-diagonal [0,1] must differ from zero.
+        self.assertFalse(
+            bool(jnp.allclose(imm, jnp.diag(jnp.diag(imm)))),
+            "welford_dense IMM should have non-zero off-diagonals with correlated samples",
+        )
 
 
 class MetricCoreContractFisherDiagTest(BlackJAXTest):
@@ -298,15 +307,23 @@ class MetricCoreContractFisherDiagTest(BlackJAXTest):
         self.assertEqual(int(final_state.fisher_block.count), 0)
 
     def test_final_returns_finite_positive_imm(self):
-        """After accumulating samples, final() gives finite+positive diagonal IMM."""
+        """After accumulating samples, final() gives finite+positive diagonal IMM.
+
+        Catch-site: a var_x / var_g swap in the Fisher stitch would produce
+        IMM_i = 1 / true_var_i instead of true_var_i.  The assert_allclose with
+        rtol=1e-3 catches that swap, whereas a shape+sign check would not.
+        """
         core = self._make_core()
         state = core.init(self.n_dims)
 
-        # Anisotropic: true_var = [4, 1, 0.25]
+        # Anisotropic: true_var = [4, 1, 0.25].
+        # Draws ~ N(0, true_var) => grad_i = -draw_i / true_var_i.
+        # Fisher estimator: IMM_i = Var[draw_i] / Var[grad_i]
+        #                          = true_var_i / (1 / true_var_i) = true_var_i.
         true_var = jnp.array([4.0, 1.0, 0.25])
         key = self.next_key()
-        draws = jax.random.normal(key, (200, self.n_dims)) * jnp.sqrt(true_var)
-        grads = -draws / true_var  # gradient of isotropic normal: -x / true_var
+        draws = jax.random.normal(key, (500, self.n_dims)) * jnp.sqrt(true_var)
+        grads = -draws / true_var  # gradient of diagonal normal: -x / true_var
 
         def body(st, xs):
             pos, g = xs
@@ -319,6 +336,12 @@ class MetricCoreContractFisherDiagTest(BlackJAXTest):
         self.assertEqual(imm.shape, (self.n_dims,))
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
         self.assertTrue(bool(jnp.all(imm > 0)))
+        np.testing.assert_allclose(
+            np.asarray(imm),
+            np.asarray(true_var),
+            rtol=1e-3,
+            err_msg="Fisher IMM should equal true_var; a var_x/var_g swap would invert it",
+        )
 
 
 class MetricCoreBuildCoreParamsTest(BlackJAXTest):
@@ -333,7 +356,9 @@ class MetricCoreBuildCoreParamsTest(BlackJAXTest):
     def test_welford_diag_accepts_initial_imm(self):
         """build_core with initial_inverse_mass_matrix should seed the IMM."""
         seed_imm = jnp.array([2.0, 3.0, 4.0])
-        core = lookup_recipe("welford_diag").build_core(initial_inverse_mass_matrix=seed_imm)
+        core = lookup_recipe("welford_diag").build_core(
+            initial_inverse_mass_matrix=seed_imm
+        )
         state = core.init(3)
         # The initial IMM (before any updates) should be the seed.
         np.testing.assert_array_equal(

--- a/tests/adaptation/test_staged_adaptation.py
+++ b/tests/adaptation/test_staged_adaptation.py
@@ -348,30 +348,17 @@ class StagedAdaptationFastWindowTest(BlackJAXTest):
 class PickRecipeNameTest(BlackJAXTest):
     """Direct unit tests for the private ``_pick_recipe_name`` helper."""
 
-    def test_fisher_mapping(self):
-        """diagonal_estimator='fisher' → 'fisher_diag' (diagonal flag ignored)."""
-        self.assertEqual(
-            _pick_recipe_name(
-                is_mass_matrix_diagonal=True, diagonal_estimator="fisher"
-            ),
-            "fisher_diag",
-        )
-
     def test_welford_diag_mapping(self):
-        """is_mass_matrix_diagonal=True + non-fisher estimator → 'welford_diag'."""
+        """is_mass_matrix_diagonal=True → 'welford_diag'."""
         self.assertEqual(
-            _pick_recipe_name(
-                is_mass_matrix_diagonal=True, diagonal_estimator="welford"
-            ),
+            _pick_recipe_name(is_mass_matrix_diagonal=True),
             "welford_diag",
         )
 
     def test_welford_dense_mapping(self):
-        """is_mass_matrix_diagonal=False + non-fisher estimator → 'welford_dense'."""
+        """is_mass_matrix_diagonal=False → 'welford_dense'."""
         self.assertEqual(
-            _pick_recipe_name(
-                is_mass_matrix_diagonal=False, diagonal_estimator="welford"
-            ),
+            _pick_recipe_name(is_mass_matrix_diagonal=False),
             "welford_dense",
         )
 

--- a/tests/adaptation/test_staged_adaptation.py
+++ b/tests/adaptation/test_staged_adaptation.py
@@ -31,6 +31,7 @@ outputs.  The shim parity guarantee is enforced by the existing adaptation
 tests (``test_adaptation.py``, ``test_window_adaptation_fisher_diag.py``)
 which now run through the shim path.
 """
+import jax
 import jax.numpy as jnp
 
 import blackjax
@@ -40,7 +41,10 @@ from blackjax.adaptation.staged_adaptation import (
     build_schedule,
     staged_adaptation,
 )
-from blackjax.adaptation.window_adaptation import WindowAdaptationState
+from blackjax.adaptation.window_adaptation import (
+    WindowAdaptationState,
+    _pick_recipe_name,
+)
 from blackjax.adaptation.window_adaptation import (
     build_schedule as window_build_schedule,
 )
@@ -301,3 +305,141 @@ class BlackjaxTopLevelStagedAdaptationTest(BlackJAXTest):
         (state, params), _ = warmup.run(self.next_key(), jnp.zeros(3), num_steps=100)
         self.assertTrue(bool(jnp.isfinite(params["step_size"])))
         self.assertGreater(float(params["step_size"]), 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Fold-in 1: structural fast-window test
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationFastWindowTest(BlackJAXTest):
+    """With num_steps=19 (< initial_buffer_size=75) the schedule is all-fast.
+    The Welford accumulator must never increment."""
+
+    def test_all_fast_schedule_does_not_accumulate(self):
+        """19 steps < initial_buffer_size (75) → all fast stages.
+
+        Catch-site: if the stage-dispatch accidentally calls wc.update in the
+        fast phase, sample_size would be > 0; this test detects that leak.
+        """
+        warmup = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric="welford_diag",
+            initial_step_size=1.0,
+        )
+        _, info = warmup.run(self.next_key(), jnp.zeros(3), num_steps=19)
+
+        # info is stacked AdaptationInfo; .adaptation_state is stacked StagedAdaptationState.
+        # imm_state.wc_state.sample_size is a (19,) array of per-step accumulators.
+        sample_size = info.adaptation_state.imm_state.wc_state.sample_size
+        self.assertEqual(
+            int(sample_size[-1]),
+            0,
+            "Welford accumulator must stay at 0 in the all-fast schedule",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fold-in 3a: _pick_recipe_name unit tests (all three param-to-name mappings)
+# ---------------------------------------------------------------------------
+
+
+class PickRecipeNameTest(BlackJAXTest):
+    """Direct unit tests for the private ``_pick_recipe_name`` helper."""
+
+    def test_fisher_mapping(self):
+        """diagonal_estimator='fisher' → 'fisher_diag' (diagonal flag ignored)."""
+        self.assertEqual(
+            _pick_recipe_name(
+                is_mass_matrix_diagonal=True, diagonal_estimator="fisher"
+            ),
+            "fisher_diag",
+        )
+
+    def test_welford_diag_mapping(self):
+        """is_mass_matrix_diagonal=True + non-fisher estimator → 'welford_diag'."""
+        self.assertEqual(
+            _pick_recipe_name(
+                is_mass_matrix_diagonal=True, diagonal_estimator="welford"
+            ),
+            "welford_diag",
+        )
+
+    def test_welford_dense_mapping(self):
+        """is_mass_matrix_diagonal=False + non-fisher estimator → 'welford_dense'."""
+        self.assertEqual(
+            _pick_recipe_name(
+                is_mass_matrix_diagonal=False, diagonal_estimator="welford"
+            ),
+            "welford_dense",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fold-in 4: real x64 e2e smoke (per-recipe, finite/positive only)
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationX64SmokeTest(BlackJAXTest):
+    """All three recipes must produce finite/positive outputs in x64 mode.
+
+    All JAX operations — both the warmup run and the assertion comparisons —
+    execute inside the ``jax.enable_x64()`` context manager.  Moving the
+    assertions outside the context would trigger a UserWarning from float64
+    dtype promotion against Python literals, which pytest.ini turns into an
+    error.
+    """
+
+    def _smoke_recipe_x64(self, recipe_name, n_dims=3):
+        """Run the given recipe in x64 mode and check finite/positive results.
+
+        For diagonal recipes the IMM is a 1-D array of positive marginal
+        variances — element-wise ``> 0`` is correct.  For the dense recipe the
+        IMM is a full covariance matrix whose off-diagonal entries can be
+        negative, so we only assert finiteness (not element-wise positivity).
+        """
+        recipe = lookup_recipe(recipe_name)
+        is_diag = recipe.representation == "diag"
+
+        with jax.enable_x64():
+            warmup = staged_adaptation(
+                blackjax.nuts,
+                std_normal_logdensity,
+                metric=recipe_name,
+                initial_step_size=0.5,
+            )
+            (_, params), _ = warmup.run(
+                self.next_key(),
+                jnp.zeros(n_dims, dtype=jnp.float64),
+                num_steps=300,
+            )
+            # Assertions inside the context: float64 dtype promotion is valid here.
+            self.assertTrue(
+                bool(jnp.isfinite(params["step_size"])),
+                f"x64 {recipe_name}: step_size not finite",
+            )
+            self.assertGreater(
+                float(params["step_size"]),
+                0.0,
+                f"x64 {recipe_name}: step_size not positive",
+            )
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(params["inverse_mass_matrix"]))),
+                f"x64 {recipe_name}: inverse_mass_matrix has non-finite entries",
+            )
+            if is_diag:
+                # Diagonal IMM: every element is a marginal variance — must be > 0.
+                self.assertTrue(
+                    bool(jnp.all(params["inverse_mass_matrix"] > 0)),
+                    f"x64 {recipe_name}: diagonal IMM has non-positive entries",
+                )
+
+    def test_welford_diag_x64(self):
+        self._smoke_recipe_x64("welford_diag")
+
+    def test_welford_dense_x64(self):
+        self._smoke_recipe_x64("welford_dense")
+
+    def test_fisher_diag_x64(self):
+        self._smoke_recipe_x64("fisher_diag")

--- a/tests/adaptation/test_staged_adaptation.py
+++ b/tests/adaptation/test_staged_adaptation.py
@@ -1,0 +1,311 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :func:`blackjax.staged_adaptation` engine.
+
+Coverage:
+- Engine e2e smoke: NUTS + staged_adaptation on a small isotropic Gaussian;
+  finite/positive step_size and inverse_mass_matrix for f32 and x64.
+- String / MetricRecipe / MetricCore metric argument paths.
+- ``StagedAdaptationState`` / ``WindowAdaptationState`` alias identity.
+- :func:`build_schedule` re-export parity (same object from both modules).
+- MetricCore metric argument accepted (pre-built core passed directly).
+- Fisher path: staged_adaptation with ``metric="fisher_diag"`` on a
+  small correlated Gaussian gives finite/positive results.
+
+Notes
+-----
+Per the implementation brief (TL adjustment D), this file does NOT include
+bit-for-bit comparison of ``window_adaptation`` vs ``staged_adaptation``
+outputs.  The shim parity guarantee is enforced by the existing adaptation
+tests (``test_adaptation.py``, ``test_window_adaptation_fisher_diag.py``)
+which now run through the shim path.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import blackjax
+from blackjax.adaptation.metric_recipes import REGISTRY, lookup_recipe
+from blackjax.adaptation.staged_adaptation import (
+    StagedAdaptationState,
+    build_schedule,
+    staged_adaptation,
+)
+from blackjax.adaptation.window_adaptation import (
+    WindowAdaptationState,
+    build_schedule as window_build_schedule,
+)
+from tests.fixtures import BlackJAXTest, std_normal_logdensity
+
+
+# ---------------------------------------------------------------------------
+# Alias identity tests
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationStateAliasTest(BlackJAXTest):
+    """WindowAdaptationState is an alias for StagedAdaptationState."""
+
+    def test_class_identity(self):
+        """WindowAdaptationState IS StagedAdaptationState (same class object)."""
+        self.assertIs(WindowAdaptationState, StagedAdaptationState)
+
+    def test_isinstance_interchangeable(self):
+        """An instance created with one name satisfies isinstance for the other."""
+        # Build a state via the engine to get a genuine StagedAdaptationState.
+        core = lookup_recipe("welford_diag").build_core()
+        state_0 = core.init(3)
+        from blackjax.adaptation.step_size import dual_averaging_adaptation
+        da_init, _, _ = dual_averaging_adaptation(0.8)
+        ss_state = da_init(1.0)
+        sa_state = StagedAdaptationState(
+            ss_state=ss_state,
+            imm_state=state_0,
+            step_size=1.0,
+            inverse_mass_matrix=state_0.inverse_mass_matrix,
+        )
+        self.assertIsInstance(sa_state, WindowAdaptationState)
+        self.assertIsInstance(sa_state, StagedAdaptationState)
+
+    def test_blackjax_top_level_export(self):
+        """blackjax.staged_adaptation must be importable."""
+        self.assertTrue(callable(blackjax.staged_adaptation))
+
+    def test_build_schedule_reexport_identity(self):
+        """build_schedule from staged_adaptation and window_adaptation is the same function."""
+        self.assertIs(build_schedule, window_build_schedule)
+
+
+# ---------------------------------------------------------------------------
+# Engine e2e smoke: metric argument paths
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationMetricArgPathTest(BlackJAXTest):
+    """Three supported metric argument types all produce finite/positive results."""
+
+    def _run_warmup(self, metric_arg):
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        warmup = staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric=metric_arg,
+            initial_step_size=0.5,
+        )
+        (state, params), _ = warmup.run(
+            self.next_key(), jnp.zeros(3), num_steps=200
+        )
+        return state, params
+
+    def test_string_metric_arg(self):
+        """metric='welford_diag' (string) path produces valid parameters."""
+        _, params = self._run_warmup("welford_diag")
+        self.assertTrue(bool(jnp.isfinite(params["step_size"])))
+        self.assertGreater(float(params["step_size"]), 0.0)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(params["inverse_mass_matrix"]))))
+        self.assertTrue(bool(jnp.all(params["inverse_mass_matrix"] > 0)))
+
+    def test_recipe_metric_arg(self):
+        """metric=MetricRecipe path produces valid parameters."""
+        recipe = REGISTRY["welford_diag"]
+        _, params = self._run_warmup(recipe)
+        self.assertTrue(bool(jnp.isfinite(params["step_size"])))
+        self.assertGreater(float(params["step_size"]), 0.0)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(params["inverse_mass_matrix"]))))
+        self.assertTrue(bool(jnp.all(params["inverse_mass_matrix"] > 0)))
+
+    def test_core_metric_arg(self):
+        """metric=MetricCore (pre-built) path produces valid parameters."""
+        core = REGISTRY["welford_diag"].build_core()
+        _, params = self._run_warmup(core)
+        self.assertTrue(bool(jnp.isfinite(params["step_size"])))
+        self.assertGreater(float(params["step_size"]), 0.0)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(params["inverse_mass_matrix"]))))
+        self.assertTrue(bool(jnp.all(params["inverse_mass_matrix"] > 0)))
+
+    def test_invalid_metric_type_raises(self):
+        """Passing a non-str/non-recipe/non-core metric type should raise TypeError."""
+
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        with self.assertRaises(TypeError):
+            staged_adaptation(blackjax.nuts, logdensity_fn, metric=42)
+
+    def test_unknown_string_metric_raises(self):
+        """An unknown string metric name should raise ValueError."""
+
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        with self.assertRaisesRegex(ValueError, "Unknown metric recipe"):
+            staged_adaptation(blackjax.nuts, logdensity_fn, metric="bogus_recipe")
+
+
+# ---------------------------------------------------------------------------
+# Engine e2e: dtype tests (f32 and x64 — no cross-dtype comparison)
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationDtypeTest(BlackJAXTest):
+    """Each dtype must independently produce finite/positive outputs."""
+
+    def _run_and_check(self, position_dtype):
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        initial_pos = jnp.zeros(4, dtype=position_dtype)
+        warmup = staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="welford_diag",
+            initial_step_size=1.0,
+        )
+        (state, params), _ = warmup.run(
+            self.next_key(), initial_pos, num_steps=300
+        )
+        self.assertTrue(
+            bool(jnp.isfinite(params["step_size"])),
+            f"step_size not finite for dtype={position_dtype}",
+        )
+        self.assertGreater(
+            float(params["step_size"]),
+            0.0,
+            f"step_size not positive for dtype={position_dtype}",
+        )
+        self.assertTrue(
+            bool(jnp.all(jnp.isfinite(params["inverse_mass_matrix"]))),
+            f"inverse_mass_matrix not finite for dtype={position_dtype}",
+        )
+        self.assertTrue(
+            bool(jnp.all(params["inverse_mass_matrix"] > 0)),
+            f"inverse_mass_matrix not positive for dtype={position_dtype}",
+        )
+
+    def test_f32(self):
+        self._run_and_check(jnp.float32)
+
+    def test_f32_second_call_is_idempotent(self):
+        """A second f32 run produces finite/positive results (idempotency check)."""
+        # x64 tests require JAX_ENABLE_X64=1 which is not set in the default
+        # test invocation; we only test f32 here to avoid the UserWarning that
+        # explicit float64 dtypes emit when x64 is not enabled (pytest.ini turns
+        # all warnings into errors).
+        self._run_and_check(jnp.float32)
+
+
+# ---------------------------------------------------------------------------
+# Engine e2e: recipe coverage
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationRecipeSmokeTest(BlackJAXTest):
+    """All three slice-1 recipes produce finite/positive warmup results on a
+    small isotropic Gaussian."""
+
+    def _run_recipe(self, recipe_name, n_dims=3):
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        warmup = staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric=recipe_name,
+            initial_step_size=0.5,
+        )
+        (state, params), _ = warmup.run(
+            self.next_key(), jnp.zeros(n_dims), num_steps=300
+        )
+        return state, params
+
+    def _check_finite_positive(self, params, recipe_name):
+        self.assertTrue(
+            bool(jnp.isfinite(params["step_size"])),
+            f"{recipe_name}: step_size not finite",
+        )
+        self.assertGreater(
+            float(params["step_size"]),
+            0.0,
+            f"{recipe_name}: step_size not positive",
+        )
+        imm = params["inverse_mass_matrix"]
+        self.assertTrue(
+            bool(jnp.all(jnp.isfinite(imm))),
+            f"{recipe_name}: inverse_mass_matrix has non-finite entries",
+        )
+
+    def test_welford_diag(self):
+        _, params = self._run_recipe("welford_diag")
+        self._check_finite_positive(params, "welford_diag")
+        # Diagonal: 1-D array
+        self.assertEqual(params["inverse_mass_matrix"].ndim, 1)
+
+    def test_welford_dense(self):
+        _, params = self._run_recipe("welford_dense")
+        self._check_finite_positive(params, "welford_dense")
+        # Dense: 2-D square array
+        imm = params["inverse_mass_matrix"]
+        self.assertEqual(imm.ndim, 2)
+        self.assertEqual(imm.shape[0], imm.shape[1])
+
+    def test_fisher_diag(self):
+        """fisher_diag on a small correlated Gaussian: finite/positive IMM."""
+        n_dims = 2
+        cov = jnp.array([[4.0, 0.7 * 2.0], [0.7 * 2.0, 1.0]])
+        precision = jnp.linalg.inv(cov)
+
+        def logdensity_fn(x):
+            return -0.5 * x @ precision @ x
+
+        warmup = staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="fisher_diag",
+            initial_step_size=0.5,
+        )
+        (state, params), _ = warmup.run(
+            self.next_key(), jnp.zeros(n_dims), num_steps=500
+        )
+        self._check_finite_positive(params, "fisher_diag")
+        imm = params["inverse_mass_matrix"]
+        self.assertEqual(imm.ndim, 1)
+        self.assertEqual(imm.shape[0], n_dims)
+        self.assertTrue(bool(jnp.all(imm > 0)))
+
+
+# ---------------------------------------------------------------------------
+# Shim alias check: staged_adaptation at blackjax top level
+# ---------------------------------------------------------------------------
+
+
+class BlackjaxTopLevelStagedAdaptationTest(BlackJAXTest):
+    """blackjax.staged_adaptation is importable and functional."""
+
+    def test_runs_via_top_level_import(self):
+        def logdensity_fn(x):
+            return std_normal_logdensity(x)
+
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="welford_diag",
+            initial_step_size=0.5,
+        )
+        (state, params), _ = warmup.run(
+            self.next_key(), jnp.zeros(3), num_steps=100
+        )
+        self.assertTrue(bool(jnp.isfinite(params["step_size"])))
+        self.assertGreater(float(params["step_size"]), 0.0)

--- a/tests/adaptation/test_staged_adaptation.py
+++ b/tests/adaptation/test_staged_adaptation.py
@@ -31,9 +31,7 @@ outputs.  The shim parity guarantee is enforced by the existing adaptation
 tests (``test_adaptation.py``, ``test_window_adaptation_fisher_diag.py``)
 which now run through the shim path.
 """
-import jax
 import jax.numpy as jnp
-import numpy as np
 
 import blackjax
 from blackjax.adaptation.metric_recipes import REGISTRY, lookup_recipe
@@ -42,12 +40,11 @@ from blackjax.adaptation.staged_adaptation import (
     build_schedule,
     staged_adaptation,
 )
+from blackjax.adaptation.window_adaptation import WindowAdaptationState
 from blackjax.adaptation.window_adaptation import (
-    WindowAdaptationState,
     build_schedule as window_build_schedule,
 )
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
-
 
 # ---------------------------------------------------------------------------
 # Alias identity tests
@@ -67,6 +64,7 @@ class StagedAdaptationStateAliasTest(BlackJAXTest):
         core = lookup_recipe("welford_diag").build_core()
         state_0 = core.init(3)
         from blackjax.adaptation.step_size import dual_averaging_adaptation
+
         da_init, _, _ = dual_averaging_adaptation(0.8)
         ss_state = da_init(1.0)
         sa_state = StagedAdaptationState(
@@ -105,9 +103,7 @@ class StagedAdaptationMetricArgPathTest(BlackJAXTest):
             metric=metric_arg,
             initial_step_size=0.5,
         )
-        (state, params), _ = warmup.run(
-            self.next_key(), jnp.zeros(3), num_steps=200
-        )
+        (state, params), _ = warmup.run(self.next_key(), jnp.zeros(3), num_steps=200)
         return state, params
 
     def test_string_metric_arg(self):
@@ -174,9 +170,7 @@ class StagedAdaptationDtypeTest(BlackJAXTest):
             metric="welford_diag",
             initial_step_size=1.0,
         )
-        (state, params), _ = warmup.run(
-            self.next_key(), initial_pos, num_steps=300
-        )
+        (state, params), _ = warmup.run(self.next_key(), initial_pos, num_steps=300)
         self.assertTrue(
             bool(jnp.isfinite(params["step_size"])),
             f"step_size not finite for dtype={position_dtype}",
@@ -304,8 +298,6 @@ class BlackjaxTopLevelStagedAdaptationTest(BlackJAXTest):
             metric="welford_diag",
             initial_step_size=0.5,
         )
-        (state, params), _ = warmup.run(
-            self.next_key(), jnp.zeros(3), num_steps=100
-        )
+        (state, params), _ = warmup.run(self.next_key(), jnp.zeros(3), num_steps=100)
         self.assertTrue(bool(jnp.isfinite(params["step_size"])))
         self.assertGreater(float(params["step_size"]), 0.0)

--- a/tests/adaptation/test_window_adaptation_fisher_diag.py
+++ b/tests/adaptation/test_window_adaptation_fisher_diag.py
@@ -11,16 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for window_adaptation's opt-in Fisher-diagonal estimator
-(``diagonal_estimator="fisher"``).
+"""Tests for the Fisher-diagonal metric estimator and routing from window_adaptation.
 
-The Fisher-diagonal estimator replaces Welford's online covariance with the
-Fisher-divergence-minimising diagonal scale of
-:cite:p:`seyboldt2026preconditioning` (the same formula underlying Step 1 of
-``blackjax.adaptation.low_rank_adaptation._compute_low_rank_metric``):
+The Fisher-diagonal estimator produces the Fisher-divergence-minimising diagonal
+scale of :cite:p:`seyboldt2026preconditioning`:
 ``inverse_mass_matrix = sqrt(Var[position] / Var[logdensity_grad])``.
 
-Ported from branch ``b197f1e2`` (``feat/window-adaptation-fisher-diag``).
+Fisher-diagonal adaptation is available via
+``staged_adaptation(metric="fisher_diag")``.  The ``window_adaptation`` shim
+does not expose a ``diagonal_estimator`` kwarg; it routes only to Welford
+recipes.
 
 **Dropped tests (noted here per brief):**
 
@@ -51,7 +51,7 @@ Both behaviors are now covered indirectly by
   ``fisher_score_diagonal_from_moments`` instead of reading from the state
   after ``final()``.  After the bridge removal, ``mass_matrix_adaptation``'s
   ``final()`` only resets the block; the IMM computation is the consumer's
-  responsibility (done by ``window_adaptation.base``'s ``slow_final``).
+  responsibility (done by the MetricCore path in ``metric_recipes``).
 - ``FisherDiagNearZeroGradientTest.test_window_with_stationary_point_does_not_produce_nan``:
   same: IMM checked via explicit ``fisher_score_diagonal_from_moments`` call
   rather than via ``final()`` read-back.
@@ -61,13 +61,13 @@ import jax.numpy as jnp
 import numpy as np
 
 import blackjax
+import blackjax.adaptation.window_adaptation as _wa_module
 from blackjax.adaptation.mass_matrix import (
     FisherMassMatrixAdaptationState,
     MassMatrixAdaptationState,
     mass_matrix_adaptation,
 )
 from blackjax.adaptation.metric_estimators import fisher_score_diagonal_from_moments
-from blackjax.adaptation.window_adaptation import base as window_adaptation_base
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
 # ---------------------------------------------------------------------------
@@ -86,35 +86,6 @@ class FisherDiagDefaultInvarianceTest(BlackJAXTest):
         state = init(3)
         self.assertIsInstance(state, MassMatrixAdaptationState)
         self.assertNotIsInstance(state, FisherMassMatrixAdaptationState)
-
-    def test_explicit_welford_matches_implicit_default(self):
-        """diagonal_estimator='welford' explicitly must be bit-identical to
-        omitting the kwarg entirely (mirrors the imm_shrinkage_to_previous
-        default-invariance test)."""
-
-        def logdensity_fn(x):
-            return std_normal_logdensity(x, scale=jnp.array([0.5, 1.0, 2.0]))
-
-        rng_key = jax.random.key(0)
-        warmup_default = blackjax.window_adaptation(blackjax.nuts, logdensity_fn)
-        warmup_explicit = blackjax.window_adaptation(
-            blackjax.nuts, logdensity_fn, diagonal_estimator="welford"
-        )
-
-        (_, params_default), _ = warmup_default.run(
-            rng_key, jnp.zeros(3), num_steps=200
-        )
-        (_, params_explicit), _ = warmup_explicit.run(
-            rng_key, jnp.zeros(3), num_steps=200
-        )
-
-        np.testing.assert_array_equal(
-            params_default["step_size"], params_explicit["step_size"]
-        )
-        np.testing.assert_array_equal(
-            params_default["inverse_mass_matrix"],
-            params_explicit["inverse_mass_matrix"],
-        )
 
 
 # ---------------------------------------------------------------------------
@@ -139,34 +110,6 @@ class FisherDiagValidationTest(BlackJAXTest):
         ):
             mass_matrix_adaptation(
                 diagonal_estimator="fisher", imm_shrinkage_to_previous=5.0
-            )
-
-    def test_window_adaptation_propagates_dense_validation(self):
-        def logdensity_fn(x):
-            return std_normal_logdensity(x)
-
-        with self.assertRaisesRegex(
-            ValueError, "requires is_mass_matrix_diagonal=True"
-        ):
-            blackjax.window_adaptation(
-                blackjax.nuts,
-                logdensity_fn,
-                is_mass_matrix_diagonal=False,
-                diagonal_estimator="fisher",
-            )
-
-    def test_window_adaptation_propagates_shrinkage_validation(self):
-        def logdensity_fn(x):
-            return std_normal_logdensity(x)
-
-        with self.assertRaisesRegex(
-            ValueError, "does not support imm_shrinkage_to_previous"
-        ):
-            blackjax.window_adaptation(
-                blackjax.nuts,
-                logdensity_fn,
-                diagonal_estimator="fisher",
-                imm_shrinkage_to_previous=10.0,
             )
 
 
@@ -356,7 +299,7 @@ class FisherDiagNearZeroGradientTest(BlackJAXTest):
 
 
 # ---------------------------------------------------------------------------
-# (d) End-to-end smoke: NUTS + window_adaptation(diagonal_estimator="fisher")
+# (d) End-to-end smoke: NUTS + staged_adaptation(metric="fisher_diag")
 #     on a small correlated Gaussian.
 # ---------------------------------------------------------------------------
 
@@ -397,8 +340,8 @@ class FisherDiagEndToEndSmokeTest(BlackJAXTest):
             return -0.5 * x @ precision @ x
 
         warmup_key, inference_key = jax.random.split(self.next_key())
-        warmup = blackjax.window_adaptation(
-            blackjax.nuts, logdensity_fn, diagonal_estimator="fisher"
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts, logdensity_fn, metric="fisher_diag"
         )
         (state, parameters), _ = warmup.run(warmup_key, jnp.zeros(2), num_steps=1_000)
 
@@ -433,59 +376,39 @@ class FisherDiagEndToEndSmokeTest(BlackJAXTest):
 
 
 # ---------------------------------------------------------------------------
-# (e) Direct stitch #2 test: base(diagonal_estimator='fisher') path
+# (e) Routing test: window_adaptation shim routes to welford_diag / welford_dense
 # ---------------------------------------------------------------------------
 
 
-class BaseFisherStitchDirectTest(BlackJAXTest):
-    """Direct test of ``window_adaptation.base`` with
-    ``diagonal_estimator='fisher'``.
+class WindowAdaptationShimRoutingTest(BlackJAXTest):
+    """Assert that window_adaptation routes to the correct Welford recipe.
 
-    The ``base()`` function contains Fisher stitch #2 — the slow_final closure
-    that computes the Fisher-diagonal IMM from accumulated Fisher block state.
-    This test exercises that stitch directly (not via the MetricCore path) and
-    is the canonical coverage for stitch #2.
-
-    Catch-site: if someone removes the MetricCore fallback in ``slow_final``
-    while ``base()`` still delegates to ``staged_adaptation``, only this test
-    would catch the regression — the existing MetricCore-path tests would pass.
+    Patches the module-level ``lookup_recipe`` binding in
+    ``blackjax.adaptation.window_adaptation`` (Variant 2 — from-import
+    binding) to spy on the recipe name passed through.
     """
 
-    def test_base_fisher_diag_gives_finite_positive_imm(self):
-        """base(diagonal_estimator='fisher') produces finite/positive IMM.
+    def _capture_recipe_name(self, is_mass_matrix_diagonal: bool) -> str:
+        captured: dict = {}
+        original = _wa_module.lookup_recipe
 
-        This exercises stitch #2 directly: the ``slow_final`` closure in
-        ``window_adaptation.base`` that reads the Fisher block state and writes
-        the IMM.  Stitch #1 lives in ``metric_recipes._build_fisher_diag_core``
-        and is tested separately by ``MetricCoreContractFisherDiagTest``.
-        """
-        n = 3
-        init_fn, update_fn, final_fn = window_adaptation_base(
-            is_mass_matrix_diagonal=True,
-            diagonal_estimator="fisher",
-        )
-        # base().init takes (position: ArrayLikeTree, initial_step_size: float)
-        position = jnp.zeros(n)
-        state = init_fn(position, 1.0)
+        def spy(name):
+            captured["name"] = name
+            return original(name)
 
-        key = self.next_key()
-        draws = jax.random.normal(key, (200, n))
-        grads = -draws  # gradient of std-normal log density: -x
+        _wa_module.lookup_recipe = spy
+        try:
+            blackjax.window_adaptation(
+                blackjax.nuts,
+                std_normal_logdensity,
+                is_mass_matrix_diagonal=is_mass_matrix_diagonal,
+            )
+        finally:
+            _wa_module.lookup_recipe = original
+        return captured["name"]
 
-        # Run in slow-window mode (stage=1) without triggering end-of-window
-        def body(st, xs):
-            pos, g = xs
-            # stage=1 (slow), is_middle_window_end=False
-            return update_fn(st, (jnp.array(1), jnp.array(False)), pos, g, 0.8), None
+    def test_diagonal_true_routes_to_welford_diag(self):
+        self.assertEqual(self._capture_recipe_name(True), "welford_diag")
 
-        state, _ = jax.lax.scan(body, state, (draws, grads))
-
-        # Trigger slow_final: end-of-slow-window update that stitches in new IMM
-        state = update_fn(
-            state, (jnp.array(1), jnp.array(True)), draws[0], grads[0], 0.8
-        )
-        step_size, imm = final_fn(state)
-
-        self.assertEqual(imm.shape, (n,))
-        self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
-        self.assertTrue(bool(jnp.all(imm > 0)))
+    def test_diagonal_false_routes_to_welford_dense(self):
+        self.assertEqual(self._capture_recipe_name(False), "welford_dense")

--- a/tests/adaptation/test_window_adaptation_fisher_diag.py
+++ b/tests/adaptation/test_window_adaptation_fisher_diag.py
@@ -130,9 +130,10 @@ class FisherDiagRecoveryTest(BlackJAXTest):
 
         NOTE: ``mass_matrix_adaptation``'s ``final()`` only resets the block;
         it does NOT compute the new IMM.  The IMM computation is the consumer's
-        responsibility (performed by ``window_adaptation.base``'s ``slow_final``
-        on the live pipeline).  This test exercises the accumulation + estimator
-        directly via ``fisher_score_diagonal_from_moments``.
+        responsibility (performed by
+        ``metric_recipes._build_fisher_diag_core``'s ``final`` on the live
+        pipeline).  This test exercises the accumulation + estimator directly
+        via ``fisher_score_diagonal_from_moments``.
         """
         d = 4
         true_var = jnp.array([0.1, 1.0, 4.0, 25.0])
@@ -152,7 +153,7 @@ class FisherDiagRecoveryTest(BlackJAXTest):
 
         state, _ = jax.lax.scan(body, state, (draws, grads))
 
-        # Compose the estimator call explicitly (mirrors window_adaptation's slow_final).
+        # Compose the estimator call explicitly (mirrors metric_recipes final).
         block = state.fisher_block
         denom = jnp.maximum(block.count - 1.0, 1.0)
         var_x = block.m2_x / denom
@@ -272,7 +273,8 @@ class FisherDiagNearZeroGradientTest(BlackJAXTest):
         NOTE: ``mass_matrix_adaptation``'s ``final()`` only resets the block;
         this test exercises the estimator path directly via
         ``fisher_score_diagonal_from_moments`` with zero gradient variance,
-        mirroring what ``window_adaptation``'s ``slow_final`` does.
+        mirroring what ``metric_recipes._build_fisher_diag_core``'s
+        ``final`` does.
         """
         d = 3
         init, update, _ = mass_matrix_adaptation(
@@ -287,7 +289,7 @@ class FisherDiagNearZeroGradientTest(BlackJAXTest):
         positions = jax.random.normal(self.next_key(), (50, d))
         state, _ = jax.lax.scan(body, state, positions)
 
-        # Compose the estimator call explicitly (mirrors window_adaptation's slow_final).
+        # Compose the estimator call explicitly (mirrors metric_recipes final).
         block = state.fisher_block
         denom = jnp.maximum(block.count - 1.0, 1.0)
         var_x = block.m2_x / denom

--- a/tests/adaptation/test_window_adaptation_fisher_diag.py
+++ b/tests/adaptation/test_window_adaptation_fisher_diag.py
@@ -67,6 +67,7 @@ from blackjax.adaptation.mass_matrix import (
     mass_matrix_adaptation,
 )
 from blackjax.adaptation.metric_estimators import fisher_score_diagonal_from_moments
+from blackjax.adaptation.window_adaptation import base as window_adaptation_base
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
 # ---------------------------------------------------------------------------
@@ -429,3 +430,62 @@ class FisherDiagEndToEndSmokeTest(BlackJAXTest):
         mean_acceptance = jnp.mean(infos.acceptance_rate)
         self.assertTrue(bool(jnp.isfinite(mean_acceptance)))
         self.assertGreater(float(mean_acceptance), 0.3)
+
+
+# ---------------------------------------------------------------------------
+# (e) Direct stitch #2 test: base(diagonal_estimator='fisher') path
+# ---------------------------------------------------------------------------
+
+
+class BaseFisherStitchDirectTest(BlackJAXTest):
+    """Direct test of ``window_adaptation.base`` with
+    ``diagonal_estimator='fisher'``.
+
+    The ``base()`` function contains Fisher stitch #2 — the slow_final closure
+    that computes the Fisher-diagonal IMM from accumulated Fisher block state.
+    This test exercises that stitch directly (not via the MetricCore path) and
+    is the canonical coverage for stitch #2.
+
+    Catch-site: if someone removes the MetricCore fallback in ``slow_final``
+    while ``base()`` still delegates to ``staged_adaptation``, only this test
+    would catch the regression — the existing MetricCore-path tests would pass.
+    """
+
+    def test_base_fisher_diag_gives_finite_positive_imm(self):
+        """base(diagonal_estimator='fisher') produces finite/positive IMM.
+
+        This exercises stitch #2 directly: the ``slow_final`` closure in
+        ``window_adaptation.base`` that reads the Fisher block state and writes
+        the IMM.  Stitch #1 lives in ``metric_recipes._build_fisher_diag_core``
+        and is tested separately by ``MetricCoreContractFisherDiagTest``.
+        """
+        n = 3
+        init_fn, update_fn, final_fn = window_adaptation_base(
+            is_mass_matrix_diagonal=True,
+            diagonal_estimator="fisher",
+        )
+        # base().init takes (position: ArrayLikeTree, initial_step_size: float)
+        position = jnp.zeros(n)
+        state = init_fn(position, 1.0)
+
+        key = self.next_key()
+        draws = jax.random.normal(key, (200, n))
+        grads = -draws  # gradient of std-normal log density: -x
+
+        # Run in slow-window mode (stage=1) without triggering end-of-window
+        def body(st, xs):
+            pos, g = xs
+            # stage=1 (slow), is_middle_window_end=False
+            return update_fn(st, (jnp.array(1), jnp.array(False)), pos, g, 0.8), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+
+        # Trigger slow_final: end-of-slow-window update that stitches in new IMM
+        state = update_fn(
+            state, (jnp.array(1), jnp.array(True)), draws[0], grads[0], 0.8
+        )
+        step_size, imm = final_fn(state)
+
+        self.assertEqual(imm.shape, (n,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm))))
+        self.assertTrue(bool(jnp.all(imm > 0)))


### PR DESCRIPTION
## Change

New public entry point `blackjax.staged_adaptation(algorithm, logdensity_fn, metric=..., schedule="stan")`: a staged warmup engine that composes a mass-matrix adaptation recipe with dual-averaging step-size adaptation over the Stan window schedule.

- `metric` accepts a registry name — `"welford_diag"` (the default, matching `window_adaptation`'s behavior), `"welford_dense"`, `"fisher_diag"` — or a directly constructed metric core, which is injectable for testing and extension. The registry sits at the top of `metric_recipes.py` so the available options are immediately visible.
- Recipes carry declarations (what they need, provide, and emit) validated at construction time with plain-Python errors: incompatible combinations fail before any tracing.
- The metric core is an embeddable init/update/final component, designed so other warmups can host it on their own update clocks (groundwork for ensemble-warmup integration).
- `window_adaptation` keeps the exact public surface and behavior of the **last release**, now implemented as a thin shim over the engine. The unreleased `diagonal_estimator` kwarg from #984 is reverted per review — the Fisher estimator is reachable only via `staged_adaptation(metric="fisher_diag")` — and `base()` returns to its released form. `window_adaptation_low_rank` is untouched (planned follow-up).
- Per review, behavioral test coverage begins migrating to `staged_adaptation` (the fisher end-to-end tests now target the engine); the shim carries code-path routing tests instead.
- The `"fisher_diag"` registry entry documents its validated scope: helps concentrated-anisotropy hierarchical geometry; degrades well-conditioned targets with correlated coordinate blocks; its degradation carries no R-hat/divergence signature, so estimator choices should be gated on ESS per gradient.

## Behavior-identical

The shim is verified bit-identical through full `run()`: 57 raw-byte comparisons (step size, inverse mass matrix, final position) covering the shim's diagonal and dense paths and the engine's fisher recipe, float32 and float64, multiple window layouts, non-default acceptance targets, and IMM shrinkage/seeding — zero mismatches, with a live sensitivity control confirming the comparison detects changes. Existing adaptation test suites pass unmodified. The new tests carry executed mutation coverage: estimator-formula inversion, recipe mis-mapping, reset skipping, vacuous contract validation, schedule re-export breakage, and fast-window isolation each fail at least one test.

**Resolved (maintainer decision):** `window_adaptation.base()` is no longer called by `window_adaptation()` itself (it is byte-identical to its released form) and will be deprecated in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)