### PR TITLE
Add low-rank metric recipes and route window_adaptation_low_rank through the staged engine

### DIFF
--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -98,6 +98,14 @@ from blackjax.adaptation.metric_estimators import (  # noqa: F401 — backward-c
     _relative_pd_floor,
     _spd_mean,
 )
+from blackjax.adaptation.metric_recipes import (
+    _build_fisher_low_rank_core,
+    seed_low_rank_sigma_from_grad,
+)
+from blackjax.adaptation.staged_adaptation import (
+    StagedAdaptationState,
+    staged_adaptation,
+)
 from blackjax.adaptation.step_size import (
     DualAveragingAdaptationState,
     dual_averaging_adaptation,
@@ -210,6 +218,57 @@ def _default_low_rank_adaptation_info_fn(
         draws_buffer=None, grads_buffer=None
     )
     return AdaptationInfo(state, info, trimmed_adaptation_state)
+
+
+def _engine_state_to_low_rank_adaptation_state(
+    engine_state: StagedAdaptationState,
+) -> "LowRankAdaptationState":
+    """Convert a :class:`~blackjax.adaptation.staged_adaptation.StagedAdaptationState`
+    (whose ``imm_state`` is a :class:`~blackjax.adaptation.metric_recipes
+    .LowRankMetricCoreState`) to a :class:`LowRankAdaptationState`.
+
+    Used by the reset-path info bridge in :func:`window_adaptation_low_rank`
+    to expose the same ``adaptation_state`` field layout as the legacy
+    :func:`base` scan loop.  Downstream code that inspects
+    ``info[-1].adaptation_state.sigma``, ``.mu_star``, ``.U``, etc. continues
+    to work without change across both buffer policies.
+    """
+    imm = engine_state.imm_state  # LowRankMetricCoreState
+    return LowRankAdaptationState(
+        ss_state=engine_state.ss_state,
+        sigma=imm.inverse_mass_matrix.sigma,
+        mu_star=imm.mu_star,
+        U=imm.inverse_mass_matrix.U,
+        lam=imm.inverse_mass_matrix.lam,
+        step_size=engine_state.step_size,
+        draws_buffer=imm.draws_buffer,
+        grads_buffer=imm.grads_buffer,
+        buffer_idx=imm.buffer_idx,
+        background_split=imm.background_split,
+        recompute_counter=imm.recompute_counter,
+    )
+
+
+def _make_low_rank_bridge_info_fn(user_fn: Callable) -> Callable:
+    """Wrap a :class:`LowRankAdaptationState`-expecting info fn for use
+    with the staged-adaptation engine.
+
+    :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation` produces
+    :class:`~blackjax.adaptation.staged_adaptation.StagedAdaptationState` as
+    its per-step adaptation state.  :func:`window_adaptation_low_rank`'s
+    ``adaptation_info_fn`` parameter (including the default
+    :func:`_default_low_rank_adaptation_info_fn`) expects a
+    :class:`LowRankAdaptationState`.  This factory bridges the two: the engine's
+    state is converted via :func:`_engine_state_to_low_rank_adaptation_state`
+    before ``user_fn`` is called, so the returned ``info`` pytree has the same
+    structure whether the reset or accumulating path is active.
+    """
+
+    def _wrapped(state, info, engine_state: StagedAdaptationState) -> AdaptationInfo:
+        lr_state = _engine_state_to_low_rank_adaptation_state(engine_state)
+        return user_fn(state, info, lr_state)
+
+    return _wrapped
 
 
 # ---------------------------------------------------------------------------
@@ -898,76 +957,146 @@ def window_adaptation_low_rank(
 
     Notes
     -----
+    The default (reset) buffer policy runs on the staged-adaptation engine;
+    the accumulating policy uses the established low-rank scan loop, which it
+    shares with earlier releases.
+
     Wrap ``warmup.run(...)`` in :func:`blackjax.progress_bar` to display a
     progress bar, e.g. ``with blackjax.progress_bar(): warmup.run(...)``.
     """
-    if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
-        mcmc_kernel = algorithm.build_kernel(integrator)
-    else:
-        mcmc_kernel = algorithm.build_kernel()
-
-    adapt_init, adapt_step, adapt_final = base(
-        max_rank=max_rank,
-        target_acceptance_rate=target_acceptance_rate,
-        gamma=gamma,
-        cutoff=cutoff,
-        gradient_based_init=gradient_based_init,
-        buffer_policy=buffer_policy,
-        recompute_every=recompute_every,
-    )
-
-    def one_step(carry, xs):
-        _, rng_key, adaptation_stage = xs
-        state, adaptation_state = carry
-
-        metric = gaussian_euclidean_low_rank(
-            adaptation_state.sigma,
-            adaptation_state.U,
-            adaptation_state.lam,
+    if buffer_policy not in ("reset", "accumulating"):
+        raise ValueError(
+            f"buffer_policy must be 'reset' or 'accumulating', got {buffer_policy!r}"
         )
-        new_state, info = mcmc_kernel(
-            rng_key,
-            state,
+    if recompute_every < 1:
+        raise ValueError(f"recompute_every must be >= 1, got {recompute_every!r}")
+
+    def _run_reset(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int) -> tuple:
+        """Reset policy: run via the staged-adaptation engine (default path).
+
+        The buffer is hard-reset to empty at every slow-window boundary.
+        Bit-exact with the pre-engine implementation for all default parameters.
+        """
+        # Size the buffer to the expected largest slow window rather than the
+        # full warmup length.  Modular indexing in the core's update() means
+        # that if a window exceeds buffer_size only the most recent buffer_size
+        # draws are kept -- matching nutpie's fixed-buffer behaviour and
+        # avoiding O(num_steps × d) allocations for large d.
+        typical_window = max(num_steps // 5, 128)
+        buffer_size = min(typical_window * 2, max(num_steps, 1))
+
+        core = _build_fisher_low_rank_core(
+            buffer_size=buffer_size,
+            max_rank=max_rank,
+            gamma=gamma,
+            cutoff=cutoff,
+        )
+
+        seeded_imm_state = None
+        if gradient_based_init:
+            # Call algorithm.init once to get the initial gradient for sigma
+            # seeding.  staged_adaptation().run() will call algorithm.init
+            # again internally (deterministic -- same result, negligible cost).
+            _init_state = algorithm.init(position, logdensity_fn)
+            n_dims = pytree_size(position)
+            seeded_imm_state = seed_low_rank_sigma_from_grad(
+                core.init(n_dims), _init_state.logdensity_grad
+            )
+
+        engine = staged_adaptation(
+            algorithm,
             logdensity_fn,
-            adaptation_state.step_size,
-            metric,
+            metric=core,
+            initial_step_size=initial_step_size,
+            target_acceptance_rate=target_acceptance_rate,
+            # Bridge: engine produces StagedAdaptationState; user's info fn
+            # expects LowRankAdaptationState -- _make_low_rank_bridge_info_fn
+            # converts between the two so that info field access is unchanged.
+            adaptation_info_fn=_make_low_rank_bridge_info_fn(adaptation_info_fn),
+            integrator=integrator,
+            schedule_fn=schedule_fn,
+            initial_metric_state=seeded_imm_state,
             **extra_parameters,
         )
-        new_adaptation_state = adapt_step(
-            adaptation_state,
-            adaptation_stage,
-            new_state.position,
-            new_state.logdensity_grad,
-            info.acceptance_rate,
-        )
-        return (
-            (new_state, new_adaptation_state),
-            adaptation_info_fn(new_state, info, new_adaptation_state),
+
+        results, info = engine.run(rng_key, position, num_steps)  # type: ignore[call-arg]
+
+        # Re-initialise chain at mu* = x̄ + σ²⊙ᾱ (optimal translation, §3.2).
+        # mu_star is preserved per-step in the bridged adaptation_state;
+        # [-1] gives the final warmup step's value.
+        mu_star = info.adaptation_state.mu_star[-1]
+        _, unravel = fu.ravel_pytree(position)
+        mu_star_state = algorithm.init(unravel(mu_star), logdensity_fn)
+
+        return AdaptationResults(mu_star_state, results.parameters), info
+
+    def _run_accumulating(
+        rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int
+    ) -> tuple:
+        """Accumulating policy: use the established low-rank scan loop.
+
+        The default (reset) buffer policy runs on the staged-adaptation engine;
+        the accumulating policy uses the established low-rank scan loop, which
+        it shares with earlier releases.  Migrating the accumulating policy onto
+        the staged-adaptation engine is future work; it must NOT be done via an
+        ``is_window_end`` kwarg on ``MetricCore.update()`` — the clean approach
+        is for the core to own its recompute cadence from a step index, or for
+        periodic recompute to fold into the engine's ``final`` contract.
+        """
+        adapt_init_fn, adapt_step_fn, adapt_final_fn = base(
+            max_rank=max_rank,
+            target_acceptance_rate=target_acceptance_rate,
+            gamma=gamma,
+            cutoff=cutoff,
+            gradient_based_init=gradient_based_init,
+            buffer_policy="accumulating",
+            recompute_every=recompute_every,
         )
 
-    def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
+        if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
+            mcmc_kernel = algorithm.build_kernel(integrator)
+        else:
+            mcmc_kernel = algorithm.build_kernel()
+
+        def one_step(carry, xs):
+            _, rng_key_, adaptation_stage = xs
+            state, adaptation_state = carry
+            metric = gaussian_euclidean_low_rank(
+                adaptation_state.sigma,
+                adaptation_state.U,
+                adaptation_state.lam,
+            )
+            new_state, step_info = mcmc_kernel(
+                rng_key_,
+                state,
+                logdensity_fn,
+                adaptation_state.step_size,
+                metric,
+                **extra_parameters,
+            )
+            new_adaptation_state = adapt_step_fn(
+                adaptation_state,
+                adaptation_stage,
+                new_state.position,
+                new_state.logdensity_grad,
+                step_info.acceptance_rate,
+            )
+            return (
+                (new_state, new_adaptation_state),
+                adaptation_info_fn(new_state, step_info, new_adaptation_state),
+            )
+
         init_state = algorithm.init(position, logdensity_fn)
         # `schedule` must be computed before sizing the buffer under
         # "accumulating" (its capacity is schedule-derived); `num_steps` is
         # already required to be a concrete Python int here regardless (it
-        # sizes `jax.random.split` and the scan length below), so `schedule`
-        # is a concrete array too -- safe to inspect with plain numpy.
+        # sizes jax.random.split and the scan length below), so `schedule` is a
+        # concrete array too -- safe to inspect with plain numpy.
         schedule = schedule_fn(num_steps)
-        if buffer_policy == "accumulating":
-            # Capacity = the accumulating policy's own worst-case buffer
-            # content (previous + current window), not the "reset" policy's
-            # heuristic below -- see _accumulating_buffer_capacity.
-            buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
-        else:
-            # Size the buffer to the expected largest slow window rather than
-            # the full warmup length.  The modular indexing in slow_update
-            # means that if a window exceeds buffer_size only the most
-            # recent buffer_size draws are kept — matching nutpie's
-            # fixed-buffer behaviour and avoiding O(num_steps × d)
-            # allocations for large d.
-            typical_window = max(num_steps // 5, 128)
-            buffer_size = min(typical_window * 2, max(num_steps, 1))
-        init_adaptation_state = adapt_init(
+        # Capacity = the accumulating policy's own worst-case buffer content
+        # (previous + current window) -- see _accumulating_buffer_capacity.
+        buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
+        init_adaptation_state = adapt_init_fn(
             position,
             init_state.logdensity_grad,
             initial_step_size,
@@ -981,10 +1110,10 @@ def window_adaptation_low_rank(
             (jnp.arange(num_steps), keys, schedule),
         )
         _, last_warmup_state, *_ = last_state
-        step_size, sigma, mu_star, U, lam = adapt_final(last_warmup_state)
+        step_size, sigma, mu_star, U, lam = adapt_final_fn(last_warmup_state)
         # Return the inverse mass matrix as a pure-array NamedTuple so that the
-        # warmup composes with `jax.vmap` over chains. The kernel layer expands
-        # this into a full `Metric` via `default_metric` at call time. See #916.
+        # warmup composes with jax.vmap over chains.  The kernel layer expands
+        # this into a full Metric via default_metric at call time.  See #916.
         inverse_mass_matrix = LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
         parameters = {
             "step_size": step_size,
@@ -997,5 +1126,12 @@ def window_adaptation_low_rank(
         _, unravel = fu.ravel_pytree(position)
         mu_star_state = algorithm.init(unravel(mu_star), logdensity_fn)
         return AdaptationResults(mu_star_state, parameters), info
+
+    def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
+        if buffer_policy == "accumulating":
+            # Accumulating path: see _run_accumulating docstring for the
+            # architectural rationale for the split.
+            return _run_accumulating(rng_key, position, num_steps)
+        return _run_reset(rng_key, position, num_steps)
 
     return AdaptationAlgorithm(run)

--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -93,7 +93,11 @@ import numpy as np
 
 import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import AdaptationInfo, AdaptationResults
-from blackjax.adaptation.metric_estimators import _relative_pd_floor, _spd_mean
+from blackjax.adaptation.metric_estimators import (  # noqa: F401 — backward-compat re-export; callers import from here
+    _compute_low_rank_metric,
+    _relative_pd_floor,
+    _spd_mean,
+)
 from blackjax.adaptation.step_size import (
     DualAveragingAdaptationState,
     dual_averaging_adaptation,
@@ -213,10 +217,11 @@ def _default_low_rank_adaptation_info_fn(
 # ---------------------------------------------------------------------------
 
 
-# _relative_pd_floor and _spd_mean are defined in metric_estimators and
-# imported above.  They remain accessible from this module's namespace for
-# backward-compatibility (existing callers that import from low_rank_adaptation
-# continue to work).  Canonical location: blackjax.adaptation.metric_estimators.
+# _relative_pd_floor, _spd_mean, and _compute_low_rank_metric are defined in
+# metric_estimators and imported above.  They remain accessible from this
+# module's namespace for backward-compatibility (existing callers that import
+# from low_rank_adaptation continue to work).
+# Canonical location: blackjax.adaptation.metric_estimators.
 
 
 def _shift_buffer_left(buf: Array, shift: Array) -> Array:
@@ -260,199 +265,6 @@ def _accumulating_buffer_capacity(schedule: Array) -> int:
         return int(window_sizes[0])
     pair_sums = window_sizes[1:] + window_sizes[:-1]
     return int(max(window_sizes[0], pair_sums.max()))
-
-
-def _compute_low_rank_metric(
-    draws_buffer: Array,
-    grads_buffer: Array,
-    n: int,
-    max_rank: int,
-    gamma: float,
-    cutoff: float,
-) -> tuple[Array, Array, Array, Array]:
-    """Compute the low-rank metric from a buffer of draws and gradients.
-
-    Implements Algorithm 1 of :cite:p:`seyboldt2026preconditioning`, following
-    the nutpie reference implementation.
-
-    Parameters
-    ----------
-    draws_buffer
-        Shape ``(B, d)``.  The first ``n`` rows are valid; remaining rows are
-        zero-padded and masked out.
-    grads_buffer
-        Shape ``(B, d)``.  Log-density gradients corresponding to each draw.
-    n
-        Number of valid samples in the buffer (may be a traced integer).
-    max_rank
-        Maximum number of eigenvectors to retain.
-    gamma
-        Regularisation scale.  The projected covariance is divided by ``gamma``
-        (not scaled by ``n``) before adding the identity, following nutpie's
-        convention.  Smaller values → weaker regularisation (the identity term
-        matters less relative to the data term); the influence of the
-        regularisation fades as the number of draws grows.
-    cutoff
-        Eigenvectors whose eigenvalue falls in ``[1/cutoff, cutoff]`` are
-        masked (eigenvalue set to 1), as they provide no useful preconditioning.
-
-    Returns
-    -------
-    sigma
-        Shape ``(d,)``.  Diagonal scaling.
-    mu_star
-        Shape ``(d,)``.  Optimal translation ``x̄ + σ² ⊙ ᾱ``.
-    U
-        Shape ``(d, max_rank)``.  Low-rank eigenvectors (orthonormal columns).
-    lam
-        Shape ``(max_rank,)``.  Eigenvalues (1 for masked components).
-
-    Notes
-    -----
-    **Dtype promotion** (round-9 schedule-port audit, GAP-1). nuts-rs runs
-    this whole estimator in ``f64`` unconditionally; blackjax chains
-    typically run in ``float32`` (JAX's default), and the audit found that
-    running THIS pipeline specifically (inverting + AIRM-geometric-meaning
-    matrices whose condition number can reach ``~1/gamma``, e.g. ``1e5`` at
-    the default ``gamma=1e-5``) in float32 produces small negative
-    eigenvalues ~98% of the time on the models tested, silently making the
-    returned metric indefinite. If the caller has enabled JAX's ``x64``
-    mode (``jax.config.update("jax_enable_x64", True)``), this function
-    promotes its inputs to ``float64`` internally regardless of the
-    incoming (possibly ``float32``) chain dtype, then casts the result back
-    -- decoupling the metric estimate's numerical precision from the
-    sampler's own working dtype, at zero cost to any other part of the
-    chain. If ``x64`` is not enabled, a cast to ``float64`` would silently
-    be truncated back to ``float32`` by JAX (there is no per-call way to
-    opt into ``float64`` without the global flag), so this function instead
-    proceeds in the input's native dtype and relies on the PD guard in
-    :func:`_spd_mean` (and the floor below) to keep the returned metric
-    positive-definite regardless. **Enabling x64 is strongly recommended**
-    for ``buffer_policy="accumulating"``/nutpie-schedule low-rank warmup,
-    matching nuts-rs's own dtype and the shipped sampling-book example.
-
-    **Array-based equivalent:**
-    :func:`blackjax.adaptation.metric_estimators.fisher_score_low_rank`
-    implements the same estimator on a plain draws array (all-valid rows, no
-    masking).  This buffer-masked variant cannot delegate to that function
-    because ``n`` is a traced JAX integer (inside ``jax.lax.scan`` closures
-    from :func:`slow_final` / :func:`slow_switch` /
-    :func:`slow_recompute_only`): dynamic slicing to ``draws_buffer[:n]``
-    changes the array shape at trace time (not supported under JAX's
-    static-shape rule), so the masking pattern is necessary and integral to
-    ALL computation steps (masked mean, masked variance, masked covariance),
-    not just a pre-processing trim before the pure math.
-    ``_spd_mean`` and ``_relative_pd_floor`` are defined in
-    ``blackjax.adaptation.metric_estimators`` and imported above.
-    """
-    orig_dtype = draws_buffer.dtype
-    compute_dtype = jnp.float64 if jax.config.jax_enable_x64 else orig_dtype
-    draws_buffer = draws_buffer.astype(compute_dtype)
-    grads_buffer = grads_buffer.astype(compute_dtype)
-
-    B, d = draws_buffer.shape
-
-    # Mask valid rows
-    mask = (jnp.arange(B) < n).astype(draws_buffer.dtype)  # (B,)
-    n_safe = jnp.maximum(n, 2).astype(draws_buffer.dtype)  # avoid div-by-zero
-
-    # --- Step 1: diagonal scaling  σ = (Var[x] / Var[∇log p])^{1/4} ---
-    mean_x = (mask[:, None] * draws_buffer).sum(0) / n_safe  # (d,)
-    mean_g = (mask[:, None] * grads_buffer).sum(0) / n_safe  # (d,)
-
-    diff_x = mask[:, None] * (draws_buffer - mean_x[None, :])  # (B, d)
-    diff_g = mask[:, None] * (grads_buffer - mean_g[None, :])  # (B, d)
-
-    # Population variance (n not n-1), matching nutpie
-    var_x = (diff_x**2).sum(0) / n_safe  # (d,)
-    var_g = (diff_g**2).sum(0) / n_safe  # (d,)
-
-    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
-    sigma = jnp.clip(sigma, 1e-20, 1e20)  # nutpie range
-
-    # Optimal translation μ* = x̄ + σ² ⊙ ᾱ  (paper §3.2)
-    mu_star = mean_x + sigma**2 * mean_g
-
-    # --- Step 2: scale draws and gradients ---
-    X = diff_x / sigma[None, :]  # (B, d)  scaled centered draws
-    A = diff_g * sigma[None, :]  # (B, d)  scaled centered gradients
-
-    # --- Step 3: principal subspaces via thin SVD ---
-    _, _, Vt_x = jnp.linalg.svd(X, full_matrices=False)  # Vt_x: (min(B,d), d)
-    _, _, Vt_a = jnp.linalg.svd(A, full_matrices=False)
-    U_x = Vt_x[:max_rank].T  # (d, max_rank)
-    U_a = Vt_a[:max_rank].T  # (d, max_rank)
-
-    # --- Step 4: combined orthonormal basis Q ∈ R^{d × q}, q = min(d, 2k) ---
-    combined = jnp.concatenate([U_x, U_a], axis=1)  # (d, 2*max_rank)
-    Q, _ = jnp.linalg.qr(combined)  # Q: (d, min(d, 2*max_rank))
-    q = Q.shape[1]  # actual subspace dimension
-
-    # --- Step 5: project onto Q ---
-    P_x = Q.T @ X.T  # (q, B)
-    P_a = Q.T @ A.T  # (q, B)
-
-    # --- Step 6: projected covariance matrices ---
-    # nutpie: C = P P^T / gamma + I  (raw gamma, NOT scaled by n -- nuts-rs
-    # estimate_mass_matrix divides the unnormalised sum-of-outer-products by
-    # gamma directly; there is no /n anywhere in that pipeline).
-    C_x = (P_x @ P_x.T) / gamma + jnp.eye(q)
-    C_a = (P_a @ P_a.T) / gamma + jnp.eye(q)
-
-    # --- Step 7: SPD geometric mean Σ = C_x # C_a^{-1} ---
-    # Theorem 2.3 / Eq. 9 (arXiv:2603.18845): the regularized optimal inverse
-    # mass matrix is M_gamma^{-1} = (cov(x)+gamma*I) # (cov(alpha)+gamma*I)^{-1}
-    # -- the score/gradient covariance must be INVERTED before the geometric
-    # mean. Cross-validated against nutpie's own `spd_mean` (nuts-rs
-    # src/transform/adapt/low_rank.rs), whose own unit test confirms
-    # spd_mean(cov_draws, cov_grads) == cov_draws # cov_grads^{-1}.
-    Sigma = _spd_mean(C_x, jnp.linalg.inv(C_a))
-
-    # --- Step 8: eigendecompose Σ in the projected subspace ---
-    vals, vecs = jnp.linalg.eigh(Sigma)  # vals ascending, (2k,)
-    # PD guard (round-9 audit, GAP-2): Sigma is PD by construction in exact
-    # arithmetic (both C_x, C_a are `P P^T / gamma + I`, hence PD, and
-    # _spd_mean itself is now floored -- see its docstring), but float32
-    # rounding through this eigendecomposition-heavy pipeline can still tip
-    # a near-zero eigenvalue negative. Flooring here is the same
-    # scale-relative guard as _spd_mean's (see _relative_pd_floor -- an
-    # ABSOLUTE eps floor is wrong for this pipeline's wide dynamic range),
-    # applied to the metric's OWN final eigenvalues (belt-and-suspenders,
-    # matching nuts-rs's own `vals.all(|x| x > 0.)` assertion in
-    # `test_estimate_mass_matrix`).
-    vals = jnp.maximum(vals, _relative_pd_floor(vals))
-    U_full = Q @ vecs  # (d, 2k) back to original space
-
-    # --- Step 9: select top max_rank by |λ-1|; mask near-unity eigenvalues ---
-    # nutpie keeps λ < 1/cutoff or λ > cutoff; others carry no preconditioning
-    # benefit.  In JAX (fixed shapes) we retain the slots but set λ=1 to
-    # effectively zero out those directions in the metric.
-    # When q < max_rank (i.e. d < 2k), only q eigenvectors exist; pad the
-    # remainder with zero columns (λ=1 → no effect on the metric).
-    actual_rank = min(max_rank, q)  # static: both are Python ints at trace time
-    distances = jnp.abs(vals - 1.0)
-    order = jnp.argsort(-distances)[:actual_rank]  # (actual_rank,) indices
-    U_out = U_full[:, order]  # (d, actual_rank)
-    lam_raw = vals[order]
-    is_informative = (lam_raw < 1.0 / cutoff) | (lam_raw > cutoff)
-    lam_out = jnp.where(is_informative, lam_raw, 1.0)
-
-    if actual_rank < max_rank:
-        pad = max_rank - actual_rank
-        U_out = jnp.concatenate([U_out, jnp.zeros((d, pad))], axis=1)
-        lam_out = jnp.concatenate([lam_out, jnp.ones(pad)])
-
-    # Cast back to the caller's original dtype -- the metric's INTERNAL
-    # computation may have been promoted to float64 above, but the returned
-    # state fields (sigma/mu_star/U/lam, folded into LowRankAdaptationState)
-    # must stay in the chain's own working dtype so the rest of the warmup
-    # loop's pytree structure is unaffected.
-    return (
-        sigma.astype(orig_dtype),
-        mu_star.astype(orig_dtype),
-        U_out.astype(orig_dtype),
-        lam_out.astype(orig_dtype),
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -19,7 +19,9 @@ All functions are JAX-traceable and safe to use inside ``jax.lax.scan`` /
 ``jax.vmap`` provided that ``max_rank`` (where applicable) is a static
 Python integer (required to determine output shapes).
 
-**Source lineage** (as of 2026-07-11, main @ 532631c1):
+**Source lineage** (estimator extraction history; the private
+``_compute_low_rank_metric`` helper shared by the fisher path now resides in
+this module, relocated from ``low_rank_adaptation``):
 
 +--------------------------------------+--------------------------------------------+
 | Estimator                            | Extracted from                             |
@@ -169,7 +171,7 @@ def eigenvalue_informativeness(eigenvalues: Array) -> Array:
     This idiom is used identically in:
 
     * :func:`fisher_score_low_rank` (step 9 — top-k selection in projected
-      subspace; see ``low_rank_adaptation._compute_low_rank_metric`` :468).
+      subspace; see ``_compute_low_rank_metric`` in this module).
     * :func:`draws_singular_value_low_rank` (top-k SVD eigenvalue selection;
       see ``mclmc_lrd_adaptation._extract_lrd_from_samples`` :271).
     * :func:`sample_covariance_eigh_low_rank` (top-k eigh eigenvalue selection;
@@ -211,8 +213,7 @@ def select_top_eigenvalues_by_informativeness(
         which arises when ``d < 2 · max_rank``), the output is **zero-padded**
         to the requested shape — zero columns in ``U`` and ``lam=1`` entries
         — so the return shape is always ``(d, max_rank)`` / ``(max_rank,)``.
-        Matches ``low_rank_adaptation._compute_low_rank_metric`` steps 8–9
-        (:468–484).
+        Matches ``_compute_low_rank_metric`` (this module) steps 8–9.
 
     ``tail_handling="raw"``
         Used by :func:`draws_singular_value_low_rank` and
@@ -267,7 +268,7 @@ def select_top_eigenvalues_by_informativeness(
 
     if tail_handling == "mask_pad":
         # argsort(-scores): ascending original-index tie-break — matches the
-        # fisher consumer (low_rank_adaptation._compute_low_rank_metric :468).
+        # fisher consumer (_compute_low_rank_metric, this module).
         order = jnp.argsort(-scores)
         actual_rank = min(max_rank, q)  # static: both are Python ints at trace time
         top_order = order[:actual_rank]

--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -614,6 +614,173 @@ def sample_covariance_eigh_low_rank(
     return LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
 
 
+def _compute_low_rank_metric(
+    draws_buffer: Array,
+    grads_buffer: Array,
+    n: int,
+    max_rank: int,
+    gamma: float,
+    cutoff: float,
+) -> tuple[Array, Array, Array, Array]:
+    """Compute the low-rank metric from a buffer of draws and gradients.
+
+    Buffer-masked variant of :func:`fisher_score_low_rank` for use inside
+    ``jax.lax.scan`` closures where ``n`` is a **traced** JAX integer (the
+    number of valid rows in the buffer).  Unlike the plain-array
+    :func:`fisher_score_low_rank`, this function cannot slice to
+    ``draws_buffer[:n]`` at trace time (dynamic shapes are disallowed); it
+    instead zero-masks the first ``n`` rows.
+
+    Implements Algorithm 1 of :cite:p:`seyboldt2026preconditioning`, following
+    the nutpie reference implementation.
+
+    Parameters
+    ----------
+    draws_buffer
+        Shape ``(B, d)``.  The first ``n`` rows are valid; remaining rows are
+        zero-padded and masked out.
+    grads_buffer
+        Shape ``(B, d)``.  Log-density gradients corresponding to each draw.
+    n
+        Number of valid samples in the buffer (may be a traced integer).
+    max_rank
+        Maximum number of eigenvectors to retain.
+    gamma
+        Regularisation scale.  The projected covariance is divided by ``gamma``
+        (not scaled by ``n``) before adding the identity, following nutpie's
+        convention.
+    cutoff
+        Eigenvectors whose eigenvalue falls in ``[1/cutoff, cutoff]`` are
+        masked (eigenvalue set to 1), as they provide no useful preconditioning.
+
+    Returns
+    -------
+    sigma
+        Shape ``(d,)``.  Diagonal scaling.
+    mu_star
+        Shape ``(d,)``.  Optimal translation ``x̄ + σ² ⊙ ᾱ``.
+    U
+        Shape ``(d, max_rank)``.  Low-rank eigenvectors (orthonormal columns).
+    lam
+        Shape ``(max_rank,)``.  Eigenvalues (1 for masked components).
+
+    Notes
+    -----
+    **Dtype promotion** (round-9 schedule-port audit, GAP-1): when JAX's
+    ``jax_enable_x64`` mode is enabled, promotes all computation to
+    ``float64`` regardless of the chain's working dtype, then casts the result
+    back — decoupling the metric estimate's numerical precision from the
+    sampler's own dtype.  Without ``x64``, proceeds in the input's native
+    dtype and relies on the PD guard in :func:`_spd_mean` and the eigenvalue
+    floor below.  Enabling x64 is strongly recommended for the Fisher
+    low-rank warmup, matching nuts-rs's own f64-throughout estimator.
+
+    **Canonical location:** moved from
+    ``blackjax.adaptation.low_rank_adaptation``; that module re-exports from
+    here for backward compatibility.
+    """
+    orig_dtype = draws_buffer.dtype
+    compute_dtype = jnp.float64 if jax.config.jax_enable_x64 else orig_dtype
+    draws_buffer = draws_buffer.astype(compute_dtype)
+    grads_buffer = grads_buffer.astype(compute_dtype)
+
+    B, d = draws_buffer.shape
+
+    # Mask valid rows
+    mask = (jnp.arange(B) < n).astype(draws_buffer.dtype)  # (B,)
+    n_safe = jnp.maximum(n, 2).astype(draws_buffer.dtype)  # avoid div-by-zero
+
+    # --- Step 1: diagonal scaling  σ = (Var[x] / Var[∇log p])^{1/4} ---
+    mean_x = (mask[:, None] * draws_buffer).sum(0) / n_safe  # (d,)
+    mean_g = (mask[:, None] * grads_buffer).sum(0) / n_safe  # (d,)
+
+    diff_x = mask[:, None] * (draws_buffer - mean_x[None, :])  # (B, d)
+    diff_g = mask[:, None] * (grads_buffer - mean_g[None, :])  # (B, d)
+
+    # Population variance (n not n-1), matching nutpie
+    var_x = (diff_x**2).sum(0) / n_safe  # (d,)
+    var_g = (diff_g**2).sum(0) / n_safe  # (d,)
+
+    sigma = jnp.power(jnp.clip(var_x / jnp.maximum(var_g, 1e-10), 0.0, None), 0.25)
+    sigma = jnp.clip(sigma, 1e-20, 1e20)  # nutpie range
+
+    # Optimal translation μ* = x̄ + σ² ⊙ ᾱ  (paper §3.2)
+    mu_star = mean_x + sigma**2 * mean_g
+
+    # --- Step 2: scale draws and gradients ---
+    X = diff_x / sigma[None, :]  # (B, d)  scaled centered draws
+    A = diff_g * sigma[None, :]  # (B, d)  scaled centered gradients
+
+    # --- Step 3: principal subspaces via thin SVD ---
+    _, _, Vt_x = jnp.linalg.svd(X, full_matrices=False)  # Vt_x: (min(B,d), d)
+    _, _, Vt_a = jnp.linalg.svd(A, full_matrices=False)
+    U_x = Vt_x[:max_rank].T  # (d, max_rank)
+    U_a = Vt_a[:max_rank].T  # (d, max_rank)
+
+    # --- Step 4: combined orthonormal basis Q ∈ R^{d × q}, q = min(d, 2k) ---
+    combined = jnp.concatenate([U_x, U_a], axis=1)  # (d, 2*max_rank)
+    Q, _ = jnp.linalg.qr(combined)  # Q: (d, min(d, 2*max_rank))
+    q = Q.shape[1]  # actual subspace dimension
+
+    # --- Step 5: project onto Q ---
+    P_x = Q.T @ X.T  # (q, B)
+    P_a = Q.T @ A.T  # (q, B)
+
+    # --- Step 6: projected covariance matrices ---
+    # nutpie: C = P P^T / gamma + I  (raw gamma, NOT scaled by n -- nuts-rs
+    # estimate_mass_matrix divides the unnormalised sum-of-outer-products by
+    # gamma directly; there is no /n anywhere in that pipeline).
+    C_x = (P_x @ P_x.T) / gamma + jnp.eye(q)
+    C_a = (P_a @ P_a.T) / gamma + jnp.eye(q)
+
+    # --- Step 7: SPD geometric mean Σ = C_x # C_a^{-1} ---
+    # Theorem 2.3 / Eq. 9 (arXiv:2603.18845): the regularized optimal inverse
+    # mass matrix is M_gamma^{-1} = (cov(x)+gamma*I) # (cov(alpha)+gamma*I)^{-1}
+    # -- the score/gradient covariance must be INVERTED before the geometric
+    # mean. Cross-validated against nutpie's own `spd_mean` (nuts-rs
+    # src/transform/adapt/low_rank.rs), whose own unit test confirms
+    # spd_mean(cov_draws, cov_grads) == cov_draws # cov_grads^{-1}.
+    Sigma = _spd_mean(C_x, jnp.linalg.inv(C_a))
+
+    # --- Step 8: eigendecompose Σ in the projected subspace ---
+    vals, vecs = jnp.linalg.eigh(Sigma)  # vals ascending, (2k,)
+    # PD guard (round-9 audit, GAP-2): Sigma is PD by construction in exact
+    # arithmetic, but float32 rounding through this eigendecomposition-heavy
+    # pipeline can tip a near-zero eigenvalue negative.  Scale-relative floor
+    # matches nuts-rs's own PD-by-construction invariant.
+    vals = jnp.maximum(vals, _relative_pd_floor(vals))
+    U_full = Q @ vecs  # (d, 2k) back to original space
+
+    # --- Step 9: select top max_rank by |λ-1|; mask near-unity eigenvalues ---
+    # nutpie keeps λ < 1/cutoff or λ > cutoff; others carry no preconditioning
+    # benefit.  In JAX (fixed shapes) we retain the slots but set λ=1 to
+    # effectively zero out those directions in the metric.
+    # When q < max_rank (i.e. d < 2k), only q eigenvectors exist; pad the
+    # remainder with zero columns (λ=1 → no effect on the metric).
+    actual_rank = min(max_rank, q)  # static: both are Python ints at trace time
+    distances = jnp.abs(vals - 1.0)
+    order = jnp.argsort(-distances)[:actual_rank]  # (actual_rank,) indices
+    U_out = U_full[:, order]  # (d, actual_rank)
+    lam_raw = vals[order]
+    is_informative = (lam_raw < 1.0 / cutoff) | (lam_raw > cutoff)
+    lam_out = jnp.where(is_informative, lam_raw, 1.0)
+
+    if actual_rank < max_rank:
+        pad = max_rank - actual_rank
+        U_out = jnp.concatenate([U_out, jnp.zeros((d, pad))], axis=1)
+        lam_out = jnp.concatenate([lam_out, jnp.ones(pad)])
+
+    # Cast back to the caller's original dtype -- the metric's INTERNAL
+    # computation may have been promoted to float64 above, but the returned
+    # state fields must stay in the chain's own working dtype.
+    return (
+        sigma.astype(orig_dtype),
+        mu_star.astype(orig_dtype),
+        U_out.astype(orig_dtype),
+        lam_out.astype(orig_dtype),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Diagonal estimators
 # ---------------------------------------------------------------------------

--- a/blackjax/adaptation/metric_estimators.py
+++ b/blackjax/adaptation/metric_estimators.py
@@ -624,13 +624,6 @@ def _compute_low_rank_metric(
 ) -> tuple[Array, Array, Array, Array]:
     """Compute the low-rank metric from a buffer of draws and gradients.
 
-    Buffer-masked variant of :func:`fisher_score_low_rank` for use inside
-    ``jax.lax.scan`` closures where ``n`` is a **traced** JAX integer (the
-    number of valid rows in the buffer).  Unlike the plain-array
-    :func:`fisher_score_low_rank`, this function cannot slice to
-    ``draws_buffer[:n]`` at trace time (dynamic shapes are disallowed); it
-    instead zero-masks the first ``n`` rows.
-
     Implements Algorithm 1 of :cite:p:`seyboldt2026preconditioning`, following
     the nutpie reference implementation.
 
@@ -648,7 +641,9 @@ def _compute_low_rank_metric(
     gamma
         Regularisation scale.  The projected covariance is divided by ``gamma``
         (not scaled by ``n``) before adding the identity, following nutpie's
-        convention.
+        convention.  Smaller values → weaker regularisation (the identity term
+        matters less relative to the data term); the influence of the
+        regularisation fades as the number of draws grows.
     cutoff
         Eigenvectors whose eigenvalue falls in ``[1/cutoff, cutoff]`` are
         masked (eigenvalue set to 1), as they provide no useful preconditioning.
@@ -666,18 +661,41 @@ def _compute_low_rank_metric(
 
     Notes
     -----
-    **Dtype promotion** (round-9 schedule-port audit, GAP-1): when JAX's
-    ``jax_enable_x64`` mode is enabled, promotes all computation to
-    ``float64`` regardless of the chain's working dtype, then casts the result
-    back — decoupling the metric estimate's numerical precision from the
-    sampler's own dtype.  Without ``x64``, proceeds in the input's native
-    dtype and relies on the PD guard in :func:`_spd_mean` and the eigenvalue
-    floor below.  Enabling x64 is strongly recommended for the Fisher
-    low-rank warmup, matching nuts-rs's own f64-throughout estimator.
+    **Dtype promotion** (round-9 schedule-port audit, GAP-1). nuts-rs runs
+    this whole estimator in ``f64`` unconditionally; blackjax chains
+    typically run in ``float32`` (JAX's default), and the audit found that
+    running THIS pipeline specifically (inverting + AIRM-geometric-meaning
+    matrices whose condition number can reach ``~1/gamma``, e.g. ``1e5`` at
+    the default ``gamma=1e-5``) in float32 produces small negative
+    eigenvalues ~98% of the time on the models tested, silently making the
+    returned metric indefinite. If the caller has enabled JAX's ``x64``
+    mode (``jax.config.update("jax_enable_x64", True)``), this function
+    promotes its inputs to ``float64`` internally regardless of the
+    incoming (possibly ``float32``) chain dtype, then casts the result back
+    -- decoupling the metric estimate's numerical precision from the
+    sampler's own working dtype, at zero cost to any other part of the
+    chain. If ``x64`` is not enabled, a cast to ``float64`` would silently
+    be truncated back to ``float32`` by JAX (there is no per-call way to
+    opt into ``float64`` without the global flag), so this function instead
+    proceeds in the input's native dtype and relies on the PD guard in
+    :func:`_spd_mean` (and the floor below) to keep the returned metric
+    positive-definite regardless. **Enabling x64 is strongly recommended**
+    for ``buffer_policy="accumulating"``/nutpie-schedule low-rank warmup,
+    matching nuts-rs's own dtype and the shipped sampling-book example.
 
-    **Canonical location:** moved from
-    ``blackjax.adaptation.low_rank_adaptation``; that module re-exports from
-    here for backward compatibility.
+    **Array-based equivalent:**
+    :func:`blackjax.adaptation.metric_estimators.fisher_score_low_rank`
+    implements the same estimator on a plain draws array (all-valid rows, no
+    masking).  This buffer-masked variant cannot delegate to that function
+    because ``n`` is a traced JAX integer (inside ``jax.lax.scan`` closures
+    from :func:`slow_final` / :func:`slow_switch` /
+    :func:`slow_recompute_only`): dynamic slicing to ``draws_buffer[:n]``
+    changes the array shape at trace time (not supported under JAX's
+    static-shape rule), so the masking pattern is necessary and integral to
+    ALL computation steps (masked mean, masked variance, masked covariance),
+    not just a pre-processing trim before the pure math.
+    ``_spd_mean`` and ``_relative_pd_floor`` are defined in
+    ``blackjax.adaptation.metric_estimators`` and imported above.
     """
     orig_dtype = draws_buffer.dtype
     compute_dtype = jnp.float64 if jax.config.jax_enable_x64 else orig_dtype
@@ -745,9 +763,15 @@ def _compute_low_rank_metric(
     # --- Step 8: eigendecompose Σ in the projected subspace ---
     vals, vecs = jnp.linalg.eigh(Sigma)  # vals ascending, (2k,)
     # PD guard (round-9 audit, GAP-2): Sigma is PD by construction in exact
-    # arithmetic, but float32 rounding through this eigendecomposition-heavy
-    # pipeline can tip a near-zero eigenvalue negative.  Scale-relative floor
-    # matches nuts-rs's own PD-by-construction invariant.
+    # arithmetic (both C_x, C_a are `P P^T / gamma + I`, hence PD, and
+    # _spd_mean itself is now floored -- see its docstring), but float32
+    # rounding through this eigendecomposition-heavy pipeline can still tip
+    # a near-zero eigenvalue negative. Flooring here is the same
+    # scale-relative guard as _spd_mean's (see _relative_pd_floor -- an
+    # ABSOLUTE eps floor is wrong for this pipeline's wide dynamic range),
+    # applied to the metric's OWN final eigenvalues (belt-and-suspenders,
+    # matching nuts-rs's own `vals.all(|x| x > 0.)` assertion in
+    # `test_estimate_mass_matrix`).
     vals = jnp.maximum(vals, _relative_pd_floor(vals))
     U_full = Q @ vecs  # (d, 2k) back to original space
 
@@ -772,7 +796,9 @@ def _compute_low_rank_metric(
 
     # Cast back to the caller's original dtype -- the metric's INTERNAL
     # computation may have been promoted to float64 above, but the returned
-    # state fields must stay in the chain's own working dtype.
+    # state fields (sigma/mu_star/U/lam, folded into LowRankAdaptationState)
+    # must stay in the chain's own working dtype so the rest of the warmup
+    # loop's pytree structure is unaffected.
     return (
         sigma.astype(orig_dtype),
         mu_star.astype(orig_dtype),

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -64,14 +64,15 @@ Layer doctrine:
 - The METRIC CORE (:class:`MetricCore`) handles mass-matrix tuning only.
 - Step-size adaptation and the stage schedule live in the HOST
   (:mod:`~blackjax.adaptation.staged_adaptation`).
-- L3 step-size proxy independence (RFC §4.3): for HMC/NUTS, the dual-averaging
-  step-size proxy is the scalar Metropolis acceptance rate — NOT an eigenvalue
-  quantity of the adapted metric.  This differs from MCLMC-LRD where
-  step_size ∝ 1/√λ_max caused a 20.6×→1.27× effective-sample collapse (the
-  "ε-collapse" RFC finding).  For HMC/NUTS the full low-rank metric feeds the
-  MCMC kernel (correct coupling), and dual averaging reads only acceptance_rate
-  — L3 is naturally satisfied; no diagonal-reference split is needed.  This
-  analysis applies to ALL recipes in this module, including the low-rank slice.
+- Step-size/metric decoupling: for HMC/NUTS, the dual-averaging step-size proxy
+  is the scalar Metropolis acceptance rate — NOT an eigenvalue quantity of the
+  adapted metric.  This matters because in MCLMC-LRD, where step_size ∝ 1/√λ_max,
+  feeding the full low-rank metric to the proxy caused a previously observed
+  step-size collapse (effective-sample rate dropped 20.6×→1.27×).  For HMC/NUTS
+  the full low-rank metric feeds the MCMC kernel (correct coupling), and dual
+  averaging reads only acceptance_rate — the step-size/metric decoupling
+  principle is naturally satisfied; no diagonal-reference split is needed.  This
+  analysis applies to ALL recipes in this module.
 
 Notes
 -----
@@ -611,10 +612,11 @@ def _build_fisher_low_rank_core(
        ._compute_low_rank_metric` on the buffer, stores new sigma/mu_star/U/lam
        in ``inverse_mass_matrix`` and ``mu_star``, resets the buffer to zeros.
 
-    **L3 note** (RFC §4.3): the dual-averaging step-size proxy reads only the
-    scalar Metropolis acceptance rate, NOT an eigenvalue quantity — L3 is
-    naturally satisfied for HMC/NUTS regardless of metric rank.  See module
-    docstring for the full analysis.
+    **Step-size/metric decoupling**: the dual-averaging step-size proxy reads
+    only the scalar Metropolis acceptance rate, NOT an eigenvalue quantity of
+    the adapted metric — the decoupling principle is naturally satisfied for
+    HMC/NUTS regardless of metric rank.  See module docstring for the full
+    analysis.
 
     Parameters
     ----------
@@ -854,8 +856,9 @@ REGISTRY: dict[str, MetricRecipe] = {
             "Uses position AND gradient samples; requires x64 for float32 chains "
             "(see _compute_low_rank_metric dtype note).  Composes with any "
             "schedule_fn; pair with build_growing_window_schedule for the nutpie "
-            "schedule.  L3 is naturally satisfied for HMC/NUTS (acceptance rate "
-            "proxy is not an eigenvalue quantity — see module docstring)."
+            "schedule.  Step-size/metric decoupling is naturally satisfied for "
+            "HMC/NUTS (acceptance-rate proxy is not an eigenvalue quantity — "
+            "see module docstring)."
         ),
     ),
     "sample_cov_low_rank": MetricRecipe(

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -385,6 +385,12 @@ class MetricRecipe:
                 f"Choose an estimator whose emits tag matches the declared "
                 f"representation, or update representation to {self.emits!r}."
             )
+        if self.representation == "low_rank" and self.max_rank is None:
+            raise ValueError(
+                "MetricRecipe: max_rank is required for low-rank representations "
+                f"(representation={self.representation!r}).  "
+                "Set max_rank to a positive integer."
+            )
 
     def build_core(
         self,
@@ -449,11 +455,12 @@ class MetricRecipe:
                     "the 'fisher_low_rank' estimator.  Pass buffer_size=<int> "
                     "or build the core directly via _build_fisher_low_rank_core()."
                 )
-            # max_rank/gamma/cutoff are guaranteed non-None by the registry
-            # constructor; the Optional typing is for the dataclass default.
-            assert (
-                self.max_rank is not None
-            ), "fisher_low_rank recipe must have max_rank"
+            # max_rank/gamma/cutoff are non-None here: __post_init__ raises
+            # ValueError for low_rank representations with max_rank=None, and
+            # the registry always supplies gamma/cutoff for fisher_low_rank entries.
+            # The three asserts below are for mypy narrowing only — the runtime
+            # guard is in __post_init__ (ValueError, not stripped by -O).
+            assert self.max_rank is not None  # narrowing: enforced by __post_init__
             assert self.gamma is not None, "fisher_low_rank recipe must have gamma"
             assert self.cutoff is not None, "fisher_low_rank recipe must have cutoff"
             return _build_fisher_low_rank_core(
@@ -469,9 +476,9 @@ class MetricRecipe:
                     "the 'sample_cov_low_rank' estimator.  Pass buffer_size=<int> "
                     "or build the core directly via _build_sample_cov_low_rank_core()."
                 )
-            assert (
-                self.max_rank is not None
-            ), "sample_cov_low_rank recipe must have max_rank"
+            # max_rank is non-None: __post_init__ raises ValueError for
+            # low_rank representations with max_rank=None.
+            assert self.max_rank is not None  # narrowing: enforced by __post_init__
             return _build_sample_cov_low_rank_core(
                 buffer_size=buffer_size,
                 max_rank=self.max_rank,

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -24,15 +24,27 @@ Pass any of the following string names as the ``metric=`` argument to
 - ``"fisher_diag"`` — Fisher-divergence-minimising diagonal estimator
   (situational; requires position *and* gradient samples; see registry
   provenance note for operational guidance).
+- ``"fisher_low_rank"`` — Fisher-divergence-minimising LOW-RANK estimator;
+  requires position *and* gradient samples; needs a ``buffer_size``
+  argument in ``build_core()``.  Algorithm 1 of
+  :cite:p:`seyboldt2026preconditioning` / nutpie's mass-matrix estimator.
+- ``"sample_cov_low_rank"`` — Sample-covariance low-rank estimator (MEADS
+  / Scheme-B form); draws only, no gradients, no regularisation.  Needs a
+  ``buffer_size`` argument in ``build_core()``.
 
 Usage::
 
     # String sugar (registry lookup):
     wu = staged_adaptation(nuts, logdensity_fn, metric="welford_diag")
 
-    # Recipe constructor (testability / custom configuration):
-    from blackjax.adaptation.metric_recipes import REGISTRY
-    core = REGISTRY["welford_diag"].build_core(imm_shrinkage_to_previous=5.0)
+    # Low-rank: pre-build the core with buffer_size, then pass to engine:
+    from blackjax.adaptation.metric_recipes import REGISTRY, _build_fisher_low_rank_core
+    core = _build_fisher_low_rank_core(buffer_size=256, max_rank=10, gamma=1e-5, cutoff=2.0)
+    wu = staged_adaptation(nuts, logdensity_fn, metric=core, schedule_fn=my_schedule_fn)
+
+    # Via the recipe (also needs buffer_size):
+    recipe = REGISTRY["fisher_low_rank"]
+    core = recipe.build_core(buffer_size=256)
     wu = staged_adaptation(nuts, logdensity_fn, metric=core)
 
 Design
@@ -52,11 +64,14 @@ Layer doctrine:
 - The METRIC CORE (:class:`MetricCore`) handles mass-matrix tuning only.
 - Step-size adaptation and the stage schedule live in the HOST
   (:mod:`~blackjax.adaptation.staged_adaptation`).
-- Step-size proxy independence: for diag/dense representations (this slice),
-  the dual-averaging acceptance-rate proxy is not an eigenvalue proxy of the
-  adapted metric, so the step-size and metric adaptation are decoupled.  A
-  ``diag_reference`` accessor will be added in the low-rank slice where this
-  independence no longer holds.
+- L3 step-size proxy independence (RFC §4.3): for HMC/NUTS, the dual-averaging
+  step-size proxy is the scalar Metropolis acceptance rate — NOT an eigenvalue
+  quantity of the adapted metric.  This differs from MCLMC-LRD where
+  step_size ∝ 1/√λ_max caused a 20.6×→1.27× effective-sample collapse (the
+  "ε-collapse" RFC finding).  For HMC/NUTS the full low-rank metric feeds the
+  MCMC kernel (correct coupling), and dual averaging reads only acceptance_rate
+  — L3 is naturally satisfied; no diagonal-reference split is needed.  This
+  analysis applies to ALL recipes in this module, including the low-rank slice.
 
 Notes
 -----
@@ -69,6 +84,8 @@ all recipe families.  Import directly from ``blackjax.adaptation.metric_recipes`
 import dataclasses
 from typing import Callable, NamedTuple
 
+import jax
+import jax.flatten_util as fu
 import jax.numpy as jnp
 
 from blackjax.adaptation.mass_matrix import (
@@ -76,14 +93,21 @@ from blackjax.adaptation.mass_matrix import (
     MassMatrixAdaptationState,
     mass_matrix_adaptation,
 )
-from blackjax.adaptation.metric_estimators import fisher_score_diagonal_from_moments
+from blackjax.adaptation.metric_estimators import (
+    _compute_low_rank_metric,
+    fisher_score_diagonal_from_moments,
+    sample_covariance_eigh_low_rank,
+)
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from blackjax.types import Array, ArrayLikeTree
 
 __all__ = [
+    "LowRankMetricCoreState",
     "MetricCore",
     "MetricRecipe",
     "REGISTRY",
     "lookup_recipe",
+    "seed_low_rank_sigma_from_grad",
 ]
 
 
@@ -133,6 +157,149 @@ class MetricCore(NamedTuple):
     init: Callable
     update: Callable
     final: Callable
+
+
+# ---------------------------------------------------------------------------
+# LowRankMetricCoreState — state type for the low-rank MetricCore
+# ---------------------------------------------------------------------------
+
+
+class LowRankMetricCoreState(NamedTuple):
+    """Scan-carry state for the low-rank mass-matrix MetricCore.
+
+    Holds the current low-rank inverse mass matrix factors, the draw/gradient
+    circular buffer, and the buffer bookkeeping counters.  The engine reads
+    ``inverse_mass_matrix`` at each window boundary; the core's ``final()``
+    updates it.
+
+    Parameters
+    ----------
+    inverse_mass_matrix
+        Current low-rank IMM as a
+        :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix` NamedTuple
+        ``(sigma, U, lam)`` with shapes ``(d,)``, ``(d, max_rank)``,
+        ``(max_rank,)``.  This field is read by the engine at window boundaries
+        (via ``StagedAdaptationState.inverse_mass_matrix``) and by the MCMC
+        kernel's ``default_metric`` dispatch.
+    mu_star
+        Optimal translation ``x̄ + σ² ⊙ ᾱ``, shape ``(d,)``.  Not part of the
+        engine's host protocol; the shim reads this from the last adaptation
+        state to re-initialize the chain after warmup.  Always zero for the
+        ``"sample_cov_low_rank"`` recipe (no optimal translation in that
+        estimator).
+    draws_buffer
+        Circular buffer of chain positions, shape ``(buffer_size, d)``.
+        The first ``buffer_idx`` rows are valid; the remainder are zero-padded.
+        Dropped (replaced with ``None``) by the default OOM-guard
+        ``adaptation_info_fn`` in the shim to avoid O(num_steps × buffer_size × d)
+        allocations inside ``jax.lax.scan``.
+    grads_buffer
+        Circular buffer of log-density gradients, shape ``(buffer_size, d)``.
+        Same layout and OOM-guard treatment as ``draws_buffer``.  Always zeros
+        for the ``"sample_cov_low_rank"`` recipe (not used by that estimator).
+    buffer_idx
+        Number of draws written to the buffer so far (monotonically increasing,
+        NOT wrapped).  Modular indexing in ``update()`` handles wrap-around so
+        the most recent ``buffer_size`` draws are always in the buffer.
+        Reset to 0 by ``final()`` under the default ``"reset"`` buffer policy.
+    background_split
+        Number of the buffer's leading rows considered "background" (for the
+        accumulating buffer policy only).  Always 0 under the default
+        ``"reset"`` policy.
+    recompute_counter
+        Steps since the last metric recompute (for accumulating periodic
+        recompute only).  Always 0 under the default ``"reset"`` policy.
+    """
+
+    inverse_mass_matrix: LowRankInverseMassMatrix
+    mu_star: Array
+    draws_buffer: Array
+    grads_buffer: Array
+    buffer_idx: int
+    background_split: int
+    recompute_counter: int
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers for gradient_based_init
+# ---------------------------------------------------------------------------
+
+
+def seed_low_rank_sigma_from_grad(
+    state: LowRankMetricCoreState,
+    grad: ArrayLikeTree,
+) -> LowRankMetricCoreState:
+    """Seed the diagonal scale ``sigma`` from the initial log-density gradient.
+
+    Implements nutpie's ``gradient_based_init`` logic: instead of starting from
+    the identity (``sigma=1`` for every coordinate), set
+    ``sigma_i = 1/sqrt(clip(|grad_i|, 1e-20, 1e20))`` so that the initial
+    diagonal inverse mass matrix equals ``M^{-1}_i = sigma_i^2 = 1/|grad_i|``,
+    matching ``M = diag(|grad|)`` (a diagonal Hessian approximation at the
+    starting point; cf. L-BFGS and paper §3.1).
+
+    Coordinates where ``|grad_i| < 1e-10`` fall back to ``sigma_i = 1.0``
+    (identity) rather than the astronomically large ``sigma_i = 1e10`` that the
+    raw formula would give.  This defends the real edge case of initialising
+    at (or very near) a stationary point of the target — e.g. ``x=0`` on any
+    centered/standardised density — where the gradient is exactly zero and an
+    extreme initial scale causes near-certain divergence on the very first
+    trajectory (root-caused via the Fisher 2×2 calibration study).
+
+    This function is a **named seeding entry point** so that any host (the
+    window-adaptation shim, ChEES, etc.) can call the same code path and the
+    seeding logic is independently testable.
+
+    Parameters
+    ----------
+    state
+        Initial :class:`LowRankMetricCoreState` from ``core.init(n_dims)``
+        (before any gradient information).
+    grad
+        Log-density gradient at the initial position.  Must be the same pytree
+        structure as the chain's position.
+
+    Returns
+    -------
+    LowRankMetricCoreState
+        State with ``sigma`` replaced by the gradient-seeded values and
+        ``inverse_mass_matrix`` updated accordingly (``U``/``lam`` unchanged,
+        ``mu_star`` unchanged).
+    """
+    grad_flat, _ = fu.ravel_pytree(grad)
+    abs_grad = jnp.abs(grad_flat)
+    near_zero_grad_threshold = 1e-10
+    safe_sigma = jnp.power(jnp.clip(abs_grad, 1e-20, 1e20), -0.5)
+    sigma = jnp.where(abs_grad < near_zero_grad_threshold, 1.0, safe_sigma)
+    new_imm = LowRankInverseMassMatrix(
+        sigma=sigma,
+        U=state.inverse_mass_matrix.U,
+        lam=state.inverse_mass_matrix.lam,
+    )
+    return state._replace(inverse_mass_matrix=new_imm)
+
+
+# ---------------------------------------------------------------------------
+# Buffer utility (for accumulating policy; currently used by reset path too)
+# ---------------------------------------------------------------------------
+
+
+def _shift_buffer_left(buf: Array, shift: Array) -> Array:
+    """Drop the first ``shift`` rows of ``buf``, shifting the remainder forward.
+
+    Implements nutpie's partial-forget buffer pop under JAX's static-shape
+    constraint.  Canonical source: ``blackjax.adaptation.low_rank_adaptation``
+    ``._shift_buffer_left`` (same logic, defined here to avoid a circular
+    import since ``low_rank_adaptation`` is downstream of ``metric_recipes``
+    in the import chain).
+
+    Used by the accumulating buffer policy's ``final()`` (``slow_switch``
+    logic).  Not used by the default ``"reset"`` policy.
+    """
+    capacity = buf.shape[0]
+    shift = jnp.clip(shift, 0, capacity)
+    padded = jnp.concatenate([buf, jnp.zeros_like(buf)], axis=0)
+    return jax.lax.dynamic_slice_in_dim(padded, shift, capacity, axis=0)
 
 
 # ---------------------------------------------------------------------------
@@ -195,6 +362,10 @@ class MetricRecipe:
     provides: frozenset
     emits: str
     provenance: str
+    # Low-rank-specific fields (None for diag/dense recipes).
+    max_rank: int | None = None
+    gamma: float | None = None
+    cutoff: float | None = None
 
     def __post_init__(self) -> None:
         """Validate coupling contract at construction time."""
@@ -219,6 +390,7 @@ class MetricRecipe:
         *,
         imm_shrinkage_to_previous: float = 0.0,
         initial_inverse_mass_matrix: Array | None = None,
+        buffer_size: int | None = None,
     ) -> MetricCore:
         """Build an embeddable :class:`MetricCore` from this recipe.
 
@@ -229,12 +401,23 @@ class MetricRecipe:
             previous window's IMM.  Default ``0.0`` (Stan vanilla, no
             persistence).  Forwarded to
             :func:`~blackjax.adaptation.mass_matrix.mass_matrix_adaptation`.
-            Not supported for ``"fisher_diag"`` (``ValueError`` there per
-            ``mass_matrix_adaptation``'s validation).
+            Not supported for ``"fisher_diag"`` or the low-rank recipes
+            (``ValueError`` there per ``mass_matrix_adaptation``'s validation).
         initial_inverse_mass_matrix
             Optional seed array for the initial inverse mass matrix.  ``None``
             (default) uses the standard identity initialisation (``ones(d)``
-            for diagonal, ``identity(d)`` for dense).
+            for diagonal, ``identity(d)`` for dense).  Ignored for the
+            low-rank estimators (``"fisher_low_rank"``, ``"sample_cov_low_rank"``).
+        buffer_size
+            Required for low-rank recipes (``"fisher_low_rank"`` and
+            ``"sample_cov_low_rank"``).  Size of the circular draw/gradient
+            buffer (number of rows).  Use the schedule-derived heuristic in
+            :func:`~blackjax.adaptation.low_rank_adaptation.window_adaptation_low_rank`
+            or compute it yourself:
+            ``min(2 * max(num_steps // 5, 128), max(num_steps, 1))`` for the
+            reset policy; :func:`~blackjax.adaptation.low_rank_adaptation
+            ._accumulating_buffer_capacity` for the accumulating policy.
+            Ignored for diag/dense recipes.
 
         Returns
         -------
@@ -244,7 +427,8 @@ class MetricRecipe:
         Raises
         ------
         ValueError
-            If the estimator tag is not supported by this slice.
+            If the estimator tag is not supported, or if ``buffer_size`` is
+            ``None`` for a low-rank estimator.
         """
         if self.estimator == "welford":
             is_diagonal = self.representation == "diag"
@@ -257,10 +441,45 @@ class MetricRecipe:
             return _build_fisher_diag_core(
                 initial_inverse_mass_matrix=initial_inverse_mass_matrix,
             )
+        elif self.estimator == "fisher_low_rank":
+            if buffer_size is None:
+                raise ValueError(
+                    "MetricRecipe.build_core: buffer_size is required for "
+                    "the 'fisher_low_rank' estimator.  Pass buffer_size=<int> "
+                    "or build the core directly via _build_fisher_low_rank_core()."
+                )
+            # max_rank/gamma/cutoff are guaranteed non-None by the registry
+            # constructor; the Optional typing is for the dataclass default.
+            assert (
+                self.max_rank is not None
+            ), "fisher_low_rank recipe must have max_rank"
+            assert self.gamma is not None, "fisher_low_rank recipe must have gamma"
+            assert self.cutoff is not None, "fisher_low_rank recipe must have cutoff"
+            return _build_fisher_low_rank_core(
+                buffer_size=buffer_size,
+                max_rank=self.max_rank,
+                gamma=self.gamma,
+                cutoff=self.cutoff,
+            )
+        elif self.estimator == "sample_cov_low_rank":
+            if buffer_size is None:
+                raise ValueError(
+                    "MetricRecipe.build_core: buffer_size is required for "
+                    "the 'sample_cov_low_rank' estimator.  Pass buffer_size=<int> "
+                    "or build the core directly via _build_sample_cov_low_rank_core()."
+                )
+            assert (
+                self.max_rank is not None
+            ), "sample_cov_low_rank recipe must have max_rank"
+            return _build_sample_cov_low_rank_core(
+                buffer_size=buffer_size,
+                max_rank=self.max_rank,
+            )
         else:
             raise ValueError(
                 f"Unknown estimator tag {self.estimator!r} in MetricRecipe.build_core. "
-                f"Slice-1 supports 'welford' and 'fisher_diag'."
+                f"Known estimators: 'welford', 'fisher_diag', 'fisher_low_rank', "
+                f"'sample_cov_low_rank'."
             )
 
 
@@ -371,6 +590,192 @@ def _build_fisher_diag_core(
     return MetricCore(init=init, update=update, final=final)
 
 
+def _build_fisher_low_rank_core(
+    *,
+    buffer_size: int,
+    max_rank: int,
+    gamma: float,
+    cutoff: float,
+) -> MetricCore:
+    """Build a MetricCore for the Fisher-score low-rank estimator (reset policy).
+
+    Implements the same window-end recompute as
+    :func:`~blackjax.adaptation.low_rank_adaptation.base`'s ``slow_final``
+    under ``buffer_policy="reset"``:
+
+    1. ``init(n_dims)`` — creates a zero-filled draw/gradient buffer of shape
+       ``(buffer_size, n_dims)`` with identity sigma, zero U, ones lam.
+    2. ``update(state, position, grad)`` — writes (position, grad) at
+       ``buffer_idx % buffer_size`` via dynamic update; increments ``buffer_idx``.
+    3. ``final(state)`` — calls :func:`~blackjax.adaptation.metric_estimators
+       ._compute_low_rank_metric` on the buffer, stores new sigma/mu_star/U/lam
+       in ``inverse_mass_matrix`` and ``mu_star``, resets the buffer to zeros.
+
+    **L3 note** (RFC §4.3): the dual-averaging step-size proxy reads only the
+    scalar Metropolis acceptance rate, NOT an eigenvalue quantity — L3 is
+    naturally satisfied for HMC/NUTS regardless of metric rank.  See module
+    docstring for the full analysis.
+
+    Parameters
+    ----------
+    buffer_size
+        Number of rows in the circular draw/gradient buffer.
+    max_rank
+        Maximum number of eigenvectors retained in the low-rank correction.
+        Default 10, matching :func:`~blackjax.adaptation.low_rank_adaptation
+        .window_adaptation_low_rank`.
+    gamma
+        Regularisation scale (nutpie convention — projected covariance divided
+        by ``gamma`` before adding identity, no ``n`` scaling).  Default
+        1e-5.
+    cutoff
+        Eigenvalues in ``[1/cutoff, cutoff]`` are masked to 1.  Default 2.0.
+    """
+
+    def init(n_dims: int) -> LowRankMetricCoreState:
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=LowRankInverseMassMatrix(
+                sigma=jnp.ones(n_dims),
+                U=jnp.zeros((n_dims, max_rank)),
+                lam=jnp.ones(max_rank),
+            ),
+            mu_star=jnp.zeros(n_dims),
+            draws_buffer=jnp.zeros((buffer_size, n_dims)),
+            grads_buffer=jnp.zeros((buffer_size, n_dims)),
+            buffer_idx=0,
+            background_split=0,
+            recompute_counter=0,
+        )
+
+    def update(
+        state: LowRankMetricCoreState,
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree | None = None,
+    ) -> LowRankMetricCoreState:
+        pos_flat, _ = fu.ravel_pytree(position)
+        grad_flat, _ = fu.ravel_pytree(grad)
+        B = state.draws_buffer.shape[0]
+        idx = state.buffer_idx % B  # wrap to avoid out-of-bounds during trace
+        new_draws = jax.lax.dynamic_update_slice(
+            state.draws_buffer, pos_flat[None, :], (idx, 0)
+        )
+        new_grads = jax.lax.dynamic_update_slice(
+            state.grads_buffer, grad_flat[None, :], (idx, 0)
+        )
+        return state._replace(
+            draws_buffer=new_draws,
+            grads_buffer=new_grads,
+            buffer_idx=state.buffer_idx + 1,
+        )
+
+    def final(state: LowRankMetricCoreState) -> LowRankMetricCoreState:
+        # Recompute metric from buffer, then hard-reset for the next window.
+        sigma, mu_star, U, lam = _compute_low_rank_metric(
+            state.draws_buffer,
+            state.grads_buffer,
+            state.buffer_idx,
+            max_rank,
+            gamma,
+            cutoff,
+        )
+        B, d = state.draws_buffer.shape
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam),
+            mu_star=mu_star,
+            draws_buffer=jnp.zeros((B, d)),
+            grads_buffer=jnp.zeros((B, d)),
+            buffer_idx=0,
+            background_split=0,
+            recompute_counter=0,
+        )
+
+    return MetricCore(init=init, update=update, final=final)
+
+
+def _build_sample_cov_low_rank_core(
+    *,
+    buffer_size: int,
+    max_rank: int,
+) -> MetricCore:
+    """Build a MetricCore for the sample-covariance low-rank estimator (MEADS form).
+
+    Draws-only variant (no gradient data, no regularisation, raw top-k eigh
+    selection) following MEADS / Scheme-B.  Delegates to
+    :func:`~blackjax.adaptation.metric_estimators.sample_covariance_eigh_low_rank`
+    in ``final()``.
+
+    1. ``init(n_dims)`` — same buffer layout as the Fisher core; ``grads_buffer``
+       is allocated but stays zero (not used).
+    2. ``update(state, position, grad)`` — writes only ``position`` to
+       ``draws_buffer``; grad is accepted for interface uniformity but ignored.
+    3. ``final(state)`` — computes the masked sample covariance matrix from the
+       buffer, calls :func:`~blackjax.adaptation.metric_estimators
+       .sample_covariance_eigh_low_rank`, resets buffer.  ``mu_star`` is always
+       zero (this estimator does not compute an optimal translation).
+
+    Parameters
+    ----------
+    buffer_size
+        Number of rows in the circular draw buffer.
+    max_rank
+        Maximum number of eigenvectors retained.
+    """
+
+    def init(n_dims: int) -> LowRankMetricCoreState:
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=LowRankInverseMassMatrix(
+                sigma=jnp.ones(n_dims),
+                U=jnp.zeros((n_dims, max_rank)),
+                lam=jnp.ones(max_rank),
+            ),
+            mu_star=jnp.zeros(n_dims),
+            draws_buffer=jnp.zeros((buffer_size, n_dims)),
+            grads_buffer=jnp.zeros((buffer_size, n_dims)),  # unused; zeros always
+            buffer_idx=0,
+            background_split=0,
+            recompute_counter=0,
+        )
+
+    def update(
+        state: LowRankMetricCoreState,
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree | None = None,  # accepted for interface uniformity
+    ) -> LowRankMetricCoreState:
+        pos_flat, _ = fu.ravel_pytree(position)
+        B = state.draws_buffer.shape[0]
+        idx = state.buffer_idx % B
+        new_draws = jax.lax.dynamic_update_slice(
+            state.draws_buffer, pos_flat[None, :], (idx, 0)
+        )
+        return state._replace(
+            draws_buffer=new_draws,
+            buffer_idx=state.buffer_idx + 1,
+        )
+
+    def final(state: LowRankMetricCoreState) -> LowRankMetricCoreState:
+        B, d = state.draws_buffer.shape
+        n = state.buffer_idx
+        # Compute masked mean and accumulated sum of squared deviations from
+        # the buffer (same masking pattern as _compute_low_rank_metric).
+        mask = (jnp.arange(B) < n).astype(state.draws_buffer.dtype)
+        n_safe = jnp.maximum(n, 2).astype(state.draws_buffer.dtype)
+        mean = (mask[:, None] * state.draws_buffer).sum(0) / n_safe  # (d,)
+        diff = mask[:, None] * (state.draws_buffer - mean[None, :])  # (B, d)
+        m2 = diff.T @ diff  # (d, d) accumulated sum of squared deviations
+        new_imm = sample_covariance_eigh_low_rank(m2, n, max_rank)
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=new_imm,
+            mu_star=jnp.zeros(d),  # no optimal translation for this estimator
+            draws_buffer=jnp.zeros((B, d)),
+            grads_buffer=jnp.zeros((B, d)),
+            buffer_idx=0,
+            background_split=0,
+            recompute_counter=0,
+        )
+
+    return MetricCore(init=init, update=update, final=final)
+
+
 # ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
@@ -430,6 +835,51 @@ REGISTRY: dict[str, MetricRecipe] = {
             "Validated 2026-07-13."
         ),
     ),
+    "fisher_low_rank": MetricRecipe(
+        representation="low_rank",
+        estimator="fisher_low_rank",
+        buffer="reset_window",
+        support_gate=None,
+        needs=frozenset({"positions", "gradients"}),
+        provides=frozenset({"positions", "gradients"}),
+        emits="low_rank",
+        max_rank=10,
+        gamma=1e-5,
+        cutoff=2.0,
+        provenance=(
+            "Fisher-divergence-minimising LOW-RANK estimator (Algorithm 1, "
+            "seyboldt2026preconditioning; nutpie reference implementation). "
+            "Defaults match window_adaptation_low_rank: max_rank=10, gamma=1e-5, "
+            "cutoff=2.0, reset buffer policy.  Requires buffer_size in build_core(). "
+            "Uses position AND gradient samples; requires x64 for float32 chains "
+            "(see _compute_low_rank_metric dtype note).  Composes with any "
+            "schedule_fn; pair with build_growing_window_schedule for the nutpie "
+            "schedule.  L3 is naturally satisfied for HMC/NUTS (acceptance rate "
+            "proxy is not an eigenvalue quantity — see module docstring)."
+        ),
+    ),
+    "sample_cov_low_rank": MetricRecipe(
+        representation="low_rank",
+        estimator="sample_cov_low_rank",
+        buffer="reset_window",
+        support_gate=None,
+        needs=frozenset({"positions"}),
+        provides=frozenset({"positions"}),
+        emits="low_rank",
+        max_rank=10,
+        gamma=None,
+        cutoff=None,
+        provenance=(
+            "Sample-covariance low-rank estimator (MEADS / Scheme-B form). "
+            "Draws only — no gradient data, no regularisation (no gamma), "
+            "raw top-k eigh selection (no informativeness cutoff masking). "
+            "Delegates to sample_covariance_eigh_low_rank.  Appropriate when "
+            "gradients are unavailable or expensive and the full covariance "
+            "structure matters more than the AIRM geometric-mean correction.  "
+            "No optimal translation (mu_star=0).  Requires buffer_size in "
+            "build_core(); max_rank=10 default."
+        ),
+    ),
 }
 
 
@@ -439,11 +889,13 @@ def lookup_recipe(name: str) -> MetricRecipe:
     Parameters
     ----------
     name
-        Registry key.  Current slice-1 names:
+        Registry key.  Current names:
 
         - ``"welford_diag"`` (default; reproduces ``window_adaptation`` exactly)
         - ``"welford_dense"``
         - ``"fisher_diag"``
+        - ``"fisher_low_rank"`` (Algorithm 1, seyboldt2026; needs ``buffer_size``)
+        - ``"sample_cov_low_rank"`` (MEADS/Scheme-B; needs ``buffer_size``)
 
     Returns
     -------

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -386,6 +386,7 @@ def staged_adaptation(
     target_acceptance_rate: float = 0.80,
     adaptation_info_fn: Callable = return_all_adapt_info,
     integrator=mcmc.integrators.velocity_verlet,
+    schedule_fn: Callable = build_schedule,
     **extra_parameters,
 ) -> AdaptationAlgorithm:
     """Adapt the step size and inverse mass matrix for HMC-family algorithms.
@@ -440,6 +441,13 @@ def staged_adaptation(
         The symplectic integrator passed to ``algorithm.build_kernel``; only
         used if ``build_kernel`` accepts arguments.  Defaults to
         :func:`~blackjax.mcmc.integrators.velocity_verlet`.
+    schedule_fn
+        Callable ``(num_steps: int) -> Array`` that returns a
+        ``(num_steps, 2)`` array of ``(stage, is_window_end)`` pairs.
+        Default :func:`build_schedule` (Stan's fixed-absolute, 2×-doubling
+        schedule).  Pass
+        :func:`~blackjax.adaptation.low_rank_adaptation.build_growing_window_schedule`
+        for nutpie's proportional-to-tune, 1.5×-growing-window schedule.
     **extra_parameters
         Additional parameters forwarded to the MCMC kernel at every step, e.g.
         ``num_integration_steps`` for HMC.
@@ -530,7 +538,7 @@ def staged_adaptation(
 
         start_state = (init_state, init_adaptation_state)
         keys = jax.random.split(rng_key, num_steps)
-        schedule = build_schedule(num_steps)
+        schedule = schedule_fn(num_steps)
         last_state, info = jax.lax.scan(
             one_step,
             start_state,

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -387,6 +387,7 @@ def staged_adaptation(
     adaptation_info_fn: Callable = return_all_adapt_info,
     integrator=mcmc.integrators.velocity_verlet,
     schedule_fn: Callable = build_schedule,
+    initial_metric_state: Any = None,
     **extra_parameters,
 ) -> AdaptationAlgorithm:
     """Adapt the step size and inverse mass matrix for HMC-family algorithms.
@@ -448,6 +449,16 @@ def staged_adaptation(
         schedule).  Pass
         :func:`~blackjax.adaptation.low_rank_adaptation.build_growing_window_schedule`
         for nutpie's proportional-to-tune, 1.5×-growing-window schedule.
+    initial_metric_state
+        Optional pre-built mass-matrix adaptation core state.  When not
+        ``None``, overrides the ``metric_core.init(n_dims)`` call at warmup
+        start — the provided state is used as-is.  The object must be a
+        valid state for the chosen ``metric`` core (its
+        ``inverse_mass_matrix`` field is unpacked into
+        :class:`StagedAdaptationState` immediately).  Intended for callers
+        that seed the initial state from external data (e.g., gradient-based
+        diagonal-scale initialisation); ``None`` (the default) reproduces
+        the standard identity/zero initialisation.
     **extra_parameters
         Additional parameters forwarded to the MCMC kernel at every step, e.g.
         ``num_integration_steps`` for HMC.
@@ -506,6 +517,21 @@ def staged_adaptation(
         metric_core,
         target_acceptance_rate=target_acceptance_rate,
     )
+
+    if initial_metric_state is not None:
+        # Narrow seam: override core.init with the caller-supplied state.
+        # The base adapt_init still runs (sets up ss_state, step_size), and we
+        # then replace imm_state + inverse_mass_matrix in the returned carry.
+        _base_adapt_init = adapt_init
+
+        def adapt_init(  # noqa: F811 — intentional shadowing; seam is local
+            position: ArrayLikeTree, initial_step_size_: float
+        ) -> StagedAdaptationState:
+            state = _base_adapt_init(position, initial_step_size_)
+            return state._replace(
+                imm_state=initial_metric_state,
+                inverse_mass_matrix=initial_metric_state.inverse_mass_matrix,
+            )
 
     def one_step(carry, xs):
         _, rng_key, adaptation_stage = xs

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -21,18 +21,32 @@ Coverage:
 - Registry entries ``"fisher_low_rank"`` and ``"sample_cov_low_rank"``.
 - :func:`MetricRecipe.build_core` low-rank dispatch and buffer_size guard.
 - :func:`staged_adaptation` ``schedule_fn`` parameter.
+- :func:`staged_adaptation` ``initial_metric_state`` seam.
 - Bit-identity: ``_compute_low_rank_metric`` moved to ``metric_estimators``
   is the same object as the backward-compat re-export from
   ``low_rank_adaptation``.
+- :func:`window_adaptation_low_rank` shim: reset path via staged engine,
+  accumulating path via established scan loop, gradient_based_init seam,
+  info-bridge field layout, and bit-exact reset parity vs reference runner.
 """
 import jax
+import jax.flatten_util as fu
 import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest
 
 import blackjax
+import blackjax.mcmc as mcmc
+from blackjax.adaptation.base import return_all_adapt_info
 from blackjax.adaptation.low_rank_adaptation import _compute_low_rank_metric as lra_clrm
-from blackjax.adaptation.low_rank_adaptation import build_growing_window_schedule
+from blackjax.adaptation.low_rank_adaptation import (
+    _default_low_rank_adaptation_info_fn,
+    _engine_state_to_low_rank_adaptation_state,
+    _make_low_rank_bridge_info_fn,
+    base,
+    build_growing_window_schedule,
+    window_adaptation_low_rank,
+)
 from blackjax.adaptation.metric_estimators import _compute_low_rank_metric
 from blackjax.adaptation.metric_recipes import (
     REGISTRY,
@@ -44,8 +58,12 @@ from blackjax.adaptation.metric_recipes import (
     lookup_recipe,
     seed_low_rank_sigma_from_grad,
 )
-from blackjax.adaptation.staged_adaptation import build_schedule, staged_adaptation
-from blackjax.mcmc.metrics import LowRankInverseMassMatrix
+from blackjax.adaptation.staged_adaptation import (
+    StagedAdaptationState,
+    build_schedule,
+    staged_adaptation,
+)
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix, gaussian_euclidean_low_rank
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
 # ---------------------------------------------------------------------------
@@ -596,6 +614,570 @@ class FisherLowRankStagedAdaptationTest(BlackJAXTest):
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+
+
+# ---------------------------------------------------------------------------
+# staged_adaptation initial_metric_state seam
+# ---------------------------------------------------------------------------
+
+
+def _make_seeded_state(n_dims, max_rank=4):
+    """Build a LowRankMetricCoreState seeded with non-identity sigma."""
+    buffer_size = 64
+    core = _build_fisher_low_rank_core(
+        buffer_size=buffer_size, max_rank=max_rank, gamma=1e-5, cutoff=2.0
+    )
+    base_state = core.init(n_dims)
+    # Seed sigma so we can distinguish it from the identity default.
+    grad = jnp.arange(1, n_dims + 1, dtype=jnp.float32)
+    return seed_low_rank_sigma_from_grad(base_state, grad), core
+
+
+class InitialMetricStateSeamTest(BlackJAXTest):
+    """staged_adaptation initial_metric_state=... overrides core.init(n_dims)."""
+
+    def test_seam_overrides_sigma_at_first_step(self):
+        """When initial_metric_state is provided, the first adaptation step must
+        use the seeded sigma rather than ones."""
+        n_dims = 4
+        seeded_state, core = _make_seeded_state(n_dims)
+        seeded_sigma = seeded_state.inverse_mass_matrix.sigma
+
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+            adaptation_info_fn=return_all_adapt_info,
+            initial_metric_state=seeded_state,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        _, info = wu.run(key, pos, num_steps=10)
+        # At step 0 the adaptation state still carries the seeded sigma
+        # (no slow window has ended yet at 10 steps with the default schedule).
+        first_sigma = info.adaptation_state.imm_state.inverse_mass_matrix.sigma[0]
+        self.assertTrue(bool(jnp.allclose(first_sigma, seeded_sigma, atol=0.0)))
+
+    def test_seam_none_uses_core_init(self):
+        """When initial_metric_state=None (default), core.init is used (sigma=ones)."""
+        n_dims = 5
+        buffer_size = 64
+        core = _build_fisher_low_rank_core(
+            buffer_size=buffer_size, max_rank=4, gamma=1e-5, cutoff=2.0
+        )
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+            adaptation_info_fn=return_all_adapt_info,
+            initial_metric_state=None,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        _, info = wu.run(key, pos, num_steps=10)
+        first_sigma = info.adaptation_state.imm_state.inverse_mass_matrix.sigma[0]
+        self.assertTrue(bool(jnp.allclose(first_sigma, jnp.ones(n_dims), atol=0.0)))
+
+    def test_seam_produces_finite_output(self):
+        """staged_adaptation with initial_metric_state seam runs to completion."""
+        n_dims = 6
+        seeded_state, core = _make_seeded_state(n_dims, max_rank=4)
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+            initial_metric_state=seeded_state,
+        )
+        key = self.next_key()
+        (state, params), _ = wu.run(key, jnp.zeros(n_dims), num_steps=200)
+        imm = params["inverse_mass_matrix"]
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+
+    def test_seam_inverse_mass_matrix_carried_immediately(self):
+        """The seeded inverse_mass_matrix must be present in StagedAdaptationState
+        inverse_mass_matrix field at step 0 (i.e., MCMC kernel sees it)."""
+        n_dims = 4
+        seeded_state, core = _make_seeded_state(n_dims)
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+            adaptation_info_fn=return_all_adapt_info,
+            initial_metric_state=seeded_state,
+        )
+        key = self.next_key()
+        _, info = wu.run(key, jnp.zeros(n_dims), num_steps=5)
+        # StagedAdaptationState.inverse_mass_matrix is a LowRankInverseMassMatrix;
+        # after scan stacking, .sigma has shape (num_steps, n_dims).  [0] gives
+        # the step-0 sigma, which must NOT be ones (the identity default).
+        first_sigma = info.adaptation_state.inverse_mass_matrix.sigma[0]
+        self.assertFalse(bool(jnp.allclose(first_sigma, jnp.ones(n_dims), atol=1e-6)))
+
+
+# ---------------------------------------------------------------------------
+# Engine-to-LowRankAdaptationState bridge
+# ---------------------------------------------------------------------------
+
+
+class LowRankBridgeFnTest(BlackJAXTest):
+    """_engine_state_to_low_rank_adaptation_state and _make_low_rank_bridge_info_fn."""
+
+    def _make_engine_state(self, n_dims=4, max_rank=3):
+        from blackjax.adaptation.step_size import dual_averaging_adaptation
+
+        da_init, _, _ = dual_averaging_adaptation(0.80)
+        ss_state = da_init(0.5)
+        imm = LowRankInverseMassMatrix(
+            sigma=jnp.full(n_dims, 2.0),
+            U=jnp.eye(n_dims, max_rank),
+            lam=jnp.full(max_rank, 1.5),
+        )
+        imm_state = LowRankMetricCoreState(
+            inverse_mass_matrix=imm,
+            mu_star=jnp.full(n_dims, 0.1),
+            draws_buffer=jnp.ones((16, n_dims)),
+            grads_buffer=jnp.ones((16, n_dims)) * 0.5,
+            buffer_idx=7,
+            background_split=3,
+            recompute_counter=2,
+        )
+        return StagedAdaptationState(
+            ss_state=ss_state,
+            imm_state=imm_state,
+            step_size=0.5,
+            inverse_mass_matrix=imm,
+        )
+
+    def test_bridge_sigma_matches(self):
+        es = self._make_engine_state()
+        lr = _engine_state_to_low_rank_adaptation_state(es)
+        self.assertTrue(
+            bool(jnp.allclose(lr.sigma, es.imm_state.inverse_mass_matrix.sigma))
+        )
+
+    def test_bridge_mu_star_matches(self):
+        es = self._make_engine_state()
+        lr = _engine_state_to_low_rank_adaptation_state(es)
+        self.assertTrue(bool(jnp.allclose(lr.mu_star, es.imm_state.mu_star)))
+
+    def test_bridge_u_lam_match(self):
+        es = self._make_engine_state()
+        lr = _engine_state_to_low_rank_adaptation_state(es)
+        self.assertTrue(bool(jnp.allclose(lr.U, es.imm_state.inverse_mass_matrix.U)))
+        self.assertTrue(
+            bool(jnp.allclose(lr.lam, es.imm_state.inverse_mass_matrix.lam))
+        )
+
+    def test_bridge_buffer_fields_match(self):
+        es = self._make_engine_state()
+        lr = _engine_state_to_low_rank_adaptation_state(es)
+        self.assertTrue(bool(jnp.allclose(lr.draws_buffer, es.imm_state.draws_buffer)))
+        self.assertTrue(bool(jnp.allclose(lr.grads_buffer, es.imm_state.grads_buffer)))
+        self.assertEqual(int(lr.buffer_idx), int(es.imm_state.buffer_idx))
+        self.assertEqual(int(lr.background_split), int(es.imm_state.background_split))
+        self.assertEqual(int(lr.recompute_counter), int(es.imm_state.recompute_counter))
+
+    def test_bridge_step_size_matches(self):
+        es = self._make_engine_state()
+        lr = _engine_state_to_low_rank_adaptation_state(es)
+        self.assertEqual(float(lr.step_size), float(es.step_size))
+
+    def test_bridge_info_fn_drops_buffers(self):
+        """_make_low_rank_bridge_info_fn + _default_low_rank_adaptation_info_fn
+        must drop draws_buffer/grads_buffer from the returned adaptation_state."""
+        es = self._make_engine_state()
+        # Dummy MCMC state and info objects.
+        dummy_state = object()
+        dummy_info = object()
+        bridge_fn = _make_low_rank_bridge_info_fn(_default_low_rank_adaptation_info_fn)
+        result = bridge_fn(dummy_state, dummy_info, es)
+        self.assertIsNone(result.adaptation_state.draws_buffer)
+        self.assertIsNone(result.adaptation_state.grads_buffer)
+        # sigma and mu_star must still be present.
+        self.assertIsNotNone(result.adaptation_state.sigma)
+        self.assertIsNotNone(result.adaptation_state.mu_star)
+
+
+# ---------------------------------------------------------------------------
+# window_adaptation_low_rank shim — integration tests
+# ---------------------------------------------------------------------------
+
+
+class WindowAdaptationLowRankShimTest(BlackJAXTest):
+    """Integration tests for the rewritten window_adaptation_low_rank shim."""
+
+    _N_DIMS = 5
+    _NUM_STEPS = 200
+
+    def _run(self, **kwargs):
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            **{
+                "max_rank": 4,
+                "num_steps": self._NUM_STEPS,
+                **kwargs,
+            },
+        )
+        # window_adaptation_low_rank doesn't take num_steps in constructor;
+        # pass to run instead.
+        num_steps = kwargs.pop("num_steps", self._NUM_STEPS)
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            max_rank=4,
+        )
+        return wu.run(self.next_key(), jnp.zeros(self._N_DIMS), num_steps=num_steps)
+
+    def test_reset_path_runs(self):
+        """buffer_policy='reset' (default) must complete and return finite metric."""
+        wu = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4
+        )
+        (state, params), info = wu.run(
+            self.next_key(), jnp.zeros(self._N_DIMS), num_steps=self._NUM_STEPS
+        )
+        imm = params["inverse_mass_matrix"]
+        self.assertIsInstance(imm, LowRankInverseMassMatrix)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+
+    def test_reset_path_state_is_reinited_at_mu_star(self):
+        """The returned chain state must be re-initialised at mu_star, not the
+        last MCMC position (i.e., state.position == unravel(mu_star))."""
+        wu = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4
+        )
+        (state, params), info = wu.run(
+            self.next_key(), jnp.zeros(self._N_DIMS), num_steps=self._NUM_STEPS
+        )
+        # mu_star from the last step of info.
+        mu_star_from_info = info.adaptation_state.mu_star[-1]
+        self.assertTrue(
+            bool(jnp.allclose(state.position, mu_star_from_info, atol=1e-6))
+        )
+
+    def test_accumulating_path_runs(self):
+        """buffer_policy='accumulating' must complete and return finite metric."""
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            max_rank=4,
+            buffer_policy="accumulating",
+        )
+        (state, params), _ = wu.run(
+            self.next_key(), jnp.zeros(self._N_DIMS), num_steps=self._NUM_STEPS
+        )
+        imm = params["inverse_mass_matrix"]
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+
+    def test_gradient_based_init_reset_path(self):
+        """gradient_based_init=True on the reset path must produce finite metric
+        and a non-identity initial sigma (different from gradient_based_init=False)."""
+        wu_seed = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4, gradient_based_init=True
+        )
+        wu_no_seed = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4, gradient_based_init=False
+        )
+        key = self.next_key()
+        (_, params_seed), _ = wu_seed.run(key, jnp.zeros(self._N_DIMS), num_steps=150)
+        (_, params_no_seed), _ = wu_no_seed.run(
+            key, jnp.zeros(self._N_DIMS), num_steps=150
+        )
+        # Both must be finite.
+        self.assertTrue(
+            bool(jnp.all(jnp.isfinite(params_seed["inverse_mass_matrix"].sigma)))
+        )
+        # They need not be identical (seeding changes the trajectory).
+        # At zero position the gradient is non-zero so sigma will differ from ones.
+        initial_sigma_seed = params_seed["inverse_mass_matrix"].sigma
+        initial_sigma_no_seed = params_no_seed["inverse_mass_matrix"].sigma
+        # Cannot guarantee numerical difference since the warmup may converge to
+        # a similar value — only assert that both are finite.
+        self.assertTrue(bool(jnp.all(jnp.isfinite(initial_sigma_seed))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(initial_sigma_no_seed))))
+
+    def test_info_adaptation_state_has_lr_fields_reset_path(self):
+        """info.adaptation_state must have LowRankAdaptationState field layout
+        (sigma, mu_star, U, lam, step_size) on the reset path."""
+        wu = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4
+        )
+        _, info = wu.run(
+            self.next_key(), jnp.zeros(self._N_DIMS), num_steps=self._NUM_STEPS
+        )
+        st = info.adaptation_state
+        # Fields present and shaped correctly.
+        self.assertEqual(st.sigma.shape, (self._NUM_STEPS, self._N_DIMS))
+        self.assertEqual(st.mu_star.shape, (self._NUM_STEPS, self._N_DIMS))
+        self.assertEqual(st.U.shape, (self._NUM_STEPS, self._N_DIMS, 4))
+        self.assertEqual(st.lam.shape, (self._NUM_STEPS, 4))
+        # draws_buffer and grads_buffer dropped by default info fn.
+        self.assertIsNone(st.draws_buffer)
+        self.assertIsNone(st.grads_buffer)
+
+    def test_info_adaptation_state_has_lr_fields_accumulating_path(self):
+        """info.adaptation_state must have the same field layout on accumulating path."""
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            max_rank=4,
+            buffer_policy="accumulating",
+        )
+        _, info = wu.run(
+            self.next_key(), jnp.zeros(self._N_DIMS), num_steps=self._NUM_STEPS
+        )
+        st = info.adaptation_state
+        self.assertEqual(st.sigma.shape, (self._NUM_STEPS, self._N_DIMS))
+        self.assertIsNone(st.draws_buffer)
+
+    def test_custom_schedule_fn_reset_path(self):
+        """schedule_fn=build_growing_window_schedule must work on the reset path."""
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            max_rank=4,
+            schedule_fn=build_growing_window_schedule,
+        )
+        (state, params), _ = wu.run(
+            self.next_key(), jnp.zeros(self._N_DIMS), num_steps=self._NUM_STEPS
+        )
+        self.assertTrue(
+            bool(jnp.all(jnp.isfinite(params["inverse_mass_matrix"].sigma)))
+        )
+
+    def test_invalid_buffer_policy_raises(self):
+        """Unknown buffer_policy must raise ValueError before run()."""
+        with self.assertRaises(ValueError):
+            window_adaptation_low_rank(
+                blackjax.nuts, std_normal_logdensity, buffer_policy="invalid"
+            )
+
+    def test_invalid_recompute_every_raises(self):
+        """recompute_every < 1 must raise ValueError."""
+        with self.assertRaises(ValueError):
+            window_adaptation_low_rank(
+                blackjax.nuts, std_normal_logdensity, recompute_every=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# Bit-exact parity: reset path vs reference base() scan loop
+# ---------------------------------------------------------------------------
+
+
+def _reference_run_reset(rng_key, position, num_steps, n_dims):
+    """Run the reset path using base() directly (the pre-shim reference).
+
+    This replicates exactly what window_adaptation_low_rank did before the
+    shim rewrite: builds base() init/update/final, builds the scan loop
+    inline, and post-processes with the mu_star re-init.  The new shim's
+    reset path (via staged_adaptation) must produce bit-identical output.
+    """
+    max_rank = 4
+    gamma = 1e-5
+    cutoff = 2.0
+    initial_step_size = 1.0
+    target_acceptance_rate = 0.80
+
+    adapt_init_fn, adapt_step_fn, adapt_final_fn = base(
+        max_rank=max_rank,
+        target_acceptance_rate=target_acceptance_rate,
+        gamma=gamma,
+        cutoff=cutoff,
+        gradient_based_init=False,
+        buffer_policy="reset",
+        recompute_every=1,
+    )
+    mcmc_kernel = blackjax.nuts.build_kernel(mcmc.integrators.velocity_verlet)
+
+    def one_step(carry, xs):
+        _, rng_key_, adaptation_stage = xs
+        state, adaptation_state = carry
+        metric = gaussian_euclidean_low_rank(
+            adaptation_state.sigma, adaptation_state.U, adaptation_state.lam
+        )
+        new_state, step_info = mcmc_kernel(
+            rng_key_, state, std_normal_logdensity, adaptation_state.step_size, metric
+        )
+        new_adaptation_state = adapt_step_fn(
+            adaptation_state,
+            adaptation_stage,
+            new_state.position,
+            new_state.logdensity_grad,
+            step_info.acceptance_rate,
+        )
+        return (
+            (new_state, new_adaptation_state),
+            _default_low_rank_adaptation_info_fn(
+                new_state, step_info, new_adaptation_state
+            ),
+        )
+
+    init_state = blackjax.nuts.init(position, std_normal_logdensity)
+    schedule = build_schedule(num_steps)
+    typical_window = max(num_steps // 5, 128)
+    buffer_size = min(typical_window * 2, max(num_steps, 1))
+    init_adaptation_state = adapt_init_fn(
+        position,
+        init_state.logdensity_grad,
+        initial_step_size,
+        buffer_size,
+    )
+
+    keys = jax.random.split(rng_key, num_steps)
+    last_state, info = jax.lax.scan(
+        one_step,
+        (init_state, init_adaptation_state),
+        (jnp.arange(num_steps), keys, schedule),
+    )
+    _, last_warmup_state, *_ = last_state
+    step_size, sigma, mu_star, U, lam = adapt_final_fn(last_warmup_state)
+    inverse_mass_matrix = LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
+    _, unravel = fu.ravel_pytree(position)
+    mu_star_state = blackjax.nuts.init(unravel(mu_star), std_normal_logdensity)
+    return (
+        mu_star_state,
+        {"step_size": step_size, "inverse_mass_matrix": inverse_mass_matrix},
+        info,
+    )
+
+
+class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
+    """Bit-exact parity: reset path via staged engine == reference base() runner."""
+
+    _N_DIMS = 5
+    _NUM_STEPS = 200
+
+    def _run_shim(self, rng_key, position):
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            max_rank=4,
+        )
+        return wu.run(rng_key, position, num_steps=self._NUM_STEPS)
+
+    def test_final_step_size_identical(self):
+        """Final step_size must be bit-identical between shim and reference."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_shim), _ = self._run_shim(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_shim["step_size"], params_ref["step_size"], atol=0.0
+                )
+            )
+        )
+
+    def test_final_sigma_identical(self):
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_shim), _ = self._run_shim(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_shim["inverse_mass_matrix"].sigma,
+                    params_ref["inverse_mass_matrix"].sigma,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_final_u_identical(self):
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_shim), _ = self._run_shim(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_shim["inverse_mass_matrix"].U,
+                    params_ref["inverse_mass_matrix"].U,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_final_lam_identical(self):
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_shim), _ = self._run_shim(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_shim["inverse_mass_matrix"].lam,
+                    params_ref["inverse_mass_matrix"].lam,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_final_chain_state_position_identical(self):
+        """Returned chain state (mu_star re-init) must be bit-identical."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (state_shim, _), _ = self._run_shim(key, pos)
+        state_ref, _, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(jnp.allclose(state_shim.position, state_ref.position, atol=0.0))
+        )
+
+    def test_per_step_sigma_identical(self):
+        """Per-step sigma trace must be bit-identical across all steps."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, _), info_shim = self._run_shim(key, pos)
+        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    info_shim.adaptation_state.sigma,
+                    info_ref.adaptation_state.sigma,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_per_step_mu_star_identical(self):
+        """Per-step mu_star trace must be bit-identical."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, _), info_shim = self._run_shim(key, pos)
+        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    info_shim.adaptation_state.mu_star,
+                    info_ref.adaptation_state.mu_star,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_per_step_step_size_identical(self):
+        """Per-step step_size trace must be bit-identical."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, _), info_shim = self._run_shim(key, pos)
+        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    info_shim.adaptation_state.step_size,
+                    info_ref.adaptation_state.step_size,
+                    atol=0.0,
+                )
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the slice-2 low-rank MetricCore recipes.
+"""Tests for the low-rank MetricCore recipes.
 
 Coverage:
 - :class:`LowRankMetricCoreState` field contract.
@@ -498,7 +498,7 @@ class LowRankRegistryTest(BlackJAXTest):
                 core = recipe.build_core(buffer_size=50)
                 self.assertIsInstance(core, MetricCore)
 
-    def test_all_slice2_names_present(self):
+    def test_all_low_rank_recipe_names_present(self):
         for name in ("fisher_low_rank", "sample_cov_low_rank"):
             with self.subTest(name=name):
                 self.assertIn(name, REGISTRY)

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -1,0 +1,603 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the slice-2 low-rank MetricCore recipes.
+
+Coverage:
+- :class:`LowRankMetricCoreState` field contract.
+- :func:`seed_low_rank_sigma_from_grad` gradient seeding logic.
+- :func:`_build_fisher_low_rank_core` init/update/final contract.
+- :func:`_build_sample_cov_low_rank_core` init/update/final contract.
+- Registry entries ``"fisher_low_rank"`` and ``"sample_cov_low_rank"``.
+- :func:`MetricRecipe.build_core` low-rank dispatch and buffer_size guard.
+- :func:`staged_adaptation` ``schedule_fn`` parameter.
+- Bit-identity: ``_compute_low_rank_metric`` moved to ``metric_estimators``
+  is the same object as the backward-compat re-export from
+  ``low_rank_adaptation``.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest
+
+import blackjax
+from blackjax.adaptation.low_rank_adaptation import (
+    _compute_low_rank_metric as lra_clrm,
+    build_growing_window_schedule,
+)
+from blackjax.adaptation.metric_estimators import _compute_low_rank_metric
+from blackjax.adaptation.metric_recipes import (
+    LowRankMetricCoreState,
+    MetricCore,
+    MetricRecipe,
+    REGISTRY,
+    lookup_recipe,
+    seed_low_rank_sigma_from_grad,
+    _build_fisher_low_rank_core,
+    _build_sample_cov_low_rank_core,
+)
+from blackjax.adaptation.staged_adaptation import build_schedule, staged_adaptation
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
+from tests.fixtures import BlackJAXTest, std_normal_logdensity
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat object-identity test
+# ---------------------------------------------------------------------------
+
+
+class ComputeLowRankMetricMovedTest(BlackJAXTest):
+    """_compute_low_rank_metric moved to metric_estimators; re-export is same object."""
+
+    def test_backward_compat_import_is_same_object(self):
+        """The re-export from low_rank_adaptation must be the same callable."""
+        self.assertIs(_compute_low_rank_metric, lra_clrm)
+
+
+# ---------------------------------------------------------------------------
+# LowRankMetricCoreState field contract
+# ---------------------------------------------------------------------------
+
+
+class LowRankMetricCoreStateTest(BlackJAXTest):
+    """LowRankMetricCoreState NamedTuple field contract."""
+
+    def test_has_required_fields(self):
+        """State must have inverse_mass_matrix, mu_star, buffers, and counters."""
+        required = {
+            "inverse_mass_matrix",
+            "mu_star",
+            "draws_buffer",
+            "grads_buffer",
+            "buffer_idx",
+            "background_split",
+            "recompute_counter",
+        }
+        self.assertTrue(required <= set(LowRankMetricCoreState._fields))
+
+    def test_inverse_mass_matrix_is_low_rank_namedtuple(self):
+        """inverse_mass_matrix field must be a LowRankInverseMassMatrix."""
+        core = _build_fisher_low_rank_core(
+            buffer_size=20, max_rank=3, gamma=1e-5, cutoff=2.0
+        )
+        state = core.init(5)
+        self.assertIsInstance(state.inverse_mass_matrix, LowRankInverseMassMatrix)
+
+    def test_init_shapes(self):
+        """All buffer and metric shapes must match n_dims and max_rank."""
+        n_dims, max_rank, buffer_size = 7, 4, 30
+        core = _build_fisher_low_rank_core(
+            buffer_size=buffer_size, max_rank=max_rank, gamma=1e-5, cutoff=2.0
+        )
+        state = core.init(n_dims)
+        self.assertEqual(state.inverse_mass_matrix.sigma.shape, (n_dims,))
+        self.assertEqual(state.inverse_mass_matrix.U.shape, (n_dims, max_rank))
+        self.assertEqual(state.inverse_mass_matrix.lam.shape, (max_rank,))
+        self.assertEqual(state.mu_star.shape, (n_dims,))
+        self.assertEqual(state.draws_buffer.shape, (buffer_size, n_dims))
+        self.assertEqual(state.grads_buffer.shape, (buffer_size, n_dims))
+        self.assertEqual(int(state.buffer_idx), 0)
+        self.assertEqual(int(state.background_split), 0)
+        self.assertEqual(int(state.recompute_counter), 0)
+
+    def test_init_identity_metric(self):
+        """Initial sigma must be ones, U must be zeros, lam must be ones."""
+        core = _build_fisher_low_rank_core(
+            buffer_size=10, max_rank=2, gamma=1e-5, cutoff=2.0
+        )
+        state = core.init(4)
+        np.testing.assert_array_equal(
+            np.asarray(state.inverse_mass_matrix.sigma), np.ones(4)
+        )
+        np.testing.assert_array_equal(
+            np.asarray(state.inverse_mass_matrix.U), np.zeros((4, 2))
+        )
+        np.testing.assert_array_equal(
+            np.asarray(state.inverse_mass_matrix.lam), np.ones(2)
+        )
+        np.testing.assert_array_equal(np.asarray(state.mu_star), np.zeros(4))
+
+
+# ---------------------------------------------------------------------------
+# seed_low_rank_sigma_from_grad
+# ---------------------------------------------------------------------------
+
+
+class SeedLowRankSigmaFromGradTest(BlackJAXTest):
+    """seed_low_rank_sigma_from_grad: gradient seeding logic."""
+
+    def _make_init_state(self, n_dims=5, max_rank=2):
+        core = _build_fisher_low_rank_core(
+            buffer_size=10, max_rank=max_rank, gamma=1e-5, cutoff=2.0
+        )
+        return core.init(n_dims)
+
+    def test_returns_same_type(self):
+        state = self._make_init_state()
+        grad = jnp.ones(5) * 0.5
+        seeded = seed_low_rank_sigma_from_grad(state, grad)
+        self.assertIsInstance(seeded, LowRankMetricCoreState)
+
+    def test_sigma_seeded_from_grad_magnitude(self):
+        """sigma_i = 1/sqrt(|grad_i|) for large-enough gradients."""
+        grad = jnp.array([0.25, 1.0, 4.0, 0.1, 0.01])
+        state = self._make_init_state(n_dims=5)
+        seeded = seed_low_rank_sigma_from_grad(state, grad)
+        expected_sigma = 1.0 / jnp.sqrt(grad)
+        np.testing.assert_allclose(
+            np.asarray(seeded.inverse_mass_matrix.sigma),
+            np.asarray(expected_sigma),
+            rtol=1e-5,
+        )
+
+    def test_near_zero_grad_falls_back_to_identity(self):
+        """Coordinates with |grad| < 1e-10 must get sigma=1.0 (identity)."""
+        grad = jnp.array([0.5, 0.0, 1e-11, 1.0, 0.0])
+        state = self._make_init_state(n_dims=5)
+        seeded = seed_low_rank_sigma_from_grad(state, grad)
+        sigma = np.asarray(seeded.inverse_mass_matrix.sigma)
+        # Coordinates 1, 2, 4 have near-zero grad -> sigma = 1.0
+        np.testing.assert_allclose(sigma[1], 1.0, atol=1e-6)
+        np.testing.assert_allclose(sigma[2], 1.0, atol=1e-6)
+        np.testing.assert_allclose(sigma[4], 1.0, atol=1e-6)
+        # Coordinate 0: sigma = 1/sqrt(0.5) = sqrt(2)
+        np.testing.assert_allclose(sigma[0], np.sqrt(2.0), rtol=1e-5)
+
+    def test_u_and_lam_unchanged(self):
+        """Seeding must not modify U or lam."""
+        grad = jnp.ones(5)
+        state = self._make_init_state(n_dims=5)
+        seeded = seed_low_rank_sigma_from_grad(state, grad)
+        np.testing.assert_array_equal(
+            np.asarray(seeded.inverse_mass_matrix.U),
+            np.asarray(state.inverse_mass_matrix.U),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(seeded.inverse_mass_matrix.lam),
+            np.asarray(state.inverse_mass_matrix.lam),
+        )
+
+    def test_mu_star_unchanged(self):
+        """Seeding must not modify mu_star."""
+        grad = jnp.ones(5)
+        state = self._make_init_state(n_dims=5)
+        seeded = seed_low_rank_sigma_from_grad(state, grad)
+        np.testing.assert_array_equal(
+            np.asarray(seeded.mu_star), np.asarray(state.mu_star)
+        )
+
+
+# ---------------------------------------------------------------------------
+# _build_fisher_low_rank_core: init/update/final contract
+# ---------------------------------------------------------------------------
+
+
+class FisherLowRankCoreContractTest(BlackJAXTest):
+    """Fisher low-rank MetricCore init/update/final contract."""
+
+    n_dims = 8
+    max_rank = 4
+    buffer_size = 40
+
+    def _make_core(self):
+        return _build_fisher_low_rank_core(
+            buffer_size=self.buffer_size,
+            max_rank=self.max_rank,
+            gamma=1e-5,
+            cutoff=2.0,
+        )
+
+    def test_returns_metric_core_namedtuple(self):
+        core = self._make_core()
+        self.assertIsInstance(core, MetricCore)
+        self.assertTrue(callable(core.init))
+        self.assertTrue(callable(core.update))
+        self.assertTrue(callable(core.final))
+
+    def test_update_increments_buffer_idx(self):
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        pos = jnp.ones(self.n_dims)
+        grad = jnp.zeros(self.n_dims)
+        state2 = core.update(state, pos, grad)
+        self.assertEqual(int(state2.buffer_idx), 1)
+        state3 = core.update(state2, pos, grad)
+        self.assertEqual(int(state3.buffer_idx), 2)
+
+    def test_update_writes_to_buffer(self):
+        """The position must appear in the draws buffer after update."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        pos = jnp.arange(self.n_dims, dtype=jnp.float32)
+        state2 = core.update(state, pos, jnp.zeros(self.n_dims))
+        np.testing.assert_array_equal(
+            np.asarray(state2.draws_buffer[0]),
+            np.asarray(pos),
+        )
+
+    def test_update_is_scannable(self):
+        """update() must be safe inside jax.lax.scan (traced buffer_idx)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        k1, k2 = jax.random.split(key)
+        positions = jax.random.normal(k1, (30, self.n_dims))
+        grads = jax.random.normal(k2, (30, self.n_dims))
+
+        def body(s, xs):
+            pos, g = xs
+            return core.update(s, pos, g), None
+
+        final_state, _ = jax.lax.scan(body, state, (positions, grads))
+        self.assertEqual(int(final_state.buffer_idx), 30)
+
+    def test_final_resets_buffer(self):
+        """final() must reset buffer_idx to 0 and zero out the buffers."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        k1, k2 = jax.random.split(key)
+        positions = jax.random.normal(k1, (20, self.n_dims))
+        grads = jax.random.normal(k2, (20, self.n_dims))
+
+        def body(s, xs):
+            pos, g = xs
+            return core.update(s, pos, g), None
+
+        state, _ = jax.lax.scan(body, state, (positions, grads))
+        final_state = core.final(state)
+        self.assertEqual(int(final_state.buffer_idx), 0)
+        np.testing.assert_array_equal(
+            np.asarray(final_state.draws_buffer), np.zeros((self.buffer_size, self.n_dims))
+        )
+        np.testing.assert_array_equal(
+            np.asarray(final_state.grads_buffer), np.zeros((self.buffer_size, self.n_dims))
+        )
+
+    def test_final_produces_finite_metric(self):
+        """After accumulating anisotropic draws, final() gives finite sigma/U/lam."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        k1, k2 = jax.random.split(key)
+        scales = jnp.ones(self.n_dims).at[0].set(5.0).at[1].set(0.1)
+        draws = jax.random.normal(k1, (25, self.n_dims)) * scales
+        grads = -draws / scales**2
+
+        def body(s, xs):
+            pos, g = xs
+            return core.update(s, pos, g), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+        final_state = core.final(state)
+        imm = final_state.inverse_mass_matrix
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+        self.assertTrue(bool(jnp.all(imm.sigma > 0)))
+
+    def test_final_updates_mu_star(self):
+        """After accumulating off-center draws, mu_star should be non-zero."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        k1, k2 = jax.random.split(key)
+        # Draws from N(mean=3, scale=1)
+        draws = jax.random.normal(k1, (25, self.n_dims)) + 3.0
+        grads = -draws + 3.0  # gradient of -0.5*(x-3)^2
+
+        def body(s, xs):
+            pos, g = xs
+            return core.update(s, pos, g), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+        final_state = core.final(state)
+        self.assertTrue(bool(jnp.any(final_state.mu_star != 0.0)))
+
+    def test_final_metric_shape_correct(self):
+        """final()'s inverse_mass_matrix must have correct shapes."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        k1, k2 = jax.random.split(key)
+        draws = jax.random.normal(k1, (15, self.n_dims))
+        grads = jax.random.normal(k2, (15, self.n_dims))
+
+        def body(s, xs):
+            return core.update(s, xs[0], xs[1]), None
+
+        state, _ = jax.lax.scan(body, state, (draws, grads))
+        final_state = core.final(state)
+        imm = final_state.inverse_mass_matrix
+        self.assertEqual(imm.sigma.shape, (self.n_dims,))
+        self.assertEqual(imm.U.shape, (self.n_dims, self.max_rank))
+        self.assertEqual(imm.lam.shape, (self.max_rank,))
+
+
+# ---------------------------------------------------------------------------
+# _build_sample_cov_low_rank_core: init/update/final contract
+# ---------------------------------------------------------------------------
+
+
+class SampleCovLowRankCoreContractTest(BlackJAXTest):
+    """Sample-covariance low-rank MetricCore init/update/final contract."""
+
+    n_dims = 6
+    max_rank = 3
+    buffer_size = 30
+
+    def _make_core(self):
+        return _build_sample_cov_low_rank_core(
+            buffer_size=self.buffer_size,
+            max_rank=self.max_rank,
+        )
+
+    def test_returns_metric_core_namedtuple(self):
+        core = self._make_core()
+        self.assertIsInstance(core, MetricCore)
+
+    def test_update_only_uses_position(self):
+        """update() must work when grad=None (draws-only core)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        pos = jnp.ones(self.n_dims)
+        # grad=None should be accepted (ignored)
+        state2 = core.update(state, pos, None)
+        self.assertEqual(int(state2.buffer_idx), 1)
+
+    def test_final_mu_star_is_zero(self):
+        """mu_star must always be zero for this estimator (no optimal translation)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        draws = jax.random.normal(key, (20, self.n_dims)) + 5.0
+
+        def body(s, xs):
+            return core.update(s, xs, None), None
+
+        state, _ = jax.lax.scan(body, state, draws)
+        final_state = core.final(state)
+        np.testing.assert_array_equal(
+            np.asarray(final_state.mu_star), np.zeros(self.n_dims)
+        )
+
+    def test_final_produces_finite_metric(self):
+        """After accumulating draws, final() gives finite sigma/U/lam."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        draws = jax.random.normal(key, (20, self.n_dims))
+
+        def body(s, xs):
+            return core.update(s, xs, None), None
+
+        state, _ = jax.lax.scan(body, state, draws)
+        final_state = core.final(state)
+        imm = final_state.inverse_mass_matrix
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+        self.assertTrue(bool(jnp.all(imm.sigma > 0)))
+
+    def test_grads_buffer_unused(self):
+        """grads_buffer must remain zeros after update() (draws-only core)."""
+        core = self._make_core()
+        state = core.init(self.n_dims)
+        key = self.next_key()
+        draws = jax.random.normal(key, (10, self.n_dims))
+
+        def body(s, xs):
+            return core.update(s, xs, None), None
+
+        final_state, _ = jax.lax.scan(body, state, draws)
+        np.testing.assert_array_equal(
+            np.asarray(final_state.grads_buffer),
+            np.zeros((self.buffer_size, self.n_dims)),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry entries for new recipes
+# ---------------------------------------------------------------------------
+
+
+class LowRankRegistryTest(BlackJAXTest):
+    """Registry entries for fisher_low_rank and sample_cov_low_rank."""
+
+    def test_fisher_low_rank_in_registry(self):
+        recipe = lookup_recipe("fisher_low_rank")
+        self.assertIsInstance(recipe, MetricRecipe)
+
+    def test_sample_cov_low_rank_in_registry(self):
+        recipe = lookup_recipe("sample_cov_low_rank")
+        self.assertIsInstance(recipe, MetricRecipe)
+
+    def test_fisher_low_rank_defaults(self):
+        """Registry defaults must match window_adaptation_low_rank defaults."""
+        recipe = lookup_recipe("fisher_low_rank")
+        self.assertEqual(recipe.max_rank, 10)
+        self.assertAlmostEqual(recipe.gamma, 1e-5)
+        self.assertAlmostEqual(recipe.cutoff, 2.0)
+        self.assertEqual(recipe.representation, "low_rank")
+        self.assertEqual(recipe.emits, "low_rank")
+        self.assertIn("positions", recipe.needs)
+        self.assertIn("gradients", recipe.needs)
+
+    def test_sample_cov_low_rank_defaults(self):
+        """sample_cov_low_rank defaults: max_rank=10, no gamma/cutoff."""
+        recipe = lookup_recipe("sample_cov_low_rank")
+        self.assertEqual(recipe.max_rank, 10)
+        self.assertIsNone(recipe.gamma)
+        self.assertIsNone(recipe.cutoff)
+        self.assertIn("positions", recipe.needs)
+        self.assertNotIn("gradients", recipe.needs)
+
+    def test_build_core_requires_buffer_size_for_fisher_low_rank(self):
+        """build_core without buffer_size must raise ValueError."""
+        recipe = lookup_recipe("fisher_low_rank")
+        with self.assertRaisesRegex(ValueError, "buffer_size"):
+            recipe.build_core()
+
+    def test_build_core_requires_buffer_size_for_sample_cov_low_rank(self):
+        recipe = lookup_recipe("sample_cov_low_rank")
+        with self.assertRaisesRegex(ValueError, "buffer_size"):
+            recipe.build_core()
+
+    def test_build_core_with_buffer_size_returns_metric_core(self):
+        """build_core(buffer_size=N) must return a MetricCore."""
+        for name in ("fisher_low_rank", "sample_cov_low_rank"):
+            with self.subTest(name=name):
+                recipe = lookup_recipe(name)
+                core = recipe.build_core(buffer_size=50)
+                self.assertIsInstance(core, MetricCore)
+
+    def test_all_slice2_names_present(self):
+        for name in ("fisher_low_rank", "sample_cov_low_rank"):
+            with self.subTest(name=name):
+                self.assertIn(name, REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# staged_adaptation schedule_fn parameter
+# ---------------------------------------------------------------------------
+
+
+class StagedAdaptationScheduleFnTest(BlackJAXTest):
+    """schedule_fn parameter forwarding in staged_adaptation."""
+
+    def test_default_schedule_fn_is_build_schedule(self):
+        """Without schedule_fn, the default build_schedule is used (smoke test)."""
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric="welford_diag",
+        )
+        key = self.next_key()
+        pos = jnp.zeros(2)
+        (state, _), _ = wu.run(key, pos, num_steps=50)
+        self.assertEqual(state.position.shape, (2,))
+
+    def test_custom_schedule_fn_is_called(self):
+        """Passing a custom schedule_fn must route the scan through it."""
+        calls = []
+
+        def counting_schedule(num_steps):
+            calls.append(num_steps)
+            return build_schedule(num_steps)
+
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric="welford_diag",
+            schedule_fn=counting_schedule,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(2)
+        wu.run(key, pos, num_steps=50)
+        self.assertEqual(calls, [50])
+
+    def test_growing_window_schedule_fn(self):
+        """build_growing_window_schedule must work as schedule_fn."""
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric="welford_diag",
+            schedule_fn=build_growing_window_schedule,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(2)
+        (state, _), _ = wu.run(key, pos, num_steps=100)
+        self.assertEqual(state.position.shape, (2,))
+
+
+# ---------------------------------------------------------------------------
+# Integration: staged_adaptation with fisher_low_rank core on std normal
+# ---------------------------------------------------------------------------
+
+
+class FisherLowRankStagedAdaptationTest(BlackJAXTest):
+    """staged_adaptation with the fisher_low_rank MetricCore on std normal."""
+
+    def test_runs_to_completion(self):
+        """staged_adaptation with a pre-built fisher_low_rank core must complete."""
+        n_dims = 5
+        num_steps = 200
+        buffer_size = min(2 * max(num_steps // 5, 128), max(num_steps, 1))
+
+        core = _build_fisher_low_rank_core(
+            buffer_size=buffer_size,
+            max_rank=5,
+            gamma=1e-5,
+            cutoff=2.0,
+        )
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        (state, params), info = wu.run(key, pos, num_steps=num_steps)
+        self.assertEqual(state.position.shape, (n_dims,))
+        self.assertIsInstance(params["inverse_mass_matrix"], LowRankInverseMassMatrix)
+        self.assertEqual(params["inverse_mass_matrix"].sigma.shape, (n_dims,))
+        self.assertEqual(params["inverse_mass_matrix"].U.shape, (n_dims, 5))
+
+    def test_returns_finite_metric(self):
+        """All metric components must be finite after adaptation."""
+        n_dims = 4
+        num_steps = 150
+        buffer_size = min(2 * max(num_steps // 5, 128), max(num_steps, 1))
+
+        core = _build_fisher_low_rank_core(
+            buffer_size=buffer_size,
+            max_rank=4,
+            gamma=1e-5,
+            cutoff=2.0,
+        )
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        (_, params), _ = wu.run(key, pos, num_steps=num_steps)
+        imm = params["inverse_mass_matrix"]
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -427,16 +427,24 @@ class SampleCovLowRankCoreContractTest(BlackJAXTest):
         self.assertTrue(bool(jnp.all(imm.sigma > 0)))
 
     def test_grads_buffer_unused(self):
-        """grads_buffer must remain zeros after update() (draws-only core)."""
+        """grads_buffer must remain zeros even when a real gradient is passed.
+
+        Passing a non-None gradient catches the errant-grad-write mutation
+        (a sample_cov update that writes grad to grads_buffer): with grad=None
+        the mutation is a no-op because None cannot be stored; with a real
+        gradient array the mutation would write non-zero values and the
+        assertion would fail.
+        """
         core = self._make_core()
         state = core.init(self.n_dims)
-        key = self.next_key()
-        draws = jax.random.normal(key, (10, self.n_dims))
+        draws = jax.random.normal(self.next_key(), (10, self.n_dims))
+        grads = jax.random.normal(self.next_key(), (10, self.n_dims))
 
         def body(s, xs):
-            return core.update(s, xs, None), None
+            pos, grad = xs
+            return core.update(s, pos, grad), None
 
-        final_state, _ = jax.lax.scan(body, state, draws)
+        final_state, _ = jax.lax.scan(body, state, (draws, grads))
         np.testing.assert_array_equal(
             np.asarray(final_state.grads_buffer),
             np.zeros((self.buffer_size, self.n_dims)),
@@ -502,6 +510,154 @@ class LowRankRegistryTest(BlackJAXTest):
         for name in ("fisher_low_rank", "sample_cov_low_rank"):
             with self.subTest(name=name):
                 self.assertIn(name, REGISTRY)
+
+    def test_construction_low_rank_max_rank_none_raises(self):
+        """MetricRecipe with representation='low_rank' and max_rank=None must
+        raise ValueError at construction time (not deferred to build_core)."""
+        with self.assertRaises(ValueError):
+            MetricRecipe(
+                representation="low_rank",
+                estimator="sample_cov_low_rank",
+                buffer="reset_window",
+                support_gate=None,
+                needs=frozenset({"positions"}),
+                provides=frozenset({"positions"}),
+                emits="low_rank",
+                provenance="test — construction must raise",
+                max_rank=None,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Estimator correctness: condition-number reduction invariant
+# ---------------------------------------------------------------------------
+
+
+def _reconstruct_imm_matrix(
+    sigma: "np.ndarray", U: "np.ndarray", lam: "np.ndarray"
+) -> "np.ndarray":
+    """Reconstruct the d×d inverse mass matrix from (sigma, U, lam).
+
+    M^{-1} = diag(sigma) @ (I + U @ diag(lam - 1) @ U^T) @ diag(sigma)
+
+    This matches the formula in :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`.
+    """
+    sigma = np.asarray(sigma, dtype=np.float64)
+    U = np.asarray(U, dtype=np.float64)
+    lam = np.asarray(lam, dtype=np.float64)
+    d = sigma.shape[0]
+    low_rank = U @ np.diag(lam - 1.0) @ U.T
+    return np.diag(sigma) @ (np.eye(d) + low_rank) @ np.diag(sigma)
+
+
+class EstimatorCorrectnessInvariantTest(BlackJAXTest):
+    """Basis-free condition-number-reduction invariant for low-rank estimators.
+
+    For an ill-conditioned diagonal Gaussian target with covariance Σ, the
+    fitted inverse mass matrix M^{-1} must satisfy:
+
+        cond(M^{-1} Σ^{-1}) << cond(Σ^{-1})
+
+    This is the standard HMC dynamics condition number: a good metric (M^{-1} ≈ Σ)
+    makes M^{-1} Σ^{-1} ≈ I and the condition number ≈ 1.  The test is
+    basis-free (no golden values; the comparison is relative to cond_before)
+    and catches two bug classes:
+
+    - Inversion-drop: without inverting the score covariance in the geometric
+      mean, eigenvalues blow up to ~B/gamma ≈ 2e7, making cond_after >> cond_before.
+    - Gamma-drop (gamma → 0): division by zero produces NaN lam values, caught
+      by the finiteness assertion before the condition-number check.
+    """
+
+    _N_DIMS = 6
+    # stds = [50, 1, 1, 1, 1, 0.1] → cond(Σ) = (50 / 0.1)^2 = 250 000
+    _STDS = np.array([50.0, 1.0, 1.0, 1.0, 1.0, 0.1])
+    _BUFFER_SIZE = 400
+
+    def _fill_fisher_core(self, core):
+        """Fill buffer with draws + gradients from the ill-conditioned diagonal target."""
+        target_cov = np.diag(self._STDS**2)
+        rng = np.random.default_rng(42)
+        draws = rng.multivariate_normal(
+            np.zeros(self._N_DIMS), target_cov, self._BUFFER_SIZE
+        )
+        # grad log p(x) = -x / stds^2 for N(0, diag(stds^2))
+        grads = -draws / (self._STDS**2)[None, :]
+        state = core.init(self._N_DIMS)
+
+        def body(s, xs):
+            return core.update(s, xs[0], xs[1]), None
+
+        state, _ = jax.lax.scan(
+            body,
+            state,
+            (jnp.array(draws), jnp.array(grads)),
+        )
+        return core.final(state)
+
+    def _fill_sample_cov_core(self, core):
+        """Fill buffer with draws from the ill-conditioned diagonal target."""
+        target_cov = np.diag(self._STDS**2)
+        rng = np.random.default_rng(42)
+        draws = rng.multivariate_normal(
+            np.zeros(self._N_DIMS), target_cov, self._BUFFER_SIZE
+        )
+        state = core.init(self._N_DIMS)
+
+        def body(s, xs):
+            return core.update(s, xs, None), None
+
+        state, _ = jax.lax.scan(body, state, jnp.array(draws))
+        return core.final(state)
+
+    def _assert_cond_reduced(self, imm, label):
+        """Assert all metric fields are finite and condition number is reduced."""
+        self.assertTrue(
+            bool(jnp.all(jnp.isfinite(imm.sigma))), f"{label}: sigma not finite"
+        )
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))), f"{label}: U not finite")
+        self.assertTrue(
+            bool(jnp.all(jnp.isfinite(imm.lam))), f"{label}: lam not finite"
+        )
+        self.assertTrue(bool(jnp.all(imm.lam > 0)), f"{label}: lam not positive")
+        target_cov = np.diag(self._STDS**2)
+        cond_before = np.linalg.cond(target_cov)  # ≈ 250 000
+        M_inv = _reconstruct_imm_matrix(
+            np.asarray(imm.sigma), np.asarray(imm.U), np.asarray(imm.lam)
+        )
+        target_prec = np.linalg.inv(target_cov)
+        cond_after = np.linalg.cond(M_inv @ target_prec)
+        self.assertLess(
+            cond_after,
+            cond_before / 100,
+            f"{label}: metric did not reduce condition number "
+            f"(cond_before={round(cond_before)}, cond_after={round(cond_after, 1)})",
+        )
+
+    def test_fisher_low_rank_reduces_condition_number(self):
+        """Fisher low-rank metric must significantly reduce the target's condition number.
+
+        Uses x64 for stable SVD/QR (recommended for this estimator).
+        """
+        with jax.enable_x64():
+            core = _build_fisher_low_rank_core(
+                buffer_size=self._BUFFER_SIZE, max_rank=4, gamma=1e-5, cutoff=2.0
+            )
+            final_state = self._fill_fisher_core(core)
+            self._assert_cond_reduced(
+                final_state.inverse_mass_matrix, "fisher_low_rank"
+            )
+
+    def test_sample_cov_low_rank_reduces_condition_number(self):
+        """Sample-cov low-rank metric must significantly reduce the target's condition number."""
+        with jax.enable_x64():
+            core = _build_sample_cov_low_rank_core(
+                buffer_size=self._BUFFER_SIZE, max_rank=4
+            )
+            final_state = self._fill_sample_cov_core(core)
+            self._assert_cond_reduced(
+                final_state.inverse_mass_matrix, "sample_cov_low_rank"
+            )
 
 
 # ---------------------------------------------------------------------------
@@ -614,6 +770,85 @@ class FisherLowRankStagedAdaptationTest(BlackJAXTest):
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
         self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+
+
+# ---------------------------------------------------------------------------
+# Integration: staged_adaptation with sample_cov_low_rank core on std normal
+# ---------------------------------------------------------------------------
+
+
+class SampleCovLowRankStagedAdaptationTest(BlackJAXTest):
+    """staged_adaptation with the sample_cov_low_rank MetricCore on std normal."""
+
+    def test_runs_to_completion(self):
+        """staged_adaptation with a pre-built sample_cov_low_rank core must complete."""
+        n_dims = 5
+        num_steps = 200
+        buffer_size = min(2 * max(num_steps // 5, 128), max(num_steps, 1))
+
+        core = _build_sample_cov_low_rank_core(buffer_size=buffer_size, max_rank=4)
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        (state, params), _ = wu.run(key, pos, num_steps=num_steps)
+        self.assertEqual(state.position.shape, (n_dims,))
+        self.assertIsInstance(params["inverse_mass_matrix"], LowRankInverseMassMatrix)
+        self.assertEqual(params["inverse_mass_matrix"].sigma.shape, (n_dims,))
+        self.assertEqual(params["inverse_mass_matrix"].U.shape, (n_dims, 4))
+
+    def test_returns_finite_metric(self):
+        """All sample_cov_low_rank metric components must be finite after adaptation."""
+        n_dims = 4
+        num_steps = 150
+        buffer_size = min(2 * max(num_steps // 5, 128), max(num_steps, 1))
+
+        core = _build_sample_cov_low_rank_core(buffer_size=buffer_size, max_rank=4)
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        (_, params), _ = wu.run(key, pos, num_steps=num_steps)
+        imm = params["inverse_mass_matrix"]
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.sigma))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.U))))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(imm.lam))))
+
+    def test_grads_buffer_stays_zero_through_engine(self):
+        """sample_cov_low_rank through the engine must never write to grads_buffer.
+
+        Verifies that the sample_cov update does not write to grads_buffer even
+        when an adaptation_info_fn exposes the raw buffer (bypassing the default
+        buffer-drop).
+        """
+        n_dims = 4
+        num_steps = 50
+        buffer_size = 64
+
+        core = _build_sample_cov_low_rank_core(buffer_size=buffer_size, max_rank=4)
+        wu = staged_adaptation(
+            blackjax.nuts,
+            std_normal_logdensity,
+            metric=core,
+            # Use return_all_adapt_info so draws_buffer / grads_buffer are stacked.
+            adaptation_info_fn=return_all_adapt_info,
+        )
+        key = self.next_key()
+        pos = jnp.zeros(n_dims)
+        _, info = wu.run(key, pos, num_steps=num_steps)
+        # The engine stacks grads_buffer over all steps: shape (num_steps, B, d).
+        # For sample_cov_low_rank it must remain all-zeros at every step.
+        grads_trace = info.adaptation_state.imm_state.grads_buffer
+        np.testing.assert_array_equal(
+            np.asarray(grads_trace),
+            np.zeros_like(np.asarray(grads_trace)),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -811,26 +1046,6 @@ class WindowAdaptationLowRankShimTest(BlackJAXTest):
     _N_DIMS = 5
     _NUM_STEPS = 200
 
-    def _run(self, **kwargs):
-        wu = window_adaptation_low_rank(
-            blackjax.nuts,
-            std_normal_logdensity,
-            **{
-                "max_rank": 4,
-                "num_steps": self._NUM_STEPS,
-                **kwargs,
-            },
-        )
-        # window_adaptation_low_rank doesn't take num_steps in constructor;
-        # pass to run instead.
-        num_steps = kwargs.pop("num_steps", self._NUM_STEPS)
-        wu = window_adaptation_low_rank(
-            blackjax.nuts,
-            std_normal_logdensity,
-            max_rank=4,
-        )
-        return wu.run(self.next_key(), jnp.zeros(self._N_DIMS), num_steps=num_steps)
-
     def test_reset_path_runs(self):
         """buffer_policy='reset' (default) must complete and return finite metric."""
         wu = window_adaptation_low_rank(
@@ -964,6 +1179,147 @@ class WindowAdaptationLowRankShimTest(BlackJAXTest):
             window_adaptation_low_rank(
                 blackjax.nuts, std_normal_logdensity, recompute_every=0
             )
+
+    def test_gradient_based_init_seeds_sigma_at_first_step(self):
+        """With gradient_based_init=True, the sigma at step 0 in the info must
+        differ from the default ones-initialization.
+
+        The initial sigma is seeded from the gradient at the starting position
+        before the scan begins.  Step 0 is in the fast phase (no metric update),
+        so the sigma in info[0].adaptation_state reflects the initial value —
+        seeded vs ones for True vs False.  Catches h_shim_seed (shim silently
+        ignores the gradient_based_init flag).
+
+        Uses pos=2 (non-zero) so the gradient is non-zero and the seeding does
+        not fall back to identity (which happens when |grad| < 1e-10, e.g. at
+        the mode of std_normal_logdensity at x=0).
+        """
+        pos = jnp.ones(self._N_DIMS) * 2.0
+        key = self.next_key()
+        wu_true = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4, gradient_based_init=True
+        )
+        wu_false = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4, gradient_based_init=False
+        )
+        _, info_true = wu_true.run(key, pos, num_steps=self._NUM_STEPS)
+        _, info_false = wu_false.run(key, pos, num_steps=self._NUM_STEPS)
+        sigma_true_0 = info_true.adaptation_state.sigma[0]
+        sigma_false_0 = info_false.adaptation_state.sigma[0]
+        self.assertFalse(
+            bool(jnp.allclose(sigma_true_0, sigma_false_0)),
+            "sigma at step 0 must differ between gradient_based_init=True and False",
+        )
+
+    def test_accumulating_dispatch_background_split(self):
+        """background_split must be nonzero after at least one accumulating step,
+        and always zero on the reset path.
+
+        background_split is set at each slow-window switch in the accumulating
+        scan loop (marking old draws as "background" for the next partial-forget).
+        On the reset path it is always 0 (inert).  Catches b_dispatch (accumulating
+        silently routed to the reset engine, which never sets background_split).
+        """
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+
+        wu_reset = window_adaptation_low_rank(
+            blackjax.nuts, std_normal_logdensity, max_rank=4, buffer_policy="reset"
+        )
+        _, info_reset = wu_reset.run(key, pos, num_steps=self._NUM_STEPS)
+        # Reset path: background_split is always 0 at every step.
+        bg_reset = np.asarray(info_reset.adaptation_state.background_split)
+        self.assertTrue(
+            np.all(bg_reset == 0),
+            f"reset path: background_split must be all-zero, got max={bg_reset.max()}",
+        )
+
+        wu_acc = window_adaptation_low_rank(
+            blackjax.nuts,
+            std_normal_logdensity,
+            max_rank=4,
+            buffer_policy="accumulating",
+        )
+        _, info_acc = wu_acc.run(key, pos, num_steps=self._NUM_STEPS)
+        # Accumulating path: background_split must be nonzero after the first switch.
+        bg_acc = np.asarray(info_acc.adaptation_state.background_split)
+        self.assertTrue(
+            np.any(bg_acc != 0),
+            "accumulating path: background_split must be nonzero after at least one switch",
+        )
+
+
+# ---------------------------------------------------------------------------
+# x64 end-to-end smoke tests (float-promotion path)
+# ---------------------------------------------------------------------------
+
+
+class LowRankX64SmokeTest(BlackJAXTest):
+    """End-to-end smoke under x64 mode for both low-rank recipes.
+
+    The float64-promotion path inside _compute_low_rank_metric is only
+    exercised when jax_enable_x64 is True.  These tests verify the full
+    window_adaptation_low_rank pipeline produces finite, positive metric
+    components under x64.  The chain dtype follows core.init (float64
+    under x64); we do not mix float32 chains with x64 (out of scope).
+    """
+
+    _N_DIMS = 5
+    _NUM_STEPS = 200
+
+    def test_x64_smoke_fisher_low_rank(self):
+        """Full reset-path e2e under x64: all metric fields must be finite and positive."""
+        with jax.enable_x64():
+            wu = window_adaptation_low_rank(
+                blackjax.nuts, std_normal_logdensity, max_rank=4
+            )
+            (_, params), _ = wu.run(
+                self.next_key(),
+                jnp.zeros(self._N_DIMS),
+                num_steps=self._NUM_STEPS,
+            )
+            imm = params["inverse_mass_matrix"]
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(imm.sigma))), "sigma not finite under x64"
+            )
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(imm.U))), "U not finite under x64"
+            )
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(imm.lam))), "lam not finite under x64"
+            )
+            self.assertTrue(
+                bool(jnp.all(imm.sigma > 0)), "sigma not positive under x64"
+            )
+            self.assertTrue(bool(jnp.all(imm.lam > 0)), "lam not positive under x64")
+
+    def test_x64_smoke_sample_cov_low_rank(self):
+        """sample_cov_low_rank full e2e under x64: metric must be finite and positive."""
+        with jax.enable_x64():
+            num_steps = self._NUM_STEPS
+            buffer_size = min(2 * max(num_steps // 5, 128), max(num_steps, 1))
+            core = _build_sample_cov_low_rank_core(buffer_size=buffer_size, max_rank=4)
+            wu = staged_adaptation(
+                blackjax.nuts,
+                std_normal_logdensity,
+                metric=core,
+            )
+            (_, params), _ = wu.run(
+                self.next_key(),
+                jnp.zeros(self._N_DIMS),
+                num_steps=num_steps,
+            )
+            imm = params["inverse_mass_matrix"]
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(imm.sigma))), "sigma not finite under x64"
+            )
+            self.assertTrue(
+                bool(jnp.all(jnp.isfinite(imm.lam))), "lam not finite under x64"
+            )
+            self.assertTrue(
+                bool(jnp.all(imm.sigma > 0)), "sigma not positive under x64"
+            )
+            self.assertTrue(bool(jnp.all(imm.lam > 0)), "lam not positive under x64")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -31,25 +31,22 @@ import numpy as np
 from absl.testing import absltest
 
 import blackjax
-from blackjax.adaptation.low_rank_adaptation import (
-    _compute_low_rank_metric as lra_clrm,
-    build_growing_window_schedule,
-)
+from blackjax.adaptation.low_rank_adaptation import _compute_low_rank_metric as lra_clrm
+from blackjax.adaptation.low_rank_adaptation import build_growing_window_schedule
 from blackjax.adaptation.metric_estimators import _compute_low_rank_metric
 from blackjax.adaptation.metric_recipes import (
+    REGISTRY,
     LowRankMetricCoreState,
     MetricCore,
     MetricRecipe,
-    REGISTRY,
-    lookup_recipe,
-    seed_low_rank_sigma_from_grad,
     _build_fisher_low_rank_core,
     _build_sample_cov_low_rank_core,
+    lookup_recipe,
+    seed_low_rank_sigma_from_grad,
 )
 from blackjax.adaptation.staged_adaptation import build_schedule, staged_adaptation
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
-
 
 # ---------------------------------------------------------------------------
 # Backward-compat object-identity test
@@ -278,10 +275,12 @@ class FisherLowRankCoreContractTest(BlackJAXTest):
         final_state = core.final(state)
         self.assertEqual(int(final_state.buffer_idx), 0)
         np.testing.assert_array_equal(
-            np.asarray(final_state.draws_buffer), np.zeros((self.buffer_size, self.n_dims))
+            np.asarray(final_state.draws_buffer),
+            np.zeros((self.buffer_size, self.n_dims)),
         )
         np.testing.assert_array_equal(
-            np.asarray(final_state.grads_buffer), np.zeros((self.buffer_size, self.n_dims))
+            np.asarray(final_state.grads_buffer),
+            np.zeros((self.buffer_size, self.n_dims)),
         )
 
     def test_final_produces_finite_metric(self):


### PR DESCRIPTION
## Change

Adds low-rank mass-matrix recipes to the staged-adaptation engine and routes
`window_adaptation_low_rank` through it, with its public surface and behaviour unchanged.

- Two low-rank registry recipes: `"fisher_low_rank"` (the Fisher-divergence projected form —
  the recommended low-rank entry) and `"sample_cov_low_rank"` (sample-covariance eigh form,
  draws only). Both are usable directly via
  `staged_adaptation(algorithm, logdensity_fn, metric="fisher_low_rank")`.
- The low-rank metric core is an embeddable init/update/final component holding its own draw
  buffer, consistent with the diagonal/dense cores.
- `window_adaptation_low_rank` becomes a thin shim. Its default (reset) buffer policy runs on
  the staged engine; the accumulating buffer policy uses the established low-rank scan loop it
  shares with earlier releases (migrating that policy onto the engine is a documented follow-up).
- Incidental consolidation: the private low-rank metric computation is relocated to the
  estimator module alongside the other low-rank estimators (character-identical body,
  re-exported to preserve existing access; not part of the public API).
- A narrow, opt-in `initial_metric_state` override is added to `staged_adaptation()` so a host
  can seed the initial metric (used by the low-rank gradient-based initialisation); it is inert
  for all existing callers.

## Behaviour-identical

`window_adaptation_low_rank` is verified bit-identical to the previous implementation through
full `run()`: 29 raw-byte comparisons (step size, inverse mass matrix `(sigma, U, lam)`, final
position) covering **both** buffer policies, gradient-based init on and off, float32 and
float64, several `max_rank` values (including `max_rank > dimension`), the Stan and nutpie-style
growing-window schedules, and HMC with extra kernel parameters — zero mismatches, with a live
sensitivity control. Existing low-rank tests pass unmodified.

Because the shim and its reference share the same estimator, that parity check establishes
refactor-faithfulness but not estimator correctness on its own; the estimator is additionally
pinned by new basis-free invariant tests (the fitted metric must reduce a known ill-conditioned
target's condition number), which fail if the low-rank computation regresses. The suite also
covers the accumulating-policy dispatch, the gradient-based-init wiring, per-dtype float64
smokes, and construction-time recipe validation.

**Note for maintainers:** `low_rank_adaptation.base()` remains in use — it backs the
accumulating buffer policy — so it is retained here; only `window_adaptation.base()` is on the
deprecation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
