### PR TITLE
Deprecate window_adaptation.base() ahead of removal

### DIFF
--- a/blackjax/adaptation/window_adaptation.py
+++ b/blackjax/adaptation/window_adaptation.py
@@ -29,6 +29,7 @@ delegates to :func:`~blackjax.adaptation.staged_adaptation.staged_adaptation`).
 Fisher-diagonal adaptation is accessible via
 ``staged_adaptation(metric="fisher_diag")`` only.
 """
+import warnings
 from typing import Callable
 
 import jax
@@ -124,7 +125,20 @@ def base(
         Function that returns the step size and mass matrix given a warmup
         state.
 
+    .. deprecated::
+        This function is deprecated and will be removed in a future release.
+        Use :func:`blackjax.window_adaptation` for the standard warmup, or
+        :func:`blackjax.staged_adaptation` for custom metric recipes.
+
     """
+    warnings.warn(
+        "window_adaptation.base() is deprecated and will be removed in a future "
+        "release. Use blackjax.window_adaptation for the standard warmup, or "
+        "blackjax.staged_adaptation for custom metric recipes.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
     mm_init, mm_update, mm_final = mass_matrix_adaptation(
         is_mass_matrix_diagonal, imm_shrinkage_to_previous
     )

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -753,3 +753,9 @@ def test_floor_constant_value():
         np.pi
     )  # (pi/2)*sqrt(4), NOT via the CHEES_LENGTH_FLOOR_FACTOR symbol
     np.testing.assert_allclose(val, expected, rtol=1e-6)
+
+
+def test_window_adaptation_base_deprecated():
+    """Verify that calling window_adaptation.base() emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="window_adaptation.base.*deprecated"):
+        window_adaptation.base(is_mass_matrix_diagonal=True)


### PR DESCRIPTION
## Change

`window_adaptation.base()` — the low-level builder returning `(init, update, final)` — is no longer used internally: `window_adaptation()` now routes through the staged-adaptation engine. This adds a `DeprecationWarning` to `base()` pointing users at the supported entry points (`blackjax.window_adaptation` for the standard warmup, `blackjax.staged_adaptation` for custom metric recipes) ahead of removing it in a future release.

`base()`'s behaviour is unchanged and it remains exported for now; only the warning and a docstring deprecation note are added. Verified that nothing in the library or test suite calls `base()`, so the warning does not fire during normal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)