### PR TITLE
Cap JAX-nightly test workers at -n 2 to avoid runner OOM

### DIFF
--- a/.github/workflows/test_jax_nightly.yml
+++ b/.github/workflows/test_jax_nightly.yml
@@ -22,4 +22,4 @@ jobs:
         uv pip install --prerelease=allow --force-reinstall jax jaxlib \
           -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
     - name: Run tests
-      run: uv run pytest -n auto -vv --benchmark-disable tests
+      run: uv run pytest -n 2 -vv --benchmark-disable tests


### PR DESCRIPTION
## Change

The JAX-Nightly scheduled job ran the test suite with `pytest -n auto` — one worker per core.
On the memory-limited GitHub-hosted runner, that many JAX-importing workers exceeds the ~7 GB
limit, and the host sends the runner a shutdown signal mid-suite (the failure surfaced right at
the heavier adaptation tests). The regular test workflow was already capped at `-n 2` for exactly
this reason; the nightly workflow was overlooked.

This caps the nightly at `-n 2`, matching `test.yml`. The same test set (including the recently
added low-rank recipe tests) passes at `-n 2` in the standard CI, so the cap costs no coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
