### PR TITLE
Fix the optional rng_key default in InitFn

### DIFF
--- a/blackjax/base.py
+++ b/blackjax/base.py
@@ -34,7 +34,7 @@ class InitFn(Protocol):
 
     """
 
-    def __call__(self, position: Position, rng_key: PRNGKey | None) -> State:
+    def __call__(self, position: Position, rng_key: PRNGKey | None = None) -> State:
         """Initialize the algorithm's state.
 
         Parameters

--- a/tests/test_api_protocols.py
+++ b/tests/test_api_protocols.py
@@ -26,7 +26,7 @@ import jax.numpy as jnp
 import pytest
 
 import blackjax
-from blackjax.base import SamplingAlgorithm
+from blackjax.base import InitFn, SamplingAlgorithm
 from tests.fixtures import std_normal_logdensity
 
 # ---------------------------------------------------------------------------
@@ -34,6 +34,15 @@ from tests.fixtures import std_normal_logdensity
 # ---------------------------------------------------------------------------
 _DIM = 2
 _POSITION = jnp.ones(_DIM)
+
+
+def test_init_protocol_default_matches_hmc_init():
+    protocol_default = inspect.signature(InitFn.__call__).parameters["rng_key"].default
+    hmc_default = (
+        inspect.signature(_make_algorithm("hmc").init).parameters["rng_key"].default
+    )
+
+    assert protocol_default is hmc_default is None
 
 
 def _make_algorithm(name):


### PR DESCRIPTION
## Description

`SamplingAlgorithm.init` is typed by the `InitFn` protocol. The protocol allowed `rng_key` to be `None`, but it omitted the `= None` default, so Pyright treated the argument as required even though the concrete HMC initializer accepts `init(position)`.

This adds the missing default to the protocol and a regression test that compares the protocol signature with the concrete HMC initializer. It does not change runtime algorithm behavior.

## Related issues / discussions

Closes #782

## Validation

- Pyright 1.1.411: 0 errors on the issue reproducer, with both `init(position)` and `init(position, rng_key)` calls.
- `uv run pytest -q tests/test_api_protocols.py tests/mcmc/test_multinomial_hmc.py`: 93 passed.
- `uv run pre-commit run --all-files`: all applicable hooks passed.
- Full Windows CI-equivalent run: 1542 passed, 1 skipped, and 4 unrelated baseline failures. All four failures reproduced identically on the same upstream commit without the production fix; two call the unavailable `os.geteuid` API on Windows, and two are unrelated numerical assertions. The same upstream commit's Ubuntu Tests workflow is successful.

## Checklist

**General**

- [x] The branch is rebased on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes

**Code quality**

- [x] Public functions have NumPy-style docstrings (no new public function; the existing protocol docstring is unchanged)
- [x] Naming follows existing conventions
- [x] All new code is JIT-compatible (the production change is type-only)

**New sampler / algorithm**

Not applicable; this is a typing contract fix.

## AI assistance disclosure

This contribution was prepared and validated with OpenAI Codex automation. The automation reproduced the static typing error and runtime signature mismatch on the current upstream commit, produced the two-file patch, and ran the checks listed above.
