### PR TITLE
Route the accumulating low-rank buffer policy through the staged engine and remove low_rank_adaptation.base()

### DIFF
--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -65,7 +65,7 @@ accumulates in the next one -- and it recomputes the metric up to every draw
 (``mass_matrix_update_freq=1`` in ``nuts-rs``), not just at window ends
 (``nuts-rs`` ``src/transform/adapt/low_rank.rs::switch`` /
 ``src/adapt_strategy.rs``). Passing ``buffer_policy="accumulating"`` to
-:func:`base` / :func:`window_adaptation_low_rank` enables this; the default
+:func:`window_adaptation_low_rank` enables this; the default
 ``"reset"`` reproduces the original hard-reset behaviour exactly.
 
 **Numerical robustness** (round-9 schedule-port audit). ``_compute_low_rank_metric``
@@ -83,10 +83,8 @@ allocation ``jax.lax.scan`` would otherwise stack for no benefit); pass
 ``adaptation_info_fn=blackjax.adaptation.base.return_all_adapt_info``
 explicitly to keep them.
 """
-import inspect
 from typing import Callable, NamedTuple
 
-import jax
 import jax.flatten_util as fu
 import jax.numpy as jnp
 import numpy as np
@@ -99,6 +97,7 @@ from blackjax.adaptation.metric_estimators import (  # noqa: F401 — backward-c
     _spd_mean,
 )
 from blackjax.adaptation.metric_recipes import (
+    _build_fisher_low_rank_accumulating_core,
     _build_fisher_low_rank_core,
     seed_low_rank_sigma_from_grad,
 )
@@ -106,19 +105,14 @@ from blackjax.adaptation.staged_adaptation import (
     StagedAdaptationState,
     staged_adaptation,
 )
-from blackjax.adaptation.step_size import (
-    DualAveragingAdaptationState,
-    dual_averaging_adaptation,
-)
+from blackjax.adaptation.step_size import DualAveragingAdaptationState
 from blackjax.adaptation.window_adaptation import build_schedule
 from blackjax.base import AdaptationAlgorithm
-from blackjax.mcmc.metrics import LowRankInverseMassMatrix, gaussian_euclidean_low_rank
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 from blackjax.util import pytree_size
 
 __all__ = [
     "LowRankAdaptationState",
-    "base",
     "build_growing_window_schedule",
     "window_adaptation_low_rank",
 ]
@@ -227,9 +221,9 @@ def _engine_state_to_low_rank_adaptation_state(
     (whose ``imm_state`` is a :class:`~blackjax.adaptation.metric_recipes
     .LowRankMetricCoreState`) to a :class:`LowRankAdaptationState`.
 
-    Used by the reset-path info bridge in :func:`window_adaptation_low_rank`
-    to expose the same ``adaptation_state`` field layout as the legacy
-    :func:`base` scan loop.  Downstream code that inspects
+    Used by the engine-path info bridge in :func:`window_adaptation_low_rank`
+    to expose the same ``adaptation_state`` field layout for both buffer policies.
+    Downstream code that inspects
     ``info[-1].adaptation_state.sigma``, ``.mu_star``, ``.U``, etc. continues
     to work without change across both buffer policies.
     """
@@ -281,24 +275,6 @@ def _make_low_rank_bridge_info_fn(user_fn: Callable) -> Callable:
 # module's namespace for backward-compatibility (existing callers that import
 # from low_rank_adaptation continue to work).
 # Canonical location: blackjax.adaptation.metric_estimators.
-
-
-def _shift_buffer_left(buf: Array, shift: Array) -> Array:
-    """Drop the first ``shift`` rows of ``buf``, shifting the remainder to
-    the front and zero-filling the newly-vacated tail.
-
-    Implements nutpie's partial-forget buffer pop under JAX's static-shape
-    constraint (``nuts-rs`` ``src/transform/adapt/low_rank.rs::switch``:
-    ``for _ in 0..background_split { draws.pop_front() }``): pad the buffer
-    with its own capacity in zeros, then take a single dynamic-length-free
-    ``dynamic_slice`` starting at ``shift`` (a traced integer is fine here,
-    only the slice *size* -- the static ``capacity`` -- needs to be a
-    concrete Python int).
-    """
-    capacity = buf.shape[0]
-    shift = jnp.clip(shift, 0, capacity)
-    padded = jnp.concatenate([buf, jnp.zeros_like(buf)], axis=0)
-    return jax.lax.dynamic_slice_in_dim(padded, shift, capacity, axis=0)
 
 
 def _accumulating_buffer_capacity(schedule: Array) -> int:
@@ -356,11 +332,11 @@ def build_growing_window_schedule(
       (``mass_matrix_window_growth`` in nutpie's receipts).
 
     **Scope note.** This function (together with the ``gradient_based_init``
-    option on :func:`base` / :func:`window_adaptation_low_rank`) implements
+    option on :func:`window_adaptation_low_rank`) implements
     the window-sizing and gradient-based-init components of nutpie's warmup;
-    pair it with ``buffer_policy="accumulating"`` (see :func:`base`) for the
-    partial-forget buffer and continuous recompute cadence, matching
-    nutpie's other main pieces.
+    pair it with ``buffer_policy="accumulating"`` on
+    :func:`window_adaptation_low_rank` for the partial-forget buffer and
+    continuous recompute cadence, matching nutpie's other main pieces.
 
     nutpie's actual schedule is an *online*, per-draw decision
     (``adapt_strategy.rs``'s ``is_late`` look-ahead + a partial-forget
@@ -475,381 +451,6 @@ def build_growing_window_schedule(
 
 
 # ---------------------------------------------------------------------------
-# Warmup primitives  (init / update / final)
-# ---------------------------------------------------------------------------
-
-
-def base(
-    max_rank: int = 10,
-    target_acceptance_rate: float = 0.80,
-    gamma: float = 1e-5,
-    cutoff: float = 2.0,
-    gradient_based_init: bool = False,
-    buffer_policy: str = "reset",
-    recompute_every: int = 1,
-) -> tuple[Callable, Callable, Callable]:
-    """Warmup scheme using the low-rank mass matrix adaptation.
-
-    Mirrors Stan's three-phase schedule but replaces Welford covariance
-    estimation with the Fisher-divergence-minimising low-rank metric of
-    :cite:p:`seyboldt2026preconditioning`, following nutpie's implementation.
-
-    Parameters
-    ----------
-    max_rank
-        Maximum number of eigenvectors retained in the low-rank correction.
-    target_acceptance_rate
-        Target acceptance rate for dual-averaging step-size adaptation.
-    gamma
-        Regularisation scale.  The projected covariance is divided by ``gamma``
-        (nutpie convention -- no ``n`` scaling).  Default ``1e-5`` matches
-        nutpie's ``LowRankSettings::default``.
-    cutoff
-        Eigenvectors with eigenvalue in ``[1/cutoff, cutoff]`` are masked
-        (eigenvalue set to 1).  Default ``2.0`` matches nutpie's ``c=2``.
-    gradient_based_init
-        If ``True``, seed the diagonal scale from the initial gradient
-        instead of the identity: nutpie's own ``init`` calls
-        ``update_from_grad`` on the very first observed point (``nuts-rs``
-        ``src/transform/adapt/low_rank.rs::init``), which the paper's §3.1
-        motivates as ``M = diag(|alpha^(0)|)`` -- a regularised diagonal of
-        the gradient outer-product, a common Hessian approximation at the
-        starting point (cf. L-BFGS). Since blackjax's ``sigma**2`` is the
-        *inverse*-mass-matrix diagonal, this sets
-        ``sigma = 1/sqrt(clip(|grad|, 1e-20, 1e20))`` so that
-        ``M^{-1}_diag = sigma**2 = 1/|grad|``, matching ``M = diag(|grad|)``
-        -- **except per-coordinate where** ``|grad_i| < 1e-10``, **where
-        sigma_i falls back to 1.0** (the identity) instead of propagating
-        the ``1e-20`` clip floor into an astronomically loose ``sigma_i =
-        1e10``. This defends the real edge case of initialising at (or very
-        near) a stationary point of the target -- e.g. ``x=0`` on any
-        centered/standardised density -- where the gradient is exactly (or
-        near-)zero and an extreme initial scale causes near-certain
-        divergence on the very first trajectory (see the fisher-2x2
-        calibration study's root-caused finding). Only the diagonal scale
-        changes; ``U``/``lam`` still start at no-correction (``U=0``,
-        ``lam=1``), same as the default. Default ``False`` reproduces the
-        original identity/zero initialisation exactly (see also
-        :func:`build_growing_window_schedule`, which implements the
-        companion window-sizing piece of nutpie's warmup).
-    buffer_policy
-        ``"reset"`` (default) hard-resets the draw/gradient buffer to empty
-        at every window switch, matching the original Stan-schedule
-        behaviour exactly -- zero default-behavior change.
-        ``"accumulating"`` instead ports nutpie's partial-forget buffer
-        (``nuts-rs`` ``src/transform/adapt/low_rank.rs::switch``): at a
-        window switch, only the draws that were already "background" (the
-        window before last) are dropped, so the buffer keeps the
-        just-completed window's draws in addition to the next window's, and
-        the metric is recomputed both at every switch (unconditionally,
-        nutpie's ``force_update``) and periodically in between per
-        ``recompute_every`` (nutpie's ``mass_matrix_update_freq``). Composes
-        with any ``schedule_fn`` -- the buffer policy only changes what
-        happens *at* a window boundary the schedule already defines, not
-        when those boundaries occur.
-    recompute_every
-        Only used when ``buffer_policy="accumulating"``. Number of
-        slow-stage steps between metric recomputes *between* window
-        switches (switches themselves always force a recompute,
-        independent of this cadence). Default ``1`` recomputes on every
-        slow-stage step, matching nutpie's default
-        ``mass_matrix_update_freq=1`` (the fully faithful port). Raising
-        this trades fidelity for compute: an SVD-based recompute every
-        single step can be costly in JAX for large ``d``/buffer size; see
-        the PR description for measured timings before deviating from the
-        default. Ignored under ``buffer_policy="reset"`` (recompute there is
-        tied solely to ``is_window_end``, as before).
-
-    Returns
-    -------
-    ``(init, update, final)``
-        The three adaptation primitives expected by the window-adaptation loop.
-    """
-    if buffer_policy not in ("reset", "accumulating"):
-        raise ValueError(
-            f"buffer_policy must be 'reset' or 'accumulating', got {buffer_policy!r}"
-        )
-    if recompute_every < 1:
-        raise ValueError(f"recompute_every must be >= 1, got {recompute_every!r}")
-    da_init, da_update, da_final = dual_averaging_adaptation(target_acceptance_rate)
-
-    def init(
-        position: ArrayLikeTree,
-        grad: ArrayLikeTree,
-        initial_step_size: float,
-        buffer_size: int,
-    ) -> LowRankAdaptationState:
-        d = pytree_size(position)
-        if gradient_based_init:
-            grad_flat, _ = fu.ravel_pytree(grad)
-            abs_grad = jnp.abs(grad_flat)
-            # Per-coordinate fallback to the identity (sigma_i=1.0) below a
-            # near-zero-gradient threshold, rather than propagating the
-            # 1e-20 clip floor into sigma_i=1e10. A real user-facing edge:
-            # x=0 initialisation on any centered/standardised target gives
-            # an EXACTLY zero gradient, and nuts-rs's own
-            # array_update_var_inv_std_grad has no formula-level defense for
-            # this either (clamp(0, 1e-20, 1e20).recip() = 1e20 is finite,
-            # so its `fill_invalid` branch -- reserved for non-finite results
-            # -- never fires); nutpie avoids this in practice purely by
-            # jittering the initial position elsewhere in its pipeline, not
-            # via this formula. sigma=1e10 at every dimension mistunes the
-            # metric so severely relative to initial_step_size that the
-            # first trajectory diverges immediately, freezing the chain for
-            # the whole first window and collapsing the subsequent estimate
-            # -- root-caused via the Fisher 2x2 calibration study's
-            # instrumented re-run (design doc "Calibration verdict" section).
-            # Threshold 1e-10 is a defensible, disclosed choice (no nuts-rs
-            # precedent to cite at this exact boundary).
-            near_zero_grad_threshold = 1e-10
-            safe_sigma = jnp.power(jnp.clip(abs_grad, 1e-20, 1e20), -0.5)
-            sigma = jnp.where(abs_grad < near_zero_grad_threshold, 1.0, safe_sigma)
-        else:
-            sigma = jnp.ones(d)
-        mu_star = jnp.zeros(d)
-        U = jnp.zeros((d, max_rank))
-        lam = jnp.ones(max_rank)
-        ss_state = da_init(initial_step_size)
-        draws_buffer = jnp.zeros((buffer_size, d))
-        grads_buffer = jnp.zeros((buffer_size, d))
-        return LowRankAdaptationState(
-            ss_state,
-            sigma,
-            mu_star,
-            U,
-            lam,
-            initial_step_size,
-            draws_buffer,
-            grads_buffer,
-            0,
-            0,
-            0,
-        )
-
-    def fast_update(
-        position: ArrayLikeTree,
-        grad: ArrayLikeTree,
-        acceptance_rate: float,
-        state: LowRankAdaptationState,
-    ) -> LowRankAdaptationState:
-        """Fast window: only adapt step size."""
-        del position, grad
-        new_ss = da_update(state.ss_state, acceptance_rate)
-        return LowRankAdaptationState(
-            new_ss,
-            state.sigma,
-            state.mu_star,
-            state.U,
-            state.lam,
-            jnp.exp(new_ss.log_step_size),
-            state.draws_buffer,
-            state.grads_buffer,
-            state.buffer_idx,
-            state.background_split,
-            state.recompute_counter,
-        )
-
-    def slow_update(
-        position: ArrayLikeTree,
-        grad: ArrayLikeTree,
-        acceptance_rate: float,
-        state: LowRankAdaptationState,
-    ) -> LowRankAdaptationState:
-        """Slow window: adapt step size and accumulate draws/grads in buffer."""
-        pos_flat, _ = fu.ravel_pytree(position)
-        grad_flat, _ = fu.ravel_pytree(grad)
-        B = state.draws_buffer.shape[0]
-        idx = state.buffer_idx % B  # wrap to avoid out-of-bounds during trace
-        new_draws = jax.lax.dynamic_update_slice(
-            state.draws_buffer, pos_flat[None, :], (idx, 0)
-        )
-        new_grads = jax.lax.dynamic_update_slice(
-            state.grads_buffer, grad_flat[None, :], (idx, 0)
-        )
-        new_ss = da_update(state.ss_state, acceptance_rate)
-        # Only accumulate under "accumulating" -- keeps the field genuinely
-        # inert (always 0) rather than merely unread under "reset", so state
-        # inspection under the default policy is unambiguous.
-        new_recompute_counter = (
-            state.recompute_counter + 1
-            if buffer_policy == "accumulating"
-            else state.recompute_counter
-        )
-        return LowRankAdaptationState(
-            new_ss,
-            state.sigma,
-            state.mu_star,
-            state.U,
-            state.lam,
-            jnp.exp(new_ss.log_step_size),
-            new_draws,
-            new_grads,
-            state.buffer_idx + 1,
-            state.background_split,
-            new_recompute_counter,
-        )
-
-    def slow_final(state: LowRankAdaptationState) -> LowRankAdaptationState:
-        """End of slow window under ``buffer_policy="reset"``: recompute
-        metric and hard-reset the buffer to empty. Unchanged from the
-        original (pre-``buffer_policy``) behaviour -- ``background_split``/
-        ``recompute_counter`` are inert under this policy, zeroed here to
-        match the buffer's own reset for cleanliness."""
-        sigma, mu_star, U, lam = _compute_low_rank_metric(
-            state.draws_buffer,
-            state.grads_buffer,
-            state.buffer_idx,
-            max_rank,
-            gamma,
-            cutoff,
-        )
-        # Re-initialise dual averaging at the current averaged step size
-        new_ss = da_init(da_final(state.ss_state))
-        B, d = state.draws_buffer.shape
-        return LowRankAdaptationState(
-            new_ss,
-            sigma,
-            mu_star,
-            U,
-            lam,
-            jnp.exp(new_ss.log_step_size),
-            jnp.zeros((B, d)),
-            jnp.zeros((B, d)),
-            0,
-            0,
-            0,
-        )
-
-    def slow_switch(state: LowRankAdaptationState) -> LowRankAdaptationState:
-        """End of slow window under ``buffer_policy="accumulating"``: nutpie's
-        partial-forget ``switch()`` -- drop only the ``background_split``
-        oldest rows (shift the rest to the front), then the *entire*
-        surviving buffer (the just-completed window) becomes the new
-        background, matching ``nuts-rs``'s
-        ``self.background_split = self.draws.len()`` (set *after* the pop).
-        The recompute is unconditional here (nutpie's ``force_update=true``
-        on every switch), guarded only by the same ``n>=3`` minimum ``adapt()``
-        floor nuts-rs itself uses (``current_count() < 3 => return false``)
-        to avoid fitting a metric from a near-empty buffer."""
-        shift = state.background_split
-        new_draws = _shift_buffer_left(state.draws_buffer, shift)
-        new_grads = _shift_buffer_left(state.grads_buffer, shift)
-        new_n_valid = state.buffer_idx - shift
-
-        def _recompute():
-            return _compute_low_rank_metric(
-                new_draws, new_grads, new_n_valid, max_rank, gamma, cutoff
-            )
-
-        def _keep():
-            return state.sigma, state.mu_star, state.U, state.lam
-
-        sigma, mu_star, U, lam = jax.lax.cond(new_n_valid >= 3, _recompute, _keep)
-        # Re-initialise dual averaging at the current averaged step size --
-        # unchanged Stan-schedule convention, orthogonal to the buffer
-        # question (nuts-rs restarts step size only once, on the *first*
-        # successful mass-matrix change; porting that is out of this task's
-        # scope, see the module docstring / PR description).
-        new_ss = da_init(da_final(state.ss_state))
-        return LowRankAdaptationState(
-            new_ss,
-            sigma,
-            mu_star,
-            U,
-            lam,
-            jnp.exp(new_ss.log_step_size),
-            new_draws,
-            new_grads,
-            new_n_valid,
-            new_n_valid,
-            0,
-        )
-
-    def slow_recompute_only(state: LowRankAdaptationState) -> LowRankAdaptationState:
-        """Continuous (mid-window) metric recompute under
-        ``buffer_policy="accumulating"``: reuses whatever is currently in
-        the buffer (the retained previous window plus the partial current
-        window), matching nuts-rs's ``adapt()`` firing on (up to) every draw
-        independent of the window-end ``switch()`` event
-        (``mass_matrix_update_freq=1``, gated here by ``recompute_every``).
-        Buffer contents, ``background_split``, and the step-size
-        dual-averaging state are left untouched -- only the mass-matrix
-        factors change."""
-        n = state.buffer_idx
-
-        def _recompute():
-            return _compute_low_rank_metric(
-                state.draws_buffer, state.grads_buffer, n, max_rank, gamma, cutoff
-            )
-
-        def _keep():
-            return state.sigma, state.mu_star, state.U, state.lam
-
-        sigma, mu_star, U, lam = jax.lax.cond(n >= 3, _recompute, _keep)
-        return LowRankAdaptationState(
-            state.ss_state,
-            sigma,
-            mu_star,
-            U,
-            lam,
-            state.step_size,
-            state.draws_buffer,
-            state.grads_buffer,
-            state.buffer_idx,
-            state.background_split,
-            0,
-        )
-
-    def update(
-        state: LowRankAdaptationState,
-        adaptation_stage: tuple,
-        position: ArrayLikeTree,
-        grad: ArrayLikeTree,
-        acceptance_rate: float,
-    ) -> LowRankAdaptationState:
-        stage, is_window_end = adaptation_stage
-
-        new_state = jax.lax.switch(
-            stage,
-            (fast_update, slow_update),
-            position,
-            grad,
-            acceptance_rate,
-            state,
-        )
-        if buffer_policy == "accumulating":
-
-            def _maybe_periodic_recompute(s: LowRankAdaptationState):
-                due = jnp.logical_and(
-                    stage == 1, s.recompute_counter % recompute_every == 0
-                )
-                return jax.lax.cond(due, slow_recompute_only, lambda x: x, s)
-
-            new_state = jax.lax.cond(
-                is_window_end,
-                slow_switch,
-                _maybe_periodic_recompute,
-                new_state,
-            )
-        else:
-            new_state = jax.lax.cond(
-                is_window_end,
-                slow_final,
-                lambda s: s,
-                new_state,
-            )
-        return new_state
-
-    def final(
-        state: LowRankAdaptationState,
-    ) -> tuple[float, Array, Array, Array, Array]:
-        step_size = jnp.exp(state.ss_state.log_step_size_avg)
-        return step_size, state.sigma, state.mu_star, state.U, state.lam
-
-    return init, update, final
-
-
-# ---------------------------------------------------------------------------
 # High-level API
 # ---------------------------------------------------------------------------
 
@@ -915,7 +516,7 @@ def window_adaptation_low_rank(
         Integrator to pass to ``algorithm.build_kernel``.
     gradient_based_init
         Seed the diagonal scale from the initial gradient instead of the
-        identity, matching nutpie's own initialisation (see :func:`base`).
+        identity, matching nutpie's own initialisation.
         Default ``False`` reproduces the original behaviour exactly.
     schedule_fn
         Schedule-generator function ``num_steps -> (num_steps, 2)`` array of
@@ -928,10 +529,12 @@ def window_adaptation_low_rank(
         (online, per-draw) schedule.
     buffer_policy
         ``"reset"`` (default, unchanged behaviour) or ``"accumulating"``
-        (nutpie's partial-forget buffer) -- see :func:`base` for the exact
-        semantics. Composes with any ``schedule_fn``.
+        (nutpie's partial-forget buffer, ``nuts-rs`` ``switch()``).
+        Composes with any ``schedule_fn``.
     recompute_every
-        Only used when ``buffer_policy="accumulating"``; see :func:`base`.
+        Only used when ``buffer_policy="accumulating"``: number of slow-stage
+        steps between mid-window metric recomputes.  Default 1 matches
+        nutpie's ``mass_matrix_update_freq=1``.
     **extra_parameters
         Additional keyword arguments forwarded to the kernel at every step
         (e.g. ``num_integration_steps`` for HMC).
@@ -957,9 +560,11 @@ def window_adaptation_low_rank(
 
     Notes
     -----
-    The default (reset) buffer policy runs on the staged-adaptation engine;
-    the accumulating policy uses the established low-rank scan loop, which it
-    shares with earlier releases.
+    Both buffer policies run on the staged-adaptation engine.  The reset
+    policy hard-clears the draw/gradient buffer at each slow-window boundary;
+    the accumulating policy retains the previous window's draws as background
+    (nutpie partial-forget) and recomputes the metric mid-window according to
+    ``recompute_every``.
 
     Wrap ``warmup.run(...)`` in :func:`blackjax.progress_bar` to display a
     progress bar, e.g. ``with blackjax.progress_bar(): warmup.run(...)``.
@@ -1033,99 +638,55 @@ def window_adaptation_low_rank(
     def _run_accumulating(
         rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int
     ) -> tuple:
-        """Accumulating policy: use the established low-rank scan loop.
+        """Accumulating policy: run via the staged-adaptation engine.
 
-        The default (reset) buffer policy runs on the staged-adaptation engine;
-        the accumulating policy uses the established low-rank scan loop, which
-        it shares with earlier releases.  Migrating the accumulating policy onto
-        the staged-adaptation engine is future work; it must NOT be done via an
-        ``is_window_end`` kwarg on ``MetricCore.update()`` — the clean approach
-        is for the core to own its recompute cadence from a step index, or for
-        periodic recompute to fold into the engine's ``final`` contract.
+        Pre-computes the schedule to derive the tight worst-case buffer capacity
+        (``_accumulating_buffer_capacity``), then delegates to the engine via
+        ``_build_fisher_low_rank_accumulating_core``.  Buffer, counter, and
+        sigma/mu_star/U/lam state are managed entirely inside the core.
         """
-        adapt_init_fn, adapt_step_fn, adapt_final_fn = base(
+        # Pre-compute schedule before building the core so we can derive the
+        # exact accumulating buffer capacity from the window boundaries.
+        schedule = schedule_fn(num_steps)
+        buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
+
+        core = _build_fisher_low_rank_accumulating_core(
+            buffer_size=buffer_size,
             max_rank=max_rank,
-            target_acceptance_rate=target_acceptance_rate,
             gamma=gamma,
             cutoff=cutoff,
-            gradient_based_init=gradient_based_init,
-            buffer_policy="accumulating",
             recompute_every=recompute_every,
         )
 
-        if len(inspect.signature(algorithm.build_kernel).parameters) > 0:
-            mcmc_kernel = algorithm.build_kernel(integrator)
-        else:
-            mcmc_kernel = algorithm.build_kernel()
-
-        def one_step(carry, xs):
-            _, rng_key_, adaptation_stage = xs
-            state, adaptation_state = carry
-            metric = gaussian_euclidean_low_rank(
-                adaptation_state.sigma,
-                adaptation_state.U,
-                adaptation_state.lam,
-            )
-            new_state, step_info = mcmc_kernel(
-                rng_key_,
-                state,
-                logdensity_fn,
-                adaptation_state.step_size,
-                metric,
-                **extra_parameters,
-            )
-            new_adaptation_state = adapt_step_fn(
-                adaptation_state,
-                adaptation_stage,
-                new_state.position,
-                new_state.logdensity_grad,
-                step_info.acceptance_rate,
-            )
-            return (
-                (new_state, new_adaptation_state),
-                adaptation_info_fn(new_state, step_info, new_adaptation_state),
+        seeded_imm_state = None
+        if gradient_based_init:
+            _init_state = algorithm.init(position, logdensity_fn)
+            n_dims = pytree_size(position)
+            seeded_imm_state = seed_low_rank_sigma_from_grad(
+                core.init(n_dims), _init_state.logdensity_grad
             )
 
-        init_state = algorithm.init(position, logdensity_fn)
-        # `schedule` must be computed before sizing the buffer under
-        # "accumulating" (its capacity is schedule-derived); `num_steps` is
-        # already required to be a concrete Python int here regardless (it
-        # sizes jax.random.split and the scan length below), so `schedule` is a
-        # concrete array too -- safe to inspect with plain numpy.
-        schedule = schedule_fn(num_steps)
-        # Capacity = the accumulating policy's own worst-case buffer content
-        # (previous + current window) -- see _accumulating_buffer_capacity.
-        buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
-        init_adaptation_state = adapt_init_fn(
-            position,
-            init_state.logdensity_grad,
-            initial_step_size,
-            buffer_size,
-        )
-
-        keys = jax.random.split(rng_key, num_steps)
-        last_state, info = jax.lax.scan(
-            one_step,
-            (init_state, init_adaptation_state),
-            (jnp.arange(num_steps), keys, schedule),
-        )
-        _, last_warmup_state, *_ = last_state
-        step_size, sigma, mu_star, U, lam = adapt_final_fn(last_warmup_state)
-        # Return the inverse mass matrix as a pure-array NamedTuple so that the
-        # warmup composes with jax.vmap over chains.  The kernel layer expands
-        # this into a full Metric via default_metric at call time.  See #916.
-        inverse_mass_matrix = LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
-        parameters = {
-            "step_size": step_size,
-            "inverse_mass_matrix": inverse_mass_matrix,
+        engine = staged_adaptation(
+            algorithm,
+            logdensity_fn,
+            metric=core,
+            initial_step_size=initial_step_size,
+            target_acceptance_rate=target_acceptance_rate,
+            adaptation_info_fn=_make_low_rank_bridge_info_fn(adaptation_info_fn),
+            integrator=integrator,
+            schedule_fn=lambda n: schedule,  # reuse pre-computed schedule
+            initial_metric_state=seeded_imm_state,
             **extra_parameters,
-        }
-        # Re-initialise chain state at the optimal translation μ* = x̄ + σ²⊙ᾱ.
-        # mu_star is flat (d,); unravel to the original position pytree structure
-        # before passing to algorithm.init.
+        )
+
+        results, info = engine.run(rng_key, position, num_steps)  # type: ignore[call-arg]
+
+        # Re-initialise chain at mu* = x̄ + σ²⊙ᾱ (optimal translation, §3.2).
+        mu_star = info.adaptation_state.mu_star[-1]
         _, unravel = fu.ravel_pytree(position)
         mu_star_state = algorithm.init(unravel(mu_star), logdensity_fn)
-        return AdaptationResults(mu_star_state, parameters), info
+
+        return AdaptationResults(mu_star_state, results.parameters), info
 
     def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
         if buffer_policy == "accumulating":

--- a/blackjax/adaptation/low_rank_adaptation.py
+++ b/blackjax/adaptation/low_rank_adaptation.py
@@ -576,26 +576,40 @@ def window_adaptation_low_rank(
     if recompute_every < 1:
         raise ValueError(f"recompute_every must be >= 1, got {recompute_every!r}")
 
-    def _run_reset(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int) -> tuple:
-        """Reset policy: run via the staged-adaptation engine (default path).
+    def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
+        # Build the MetricCore: policy-specific buffer sizing + core builder.
+        if buffer_policy == "accumulating":
+            # Pre-compute schedule to derive the tight worst-case buffer
+            # capacity from the window boundaries.  The partial-forget switch
+            # keeps the just-completed window's draws as the new background, so
+            # the tight bound is max(window[i] + window[i-1]) over all pairs.
+            schedule = schedule_fn(num_steps)
+            buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
 
-        The buffer is hard-reset to empty at every slow-window boundary.
-        Bit-exact with the pre-engine implementation for all default parameters.
-        """
-        # Size the buffer to the expected largest slow window rather than the
-        # full warmup length.  Modular indexing in the core's update() means
-        # that if a window exceeds buffer_size only the most recent buffer_size
-        # draws are kept -- matching nutpie's fixed-buffer behaviour and
-        # avoiding O(num_steps × d) allocations for large d.
-        typical_window = max(num_steps // 5, 128)
-        buffer_size = min(typical_window * 2, max(num_steps, 1))
+            def _schedule_fn(n):
+                return schedule  # reuse the pre-computed array
 
-        core = _build_fisher_low_rank_core(
-            buffer_size=buffer_size,
-            max_rank=max_rank,
-            gamma=gamma,
-            cutoff=cutoff,
-        )
+            core = _build_fisher_low_rank_accumulating_core(
+                buffer_size=buffer_size,
+                max_rank=max_rank,
+                gamma=gamma,
+                cutoff=cutoff,
+                recompute_every=recompute_every,
+            )
+        else:
+            # Size the buffer to the expected largest slow window rather than
+            # the full warmup length.  Modular indexing in the core's update()
+            # keeps only the most recent buffer_size draws when a window exceeds
+            # buffer_size -- avoiding O(num_steps × d) allocations for large d.
+            typical_window = max(num_steps // 5, 128)
+            buffer_size = min(typical_window * 2, max(num_steps, 1))
+            _schedule_fn = schedule_fn
+            core = _build_fisher_low_rank_core(
+                buffer_size=buffer_size,
+                max_rank=max_rank,
+                gamma=gamma,
+                cutoff=cutoff,
+            )
 
         seeded_imm_state = None
         if gradient_based_init:
@@ -619,7 +633,7 @@ def window_adaptation_low_rank(
             # converts between the two so that info field access is unchanged.
             adaptation_info_fn=_make_low_rank_bridge_info_fn(adaptation_info_fn),
             integrator=integrator,
-            schedule_fn=schedule_fn,
+            schedule_fn=_schedule_fn,
             initial_metric_state=seeded_imm_state,
             **extra_parameters,
         )
@@ -634,65 +648,5 @@ def window_adaptation_low_rank(
         mu_star_state = algorithm.init(unravel(mu_star), logdensity_fn)
 
         return AdaptationResults(mu_star_state, results.parameters), info
-
-    def _run_accumulating(
-        rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int
-    ) -> tuple:
-        """Accumulating policy: run via the staged-adaptation engine.
-
-        Pre-computes the schedule to derive the tight worst-case buffer capacity
-        (``_accumulating_buffer_capacity``), then delegates to the engine via
-        ``_build_fisher_low_rank_accumulating_core``.  Buffer, counter, and
-        sigma/mu_star/U/lam state are managed entirely inside the core.
-        """
-        # Pre-compute schedule before building the core so we can derive the
-        # exact accumulating buffer capacity from the window boundaries.
-        schedule = schedule_fn(num_steps)
-        buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
-
-        core = _build_fisher_low_rank_accumulating_core(
-            buffer_size=buffer_size,
-            max_rank=max_rank,
-            gamma=gamma,
-            cutoff=cutoff,
-            recompute_every=recompute_every,
-        )
-
-        seeded_imm_state = None
-        if gradient_based_init:
-            _init_state = algorithm.init(position, logdensity_fn)
-            n_dims = pytree_size(position)
-            seeded_imm_state = seed_low_rank_sigma_from_grad(
-                core.init(n_dims), _init_state.logdensity_grad
-            )
-
-        engine = staged_adaptation(
-            algorithm,
-            logdensity_fn,
-            metric=core,
-            initial_step_size=initial_step_size,
-            target_acceptance_rate=target_acceptance_rate,
-            adaptation_info_fn=_make_low_rank_bridge_info_fn(adaptation_info_fn),
-            integrator=integrator,
-            schedule_fn=lambda n: schedule,  # reuse pre-computed schedule
-            initial_metric_state=seeded_imm_state,
-            **extra_parameters,
-        )
-
-        results, info = engine.run(rng_key, position, num_steps)  # type: ignore[call-arg]
-
-        # Re-initialise chain at mu* = x̄ + σ²⊙ᾱ (optimal translation, §3.2).
-        mu_star = info.adaptation_state.mu_star[-1]
-        _, unravel = fu.ravel_pytree(position)
-        mu_star_state = algorithm.init(unravel(mu_star), logdensity_fn)
-
-        return AdaptationResults(mu_star_state, results.parameters), info
-
-    def run(rng_key: PRNGKey, position: ArrayLikeTree, num_steps: int = 1000):
-        if buffer_policy == "accumulating":
-            # Accumulating path: see _run_accumulating docstring for the
-            # architectural rationale for the split.
-            return _run_accumulating(rng_key, position, num_steps)
-        return _run_reset(rng_key, position, num_steps)
 
     return AdaptationAlgorithm(run)

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -701,6 +701,176 @@ def _build_fisher_low_rank_core(
     return MetricCore(init=init, update=update, final=final)
 
 
+def _build_fisher_low_rank_accumulating_core(
+    *,
+    buffer_size: int,
+    max_rank: int,
+    gamma: float,
+    cutoff: float,
+    recompute_every: int = 1,
+) -> MetricCore:
+    """Build a MetricCore for the Fisher-score low-rank estimator (accumulating policy).
+
+    Implements nutpie's partial-forget buffer (``nuts-rs``
+    ``src/transform/adapt/low_rank.rs::switch``):
+
+    1. ``init(n_dims)`` — same layout as the reset core (identity sigma, zero U/lam,
+       zero buffers, ``buffer_idx=0``, ``background_split=0``, ``recompute_counter=0``).
+    2. ``update(state, position, grad)`` — writes (position, grad) into the circular
+       buffer, increments ``recompute_counter``, then periodically recomputes the
+       metric when ``recompute_counter % recompute_every == 0`` and at least 3 draws
+       are in the buffer. The recompute is a **pure function** of the current buffer
+       content: it writes *only* ``sigma``, ``mu_star``, ``U``, ``lam`` — consuming
+       no PRNG and leaving ``draws_buffer``, ``grads_buffer``, ``buffer_idx``, and
+       ``background_split`` unchanged. At slow-window-end steps the engine calls
+       ``update()`` first and then ``final()``; if the periodic recompute fires in
+       ``update()`` at that step it is a spurious extra SVD (cost note: one additional
+       ``_compute_low_rank_metric`` call per window boundary at ``recompute_every=1``,
+       acceptable because the accumulating policy already recomputes on every slow step)
+       whose sigma/mu_star/U/lam values are **unconditionally overwritten** by
+       ``final()``'s force-recompute from the shifted buffer — the spurious recompute
+       cannot perturb any field that ``final()`` does not reset.  This is the key
+       purity invariant that makes the engine path bit-exact with the legacy scan loop.
+    3. ``final(state)`` — nutpie's ``switch()``: pops the ``background_split`` oldest
+       rows from the front of the buffer (``_shift_buffer_left``), sets
+       ``new_n_valid = buffer_idx - background_split``, force-recomputes the metric
+       if ``new_n_valid >= 3`` (else keeps), resets ``recompute_counter = 0``, and
+       sets ``background_split = new_n_valid``.  Called by the engine at every
+       slow-window boundary.
+
+    **Bit-exactness with the legacy base()-backed scan loop.**  At non-window-end slow
+    steps both paths do the same work (accumulate → periodic recompute if due → keep
+    counter management consistent).  At window-end slow steps the engine calls
+    ``update()`` then ``final()`` whereas the legacy loop called ``slow_update()`` then
+    ``slow_switch()`` without an intervening periodic recompute.  The spurious
+    periodic-recompute in ``update()`` (if it fires) only modifies sigma/mu_star/U/lam,
+    and ``final()`` overwrites exactly those fields from the shifted buffer.  Every
+    other field (buffers, buffer_idx, background_split, recompute_counter) is set
+    identically by both paths after the window-end step.
+
+    Parameters
+    ----------
+    buffer_size
+        Number of rows in the circular draw/gradient buffer.  Use
+        :func:`~blackjax.adaptation.low_rank_adaptation._accumulating_buffer_capacity`
+        to derive the tight worst-case bound from the warmup schedule.
+    max_rank
+        Maximum number of eigenvectors retained in the low-rank correction.
+    gamma
+        Regularisation scale (nutpie convention — projected covariance divided by
+        ``gamma`` before adding identity, no ``n`` scaling).
+    cutoff
+        Eigenvalues in ``[1/cutoff, cutoff]`` are masked to 1.
+    recompute_every
+        Number of slow-stage steps between mid-window metric recomputes.  Default 1
+        matches nutpie's ``mass_matrix_update_freq=1`` (recompute every slow step).
+    """
+
+    def init(n_dims: int) -> LowRankMetricCoreState:
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=LowRankInverseMassMatrix(
+                sigma=jnp.ones(n_dims),
+                U=jnp.zeros((n_dims, max_rank)),
+                lam=jnp.ones(max_rank),
+            ),
+            mu_star=jnp.zeros(n_dims),
+            draws_buffer=jnp.zeros((buffer_size, n_dims)),
+            grads_buffer=jnp.zeros((buffer_size, n_dims)),
+            buffer_idx=0,
+            background_split=0,
+            recompute_counter=0,
+        )
+
+    def update(
+        state: LowRankMetricCoreState,
+        position: ArrayLikeTree,
+        grad: ArrayLikeTree | None = None,
+    ) -> LowRankMetricCoreState:
+        pos_flat, _ = fu.ravel_pytree(position)
+        grad_flat, _ = fu.ravel_pytree(grad)
+        B = state.draws_buffer.shape[0]
+        idx = state.buffer_idx % B
+        new_draws = jax.lax.dynamic_update_slice(
+            state.draws_buffer, pos_flat[None, :], (idx, 0)
+        )
+        new_grads = jax.lax.dynamic_update_slice(
+            state.grads_buffer, grad_flat[None, :], (idx, 0)
+        )
+        new_buffer_idx = state.buffer_idx + 1
+        new_recompute_counter = state.recompute_counter + 1
+
+        # Periodic mid-window metric recompute.  This pure function writes only
+        # sigma/mu_star/U/lam; it does NOT touch the buffers or the bookkeeping
+        # counters other than resetting recompute_counter to 0 when it fires.
+        # At window-end steps the engine calls final() after update(), and final()
+        # unconditionally overwrites sigma/mu_star/U/lam from the shifted buffer —
+        # so any recompute here at a window boundary is harmless (see class docstring).
+        due = jnp.logical_and(
+            new_recompute_counter % recompute_every == 0, new_buffer_idx >= 3
+        )
+
+        def _recompute():
+            return _compute_low_rank_metric(
+                new_draws, new_grads, new_buffer_idx, max_rank, gamma, cutoff
+            )
+
+        def _keep():
+            imm = state.inverse_mass_matrix
+            return imm.sigma, state.mu_star, imm.U, imm.lam
+
+        sigma, mu_star, U, lam = jax.lax.cond(due, _recompute, _keep)
+        # Reset the counter only when a recompute fires, matching base()'s
+        # slow_recompute_only (counter = 0 on recompute, unchanged otherwise).
+        next_counter = jax.lax.cond(
+            due,
+            lambda: jnp.zeros_like(new_recompute_counter),
+            lambda: new_recompute_counter,
+        )
+
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam),
+            mu_star=mu_star,
+            draws_buffer=new_draws,
+            grads_buffer=new_grads,
+            buffer_idx=new_buffer_idx,
+            background_split=state.background_split,
+            recompute_counter=next_counter,
+        )
+
+    def final(state: LowRankMetricCoreState) -> LowRankMetricCoreState:
+        # Nutpie's switch(): pop background_split oldest rows, keep the rest
+        # as the new background for the next window.
+        shift = state.background_split
+        new_draws = _shift_buffer_left(state.draws_buffer, shift)
+        new_grads = _shift_buffer_left(state.grads_buffer, shift)
+        new_n_valid = state.buffer_idx - shift
+
+        # Force-recompute from shifted buffer.  Overwrites sigma/mu_star/U/lam
+        # unconditionally (including any values written by update()'s spurious
+        # periodic recompute at this same window-end step — see class docstring).
+        def _recompute():
+            return _compute_low_rank_metric(
+                new_draws, new_grads, new_n_valid, max_rank, gamma, cutoff
+            )
+
+        def _keep():
+            imm = state.inverse_mass_matrix
+            return imm.sigma, state.mu_star, imm.U, imm.lam
+
+        sigma, mu_star, U, lam = jax.lax.cond(new_n_valid >= 3, _recompute, _keep)
+        return LowRankMetricCoreState(
+            inverse_mass_matrix=LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam),
+            mu_star=mu_star,
+            draws_buffer=new_draws,
+            grads_buffer=new_grads,
+            buffer_idx=new_n_valid,
+            background_split=new_n_valid,
+            recompute_counter=0,
+        )
+
+    return MetricCore(init=init, update=update, final=final)
+
+
 def _build_sample_cov_low_rank_core(
     *,
     buffer_size: int,

--- a/blackjax/adaptation/metric_recipes.py
+++ b/blackjax/adaptation/metric_recipes.py
@@ -607,9 +607,8 @@ def _build_fisher_low_rank_core(
 ) -> MetricCore:
     """Build a MetricCore for the Fisher-score low-rank estimator (reset policy).
 
-    Implements the same window-end recompute as
-    :func:`~blackjax.adaptation.low_rank_adaptation.base`'s ``slow_final``
-    under ``buffer_policy="reset"``:
+    Implements the reset-policy window-end recompute (hard-reset buffer at
+    each slow-window boundary):
 
     1. ``init(n_dims)`` — creates a zero-filled draw/gradient buffer of shape
        ``(buffer_size, n_dims)`` with identity sigma, zero U, ones lam.

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -191,8 +191,19 @@ def _make_engine(
         new_metric_st = metric_core.update(ws.imm_state, position, grad)
         new_ss = da_update(ws.ss_state, acceptance_rate)
         new_step_size = jnp.exp(new_ss.log_step_size)
+        # Propagate the core's current inverse_mass_matrix to the MCMC kernel
+        # at every slow step, not just at window-end.  For all non-accumulating
+        # cores (welford, fisher-diag, reset-low-rank, sample-cov) update() does
+        # not write inverse_mass_matrix, so new_metric_st.inverse_mass_matrix ==
+        # ws.inverse_mass_matrix and this is bit-identical to the previous
+        # ws.inverse_mass_matrix return.  For the accumulating core, update() may
+        # recompute inverse_mass_matrix mid-window (when recompute_counter %
+        # recompute_every == 0), and this line surfaces that to MCMC — matching
+        # the legacy base() accumulating scan loop's slow_recompute_only() which
+        # also updated adaptation_state.sigma/U/lam immediately.  Consistent with
+        # slow_final(), which already reads new_metric_st.inverse_mass_matrix.
         return StagedAdaptationState(
-            new_ss, new_metric_st, new_step_size, ws.inverse_mass_matrix
+            new_ss, new_metric_st, new_step_size, new_metric_st.inverse_mass_matrix
         )
 
     def slow_final(ws: StagedAdaptationState) -> StagedAdaptationState:

--- a/tests/adaptation/test_low_rank_adaptation.py
+++ b/tests/adaptation/test_low_rank_adaptation.py
@@ -22,10 +22,14 @@ from blackjax.adaptation.base import return_all_adapt_info
 from blackjax.adaptation.low_rank_adaptation import (
     _accumulating_buffer_capacity,
     _compute_low_rank_metric,
-    _shift_buffer_left,
     _spd_mean,
-    base,
     build_growing_window_schedule,
+)
+from blackjax.adaptation.metric_recipes import (
+    _build_fisher_low_rank_accumulating_core,
+    _build_fisher_low_rank_core,
+    _shift_buffer_left,
+    seed_low_rank_sigma_from_grad,
 )
 from blackjax.adaptation.window_adaptation import build_schedule
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
@@ -902,41 +906,56 @@ class LowRankGradientBasedInitTest(BlackJAXTest):
 
     def test_default_reproduces_identity_init(self):
         """gradient_based_init=False (default) must reproduce the original
-        sigma=ones(d) initialisation exactly -- no default-behavior change."""
-        init, _, _ = base(max_rank=3, gradient_based_init=False)
+        sigma=ones(d) initialisation exactly -- no default-behavior change.
+
+        With the engine path, the default init is ``core.init(n_dims)`` (no
+        gradient seeding), which gives sigma=ones, U=zeros, lam=ones.
+        """
         d = 5
-        grad = jnp.array([2.0, -4.0, 0.5, 10.0, 0.1])
-        state = init(jnp.zeros(d), grad, 1.0, 100)
-        np.testing.assert_allclose(state.sigma, jnp.ones(d))
-        np.testing.assert_allclose(state.U, jnp.zeros((d, 3)))
-        np.testing.assert_allclose(state.lam, jnp.ones(3))
+        core = _build_fisher_low_rank_core(
+            buffer_size=100, max_rank=3, gamma=1e-5, cutoff=2.0
+        )
+        state = core.init(d)
+        np.testing.assert_allclose(state.inverse_mass_matrix.sigma, jnp.ones(d))
+        np.testing.assert_allclose(state.inverse_mass_matrix.U, jnp.zeros((d, 3)))
+        np.testing.assert_allclose(state.inverse_mass_matrix.lam, jnp.ones(3))
 
     def test_gradient_based_init_formula(self):
         """gradient_based_init=True seeds sigma = 1/sqrt(|grad|), so that
         M^{-1}_diag = sigma**2 = 1/|grad|, matching the paper's
-        M = diag(|grad|) (mass matrix, not inverse) initialisation."""
-        init, _, _ = base(max_rank=3, gradient_based_init=True)
+        M = diag(|grad|) (mass matrix, not inverse) initialisation.
+
+        With the engine path, seeding is done via
+        ``seed_low_rank_sigma_from_grad(core.init(n_dims), grad)``.
+        """
         d = 5
+        core = _build_fisher_low_rank_core(
+            buffer_size=100, max_rank=3, gamma=1e-5, cutoff=2.0
+        )
         grad = jnp.array([2.0, -4.0, 0.5, 10.0, 0.1])
-        state = init(jnp.zeros(d), grad, 1.0, 100)
+        state = seed_low_rank_sigma_from_grad(core.init(d), grad)
         expected_sigma = jnp.abs(grad) ** -0.5
-        np.testing.assert_allclose(state.sigma, expected_sigma, rtol=1e-5)
+        np.testing.assert_allclose(
+            state.inverse_mass_matrix.sigma, expected_sigma, rtol=1e-5
+        )
         # Only the diagonal changes; low-rank correction still starts inert.
-        np.testing.assert_allclose(state.U, jnp.zeros((d, 3)))
-        np.testing.assert_allclose(state.lam, jnp.ones(3))
+        np.testing.assert_allclose(state.inverse_mass_matrix.U, jnp.zeros((d, 3)))
+        np.testing.assert_allclose(state.inverse_mass_matrix.lam, jnp.ones(3))
 
     def test_gradient_based_init_clips_extreme_gradients(self):
         """Zero or huge gradient components must not produce NaN/Inf, and an
         exactly-zero component must fall back to sigma_i=1.0 (the
         near-zero-gradient hardening fix), not the 1e-20-clip-floor-derived
         sigma_i=1e10 extreme."""
-        init, _, _ = base(max_rank=2, gradient_based_init=True)
         d = 4
+        core = _build_fisher_low_rank_core(
+            buffer_size=50, max_rank=2, gamma=1e-5, cutoff=2.0
+        )
         grad = jnp.array([0.0, 1e30, 1e-30, 5.0])
-        state = init(jnp.zeros(d), grad, 1.0, 50)
-        self.assertTrue(bool(jnp.all(jnp.isfinite(state.sigma))))
-        self.assertTrue(bool(jnp.all(state.sigma > 0)))
-        self.assertAlmostEqual(float(state.sigma[0]), 1.0, places=5)
+        state = seed_low_rank_sigma_from_grad(core.init(d), grad)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(state.inverse_mass_matrix.sigma))))
+        self.assertTrue(bool(jnp.all(state.inverse_mass_matrix.sigma > 0)))
+        self.assertAlmostEqual(float(state.inverse_mass_matrix.sigma[0]), 1.0, places=5)
 
     def test_gradient_based_init_handles_exact_zero_gradient(self):
         """Real user-facing edge case (Fisher 2x2 calibration study's
@@ -958,9 +977,11 @@ class LowRankGradientBasedInitTest(BlackJAXTest):
         boundary -- 1e-10 is a defensible, disclosed threshold choice."""
         d = 10
         grad = jnp.zeros(d)
-        init, _, _ = base(max_rank=3, gradient_based_init=True)
-        state = init(jnp.zeros(d), grad, 1.0, 100)
-        np.testing.assert_allclose(state.sigma, jnp.ones(d))
+        core = _build_fisher_low_rank_core(
+            buffer_size=100, max_rank=3, gamma=1e-5, cutoff=2.0
+        )
+        state = seed_low_rank_sigma_from_grad(core.init(d), grad)
+        np.testing.assert_allclose(state.inverse_mass_matrix.sigma, jnp.ones(d))
 
         # End-to-end: warmup on a centered Gaussian, x0=0 exactly, must
         # survive and produce finite draws with no sigma extremes.
@@ -1013,31 +1034,63 @@ class LowRankGradientBasedInitTest(BlackJAXTest):
         self.assertGreater(float(params["step_size"]), 0.0)
 
 
-def _run_schedule(policy, schedule, draws, grads, max_rank, d, recompute_every=1):
-    """Drive base()'s init/update through a concrete schedule with known
-    (draw, grad) inputs, tracking buffer_idx at every step. Used by the
-    accumulating-buffer tests below to inspect the buffer bookkeeping
-    without needing to expose the private slow_update/slow_switch closures.
+def _run_core_schedule(core, schedule, draws, grads, d):
+    """Drive a MetricCore through a concrete (stage, is_window_end) schedule.
+
+    Calls ``core.update`` at every step (regardless of stage) and
+    ``core.final`` at each window-end marker.  The returned trace is a
+    stacked ``LowRankMetricCoreState`` — access ``trace.buffer_idx``,
+    ``trace.background_split``, ``trace.inverse_mass_matrix.sigma``, etc.
+
+    Note: calling ``update`` on fast-stage steps (stage=0) is a no-op for the
+    buffer tests here because all test schedules used by
+    ``AccumulatingBufferPolicyTest`` contain only stage-1 (slow) steps, or the
+    assertions only read the trace at positions that precede any fast steps.
     """
-    init, update, final = base(
-        max_rank=max_rank, buffer_policy=policy, recompute_every=recompute_every
-    )
-    if policy == "accumulating":
-        buffer_size = _accumulating_buffer_capacity(schedule)
-    else:
-        num_steps = schedule.shape[0]
-        typical_window = max(num_steps // 5, 128)
-        buffer_size = min(typical_window * 2, max(num_steps, 1))
-    state0 = init(jnp.zeros(d), grads[0], 1.0, buffer_size)
+    state0 = core.init(d)
 
     def step(state, xs):
-        stage, is_end, pos, grad = xs
-        new_state = update(state, (stage, is_end), pos, grad, 0.8)
+        _stage, is_end, pos, grad = xs
+        new_state = core.update(state, pos, grad)
+        new_state = jax.lax.cond(is_end, core.final, lambda s: s, new_state)
         return new_state, new_state
 
     xs = (schedule[:, 0], schedule[:, 1].astype(bool), draws, grads)
     final_state, trace = jax.lax.scan(step, state0, xs)
     return final_state, trace
+
+
+def _run_accumulating_core_schedule(
+    schedule, draws, grads, max_rank, d, recompute_every=1
+):
+    """Drive ``_build_fisher_low_rank_accumulating_core`` through a schedule.
+
+    Buffer capacity is derived from ``_accumulating_buffer_capacity`` (same
+    calculation used by ``window_adaptation_low_rank``).
+    """
+    buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
+    core = _build_fisher_low_rank_accumulating_core(
+        buffer_size=buffer_size,
+        max_rank=max_rank,
+        gamma=1e-5,
+        cutoff=2.0,
+        recompute_every=recompute_every,
+    )
+    return _run_core_schedule(core, schedule, draws, grads, d)
+
+
+def _run_reset_core_schedule(schedule, draws, grads, max_rank, d):
+    """Drive ``_build_fisher_low_rank_core`` (reset policy) through a schedule."""
+    num_steps = schedule.shape[0]
+    typical_window = max(num_steps // 5, 128)
+    buffer_size = min(typical_window * 2, max(num_steps, 1))
+    core = _build_fisher_low_rank_core(
+        buffer_size=buffer_size,
+        max_rank=max_rank,
+        gamma=1e-5,
+        cutoff=2.0,
+    )
+    return _run_core_schedule(core, schedule, draws, grads, d)
 
 
 class ShiftBufferLeftTest(BlackJAXTest):
@@ -1108,27 +1161,15 @@ class AccumulatingBufferPolicyTest(BlackJAXTest):
 
     def test_invalid_buffer_policy_raises(self):
         with self.assertRaises(ValueError):
-            base(buffer_policy="bogus")
+            blackjax.window_adaptation_low_rank(
+                blackjax.nuts, lambda x: -0.5 * jnp.sum(x**2), buffer_policy="bogus"
+            )
 
     def test_invalid_recompute_every_raises(self):
         with self.assertRaises(ValueError):
-            base(recompute_every=0)
-
-    def test_default_buffer_policy_state_fields_stay_inert(self):
-        """buffer_policy="reset" (default): background_split and
-        recompute_counter are always 0 -- these fields are brand new and
-        must not perturb the pre-existing (pre-buffer_policy) behaviour."""
-        d = 6
-        num_steps = 300
-        schedule = build_growing_window_schedule(num_steps)
-        key = self.next_key()
-        draws = jax.random.normal(key, (num_steps, d))
-        grads = -draws
-        final_state, trace = _run_schedule(
-            "reset", schedule, draws, grads, max_rank=2, d=d
-        )
-        self.assertTrue(bool(jnp.all(trace.background_split == 0)))
-        self.assertTrue(bool(jnp.all(trace.recompute_counter == 0)))
+            blackjax.window_adaptation_low_rank(
+                blackjax.nuts, lambda x: -0.5 * jnp.sum(x**2), recompute_every=0
+            )
 
     def test_switch_pops_only_the_prior_windows_worth_of_draws(self):
         """Hand-computed window-switch trace against three windows of
@@ -1158,8 +1199,7 @@ class AccumulatingBufferPolicyTest(BlackJAXTest):
         key = self.next_key()
         draws = jax.random.normal(key, (num_steps, d))
         grads = -draws
-        final_state, trace = _run_schedule(
-            "accumulating",
+        final_state, trace = _run_accumulating_core_schedule(
             schedule,
             draws,
             grads,
@@ -1206,11 +1246,10 @@ class AccumulatingBufferPolicyTest(BlackJAXTest):
         draws = jax.random.normal(key, (num_steps, d))
         grads = -draws
 
-        _, trace_reset = _run_schedule(
-            "reset", schedule, draws, grads, max_rank=10, d=d
+        _, trace_reset = _run_reset_core_schedule(
+            schedule, draws, grads, max_rank=10, d=d
         )
-        _, trace_acc = _run_schedule(
-            "accumulating",
+        _, trace_acc = _run_accumulating_core_schedule(
             schedule,
             draws,
             grads,
@@ -1291,10 +1330,10 @@ class AccumulatingBufferPolicyTest(BlackJAXTest):
         # noise, not the recompute cadence actually being exercised.
         draws = jax.random.normal(key1, (20, d)) * jnp.arange(1, 21)[:, None]
         grads = jax.random.normal(key2, (20, d)) * 3.0
-        _, trace = _run_schedule(
-            "accumulating", schedule, draws, grads, max_rank=2, d=d, recompute_every=1
+        _, trace = _run_accumulating_core_schedule(
+            schedule, draws, grads, max_rank=2, d=d, recompute_every=1
         )
-        sigmas = np.asarray(trace.sigma)
+        sigmas = np.asarray(trace.inverse_mass_matrix.sigma)
         # sigma must differ across at least one consecutive pair once n>=3.
         diffs = np.abs(np.diff(sigmas[2:], axis=0)).sum(axis=1)
         self.assertTrue(bool(np.any(diffs > 1e-4)))
@@ -1314,8 +1353,7 @@ class AccumulatingBufferPolicyTest(BlackJAXTest):
         # whether a recompute actually fired.
         draws = jax.random.normal(key1, (20, d))
         grads = jax.random.normal(key2, (20, d)) * 3.0
-        _, trace = _run_schedule(
-            "accumulating",
+        _, trace = _run_accumulating_core_schedule(
             schedule,
             draws,
             grads,
@@ -1323,7 +1361,7 @@ class AccumulatingBufferPolicyTest(BlackJAXTest):
             d=d,
             recompute_every=10**9,
         )
-        sigmas = np.asarray(trace.sigma)
+        sigmas = np.asarray(trace.inverse_mass_matrix.sigma)
         # Before the final switch (index 19), sigma must be constant.
         np.testing.assert_allclose(sigmas[:19], np.tile(sigmas[0], (19, 1)))
 

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -26,8 +26,9 @@ Coverage:
   is the same object as the backward-compat re-export from
   ``low_rank_adaptation``.
 - :func:`window_adaptation_low_rank` shim: both buffer policies via staged engine,
-  gradient_based_init seam, info-bridge field layout, and bit-exact accumulating
-  parity gate vs frozen inline reference (``recompute_every=10**9``, ``atol=0.0``).
+  gradient_based_init seam, info-bridge field layout, and bit-exact parity gates
+  (reset + accumulating) vs frozen inline references on an anisotropic target
+  (``recompute_every ∈ {1, 5, 25}``, ``atol=0.0``).
 """
 import jax
 import jax.flatten_util as fu
@@ -70,6 +71,20 @@ from blackjax.adaptation.staged_adaptation import (
 from blackjax.adaptation.step_size import dual_averaging_adaptation
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix, gaussian_euclidean_low_rank
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
+
+# ---------------------------------------------------------------------------
+# Anisotropic parity target (shared by both parity gate classes)
+# ---------------------------------------------------------------------------
+# Variances [4, 1, 0.25, 0.0625, 0.015625] → std devs [2, 1, 0.5, 0.25, 0.125].
+# Spans ~2.5 orders of magnitude so the fitted (sigma, U, lam) are genuinely
+# non-identity and the parity gate is non-trivial.
+_PARITY_SCALE = jnp.array([2.0, 1.0, 0.5, 0.25, 0.125])
+
+
+def _aniso_logdensity(x):
+    """Mildly anisotropic 5-d Gaussian used by both parity gate classes."""
+    return std_normal_logdensity(x, scale=_PARITY_SCALE)
+
 
 # ---------------------------------------------------------------------------
 # Backward-compat object-identity test
@@ -1328,6 +1343,323 @@ class LowRankX64SmokeTest(BlackJAXTest):
 
 
 # ---------------------------------------------------------------------------
+# Bit-exact parity: reset path via engine vs frozen reference scan loop
+# ---------------------------------------------------------------------------
+
+
+def _reference_run_reset(rng_key, position, num_steps, n_dims, logdensity_fn=None):
+    """Frozen inline reset scan loop (verbatim copy of ``base(buffer_policy='reset')`` math).
+
+    Bit-exact reference for :class:`WindowAdaptationLowRankResetParityTest`.
+    Inline rather than importing ``base()`` so that this reference survives
+    independently of the production code and cannot be silently changed.
+
+    **Must NOT be modified** — this is the frozen pre-migration reference used by the parity gate.
+
+    The reset path is the simpler of the two policies: at each window end,
+    ``slow_final`` recomputes the metric from the current buffer and then
+    hard-clears the buffer to zeros (``buffer_idx=0``).  No mid-window
+    recomputes; no partial-forget.  The ``slow_update()`` engine fix
+    (changing ``ws.inverse_mass_matrix`` → ``new_metric_st.inverse_mass_matrix``)
+    is a no-op for the reset core because ``update()`` does not modify
+    ``inverse_mass_matrix`` — so ``new_metric_st.inverse_mass_matrix`` equals
+    the incoming ``ws.inverse_mass_matrix`` for every non-window-end step.
+    """
+    if logdensity_fn is None:
+        logdensity_fn = _aniso_logdensity
+
+    max_rank = 4
+    gamma = 1e-5
+    cutoff = 2.0
+    initial_step_size = 1.0
+    target_acceptance_rate = 0.80
+
+    da_init, da_update, da_final = dual_averaging_adaptation(target_acceptance_rate)
+    mcmc_kernel = blackjax.nuts.build_kernel(mcmc.integrators.velocity_verlet)
+    schedule = build_schedule(num_steps)
+    typical_window = max(num_steps // 5, 128)
+    buffer_size = min(typical_window * 2, max(num_steps, 1))
+    d = n_dims
+
+    def fast_update(pos, grad, acc_rate, state):
+        del pos, grad
+        new_ss = da_update(state.ss_state, acc_rate)
+        return LowRankAdaptationState(
+            new_ss,
+            state.sigma,
+            state.mu_star,
+            state.U,
+            state.lam,
+            jnp.exp(new_ss.log_step_size),
+            state.draws_buffer,
+            state.grads_buffer,
+            state.buffer_idx,
+            state.background_split,
+            state.recompute_counter,
+        )
+
+    def slow_update(pos, grad, acc_rate, state):
+        pos_flat, _ = fu.ravel_pytree(pos)
+        grad_flat, _ = fu.ravel_pytree(grad)
+        B = state.draws_buffer.shape[0]
+        idx = state.buffer_idx % B
+        new_draws = jax.lax.dynamic_update_slice(
+            state.draws_buffer, pos_flat[None, :], (idx, 0)
+        )
+        new_grads = jax.lax.dynamic_update_slice(
+            state.grads_buffer, grad_flat[None, :], (idx, 0)
+        )
+        new_ss = da_update(state.ss_state, acc_rate)
+        return LowRankAdaptationState(
+            new_ss,
+            state.sigma,
+            state.mu_star,
+            state.U,
+            state.lam,
+            jnp.exp(new_ss.log_step_size),
+            new_draws,
+            new_grads,
+            state.buffer_idx + 1,
+            state.background_split,
+            state.recompute_counter,  # inert under reset: always stays 0
+        )
+
+    def slow_final(state):
+        """Window end: recompute metric from current buffer, then hard-clear."""
+        sigma, mu_star, U, lam = _compute_low_rank_metric(
+            state.draws_buffer,
+            state.grads_buffer,
+            state.buffer_idx,
+            max_rank,
+            gamma,
+            cutoff,
+        )
+        new_ss = da_init(da_final(state.ss_state))
+        B, d_ = state.draws_buffer.shape
+        return LowRankAdaptationState(
+            new_ss,
+            sigma,
+            mu_star,
+            U,
+            lam,
+            jnp.exp(new_ss.log_step_size),
+            jnp.zeros((B, d_)),
+            jnp.zeros((B, d_)),
+            0,
+            0,
+            0,
+        )
+
+    def one_step(carry, xs):
+        _, rng_key_, adaptation_stage = xs
+        state, adaptation_state = carry
+        metric = gaussian_euclidean_low_rank(
+            adaptation_state.sigma, adaptation_state.U, adaptation_state.lam
+        )
+        new_state, step_info = mcmc_kernel(
+            rng_key_, state, logdensity_fn, adaptation_state.step_size, metric
+        )
+        stage = adaptation_stage[0]
+        is_window_end = adaptation_stage[1].astype(bool)
+        new_adapt = jax.lax.switch(
+            stage,
+            (fast_update, slow_update),
+            new_state.position,
+            new_state.logdensity_grad,
+            step_info.acceptance_rate,
+            adaptation_state,
+        )
+        new_adapt = jax.lax.cond(is_window_end, slow_final, lambda s: s, new_adapt)
+        return (
+            (new_state, new_adapt),
+            _default_low_rank_adaptation_info_fn(new_state, step_info, new_adapt),
+        )
+
+    ss_state = da_init(initial_step_size)
+    init_state = blackjax.nuts.init(position, logdensity_fn)
+    init_adaptation_state = LowRankAdaptationState(
+        ss_state,
+        jnp.ones(d),
+        jnp.zeros(d),
+        jnp.zeros((d, max_rank)),
+        jnp.ones(max_rank),
+        initial_step_size,
+        jnp.zeros((buffer_size, d)),
+        jnp.zeros((buffer_size, d)),
+        0,
+        0,
+        0,
+    )
+    keys = jax.random.split(rng_key, num_steps)
+    last_state, info = jax.lax.scan(
+        one_step,
+        (init_state, init_adaptation_state),
+        (jnp.arange(num_steps), keys, schedule),
+    )
+    _, last_warmup_state, *_ = last_state
+    step_size = jnp.exp(last_warmup_state.ss_state.log_step_size_avg)
+    inverse_mass_matrix = LowRankInverseMassMatrix(
+        sigma=last_warmup_state.sigma,
+        U=last_warmup_state.U,
+        lam=last_warmup_state.lam,
+    )
+    _, unravel = fu.ravel_pytree(position)
+    mu_star_state = blackjax.nuts.init(
+        unravel(last_warmup_state.mu_star), logdensity_fn
+    )
+    return (
+        mu_star_state,
+        {"step_size": step_size, "inverse_mass_matrix": inverse_mass_matrix},
+        info,
+    )
+
+
+class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
+    """Bit-exact parity: reset path via engine == frozen inline reset reference.
+
+    Uses the anisotropic parity target (variances [4, 1, .25, .0625, .0156])
+    so the fitted (sigma, U, lam) are genuinely non-identity.
+
+    The ``slow_update()`` engine fix changed the 4th ``StagedAdaptationState``
+    argument from ``ws.inverse_mass_matrix`` to
+    ``new_metric_st.inverse_mass_matrix``.  The reset core's ``update()``
+    does not modify ``inverse_mass_matrix``, so ``new_metric_st`` carries the
+    same value as the incoming ``ws`` for every non-window-end slow step —
+    the engine fix is a bit-identical no-op for the reset policy.  This test
+    asserts that the no-op claim holds end-to-end.
+    """
+
+    _N_DIMS = 5
+    _NUM_STEPS = 200
+
+    def _run_engine(self, rng_key, position):
+        wu = window_adaptation_low_rank(
+            blackjax.nuts,
+            _aniso_logdensity,
+            max_rank=4,
+            buffer_policy="reset",
+        )
+        return wu.run(rng_key, position, num_steps=self._NUM_STEPS)
+
+    def test_final_step_size_identical(self):
+        """Final step_size must be bit-identical between engine and frozen reference."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_engine["step_size"], params_ref["step_size"], atol=0.0
+                )
+            )
+        )
+
+    def test_final_sigma_identical(self):
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_engine["inverse_mass_matrix"].sigma,
+                    params_ref["inverse_mass_matrix"].sigma,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_final_u_identical(self):
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_engine["inverse_mass_matrix"].U,
+                    params_ref["inverse_mass_matrix"].U,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_final_lam_identical(self):
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    params_engine["inverse_mass_matrix"].lam,
+                    params_ref["inverse_mass_matrix"].lam,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_final_chain_state_position_identical(self):
+        """Returned chain state (mu_star re-init) must be bit-identical."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (state_engine, _), _ = self._run_engine(key, pos)
+        state_ref, _, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(jnp.allclose(state_engine.position, state_ref.position, atol=0.0))
+        )
+
+    def test_per_step_sigma_identical(self):
+        """Per-step sigma trace must be bit-identical across all steps."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, _), info_engine = self._run_engine(key, pos)
+        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    info_engine.adaptation_state.sigma,
+                    info_ref.adaptation_state.sigma,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_per_step_mu_star_identical(self):
+        """Per-step mu_star trace must be bit-identical."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, _), info_engine = self._run_engine(key, pos)
+        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    info_engine.adaptation_state.mu_star,
+                    info_ref.adaptation_state.mu_star,
+                    atol=0.0,
+                )
+            )
+        )
+
+    def test_per_step_step_size_identical(self):
+        """Per-step step_size trace must be bit-identical."""
+        key = self.next_key()
+        pos = jnp.zeros(self._N_DIMS)
+        (_, _), info_engine = self._run_engine(key, pos)
+        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        self.assertTrue(
+            bool(
+                jnp.allclose(
+                    info_engine.adaptation_state.step_size,
+                    info_ref.adaptation_state.step_size,
+                    atol=0.0,
+                )
+            )
+        )
+
+
+# ---------------------------------------------------------------------------
 # Bit-exact parity: accumulating path via engine vs frozen reference scan loop
 # ---------------------------------------------------------------------------
 
@@ -1468,7 +1800,7 @@ def _reference_run_accumulating(
             adaptation_state.sigma, adaptation_state.U, adaptation_state.lam
         )
         new_state, step_info = mcmc_kernel(
-            rng_key_, state, std_normal_logdensity, adaptation_state.step_size, metric
+            rng_key_, state, _aniso_logdensity, adaptation_state.step_size, metric
         )
         stage = adaptation_stage[0]
         is_window_end = adaptation_stage[1].astype(bool)
@@ -1496,7 +1828,7 @@ def _reference_run_accumulating(
         )
 
     ss_state = da_init(initial_step_size)
-    init_state = blackjax.nuts.init(position, std_normal_logdensity)
+    init_state = blackjax.nuts.init(position, _aniso_logdensity)
     init_adaptation_state = LowRankAdaptationState(
         ss_state,
         jnp.ones(d),
@@ -1525,7 +1857,7 @@ def _reference_run_accumulating(
     )
     _, unravel = fu.ravel_pytree(position)
     mu_star_state = blackjax.nuts.init(
-        unravel(last_warmup_state.mu_star), std_normal_logdensity
+        unravel(last_warmup_state.mu_star), _aniso_logdensity
     )
     return (
         mu_star_state,
@@ -1544,8 +1876,10 @@ class WindowAdaptationLowRankAccumulatingParityTest(BlackJAXTest):
     * Window 2: 50 slow steps (ends at global step 149).
     * Final fast phase: 50 steps (no mass-matrix updates).
 
-    With ``recompute_every=1`` : 73 mid-window + 2 at-window-end fires — exercises
-    every cadence combination.
+    With ``recompute_every=1`` : 71 mid-window + 2 at-window-end (73 total) — the
+    first 2 slow steps of window 1 skip the actual SVD because the ``n >= 3`` guard
+    in ``slow_recompute_only`` has not yet been satisfied; from step 3 onward every
+    step fires.  Exercises every cadence combination.
 
     With ``recompute_every=5`` : 13 mid-window + 2 at-window-end fires — exercises
     the "spurious recompute at window-end, immediately overwritten by final()" path
@@ -1559,10 +1893,11 @@ class WindowAdaptationLowRankAccumulatingParityTest(BlackJAXTest):
     Note: ``recompute_every=100`` fires zero times in 75 total slow steps and is
     equivalent to the degenerate ``10**9`` that was replaced — not included.
 
-    After the ``slow_update()`` engine fix (commit e2a4afa7d), mid-window metric
-    recomputes are forwarded to MCMC immediately (``new_metric_st.inverse_mass_matrix``
-    is returned, not ``ws.inverse_mass_matrix``), so the engine is bit-identical to
-    the legacy ``base()`` accumulating scan loop at ALL recompute cadences.
+    After the ``slow_update()`` engine fix that changed ``slow_update()`` to return
+    ``new_metric_st.inverse_mass_matrix`` rather than ``ws.inverse_mass_matrix``,
+    mid-window metric recomputes are forwarded to MCMC immediately, so the engine
+    is bit-identical to the legacy ``base()`` accumulating scan loop at ALL cadences.
+    Uses the anisotropic parity target so the fitted metric is genuinely non-identity.
     """
 
     _N_DIMS = 5
@@ -1572,7 +1907,7 @@ class WindowAdaptationLowRankAccumulatingParityTest(BlackJAXTest):
     def _run_engine(self, rng_key, position, recompute_every):
         wu = window_adaptation_low_rank(
             blackjax.nuts,
-            std_normal_logdensity,
+            _aniso_logdensity,
             max_rank=4,
             buffer_policy="accumulating",
             recompute_every=recompute_every,

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -25,9 +25,9 @@ Coverage:
 - Bit-identity: ``_compute_low_rank_metric`` moved to ``metric_estimators``
   is the same object as the backward-compat re-export from
   ``low_rank_adaptation``.
-- :func:`window_adaptation_low_rank` shim: reset path via staged engine,
-  accumulating path via established scan loop, gradient_based_init seam,
-  info-bridge field layout, and bit-exact reset parity vs reference runner.
+- :func:`window_adaptation_low_rank` shim: both buffer policies via staged engine,
+  gradient_based_init seam, info-bridge field layout, and bit-exact accumulating
+  parity gate vs frozen inline reference (``recompute_every=10**9``, ``atol=0.0``).
 """
 import jax
 import jax.flatten_util as fu
@@ -38,12 +38,15 @@ from absl.testing import absltest
 import blackjax
 import blackjax.mcmc as mcmc
 from blackjax.adaptation.base import return_all_adapt_info
+from blackjax.adaptation.low_rank_adaptation import (
+    LowRankAdaptationState,
+    _accumulating_buffer_capacity,
+)
 from blackjax.adaptation.low_rank_adaptation import _compute_low_rank_metric as lra_clrm
 from blackjax.adaptation.low_rank_adaptation import (
     _default_low_rank_adaptation_info_fn,
     _engine_state_to_low_rank_adaptation_state,
     _make_low_rank_bridge_info_fn,
-    base,
     build_growing_window_schedule,
     window_adaptation_low_rank,
 )
@@ -55,6 +58,7 @@ from blackjax.adaptation.metric_recipes import (
     MetricRecipe,
     _build_fisher_low_rank_core,
     _build_sample_cov_low_rank_core,
+    _shift_buffer_left,
     lookup_recipe,
     seed_low_rank_sigma_from_grad,
 )
@@ -63,6 +67,7 @@ from blackjax.adaptation.staged_adaptation import (
     build_schedule,
     staged_adaptation,
 )
+from blackjax.adaptation.step_size import dual_averaging_adaptation
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix, gaussian_euclidean_low_rank
 from tests.fixtures import BlackJAXTest, std_normal_logdensity
 
@@ -1323,17 +1328,29 @@ class LowRankX64SmokeTest(BlackJAXTest):
 
 
 # ---------------------------------------------------------------------------
-# Bit-exact parity: reset path vs reference base() scan loop
+# Bit-exact parity: accumulating path via engine vs frozen reference scan loop
 # ---------------------------------------------------------------------------
 
 
-def _reference_run_reset(rng_key, position, num_steps, n_dims):
-    """Run the reset path using base() directly (the pre-shim reference).
+def _reference_run_accumulating(
+    rng_key, position, num_steps, n_dims, recompute_every=10**9
+):
+    """Frozen inline accumulating scan loop (verbatim copy of ``base(buffer_policy='accumulating')`` math).
 
-    This replicates exactly what window_adaptation_low_rank did before the
-    shim rewrite: builds base() init/update/final, builds the scan loop
-    inline, and post-processes with the mu_star re-init.  The new shim's
-    reset path (via staged_adaptation) must produce bit-identical output.
+    Bit-exact reference for :class:`WindowAdaptationLowRankAccumulatingParityTest`.
+    Inline rather than importing ``base()`` so that this reference survives
+    independently of the production code and cannot be silently changed.
+
+    **Must NOT be modified** after the Slice-3 migration commit.
+
+    Bit-exact comparison requires ``recompute_every=10**9`` (the default here).
+    With the engine path, mid-window metric recomputes (``slow_recompute_only``)
+    are stored in ``imm_state.inverse_mass_matrix`` but NOT forwarded to
+    ``StagedAdaptationState.inverse_mass_matrix`` (only ``slow_final`` at
+    window-end does that).  The old scan loop DID expose mid-window metrics to
+    the MCMC kernel immediately.  With ``recompute_every=10**9`` neither path
+    fires ``slow_recompute_only`` mid-window, so both see the same metric for
+    MCMC at every step and produce identical outputs.
     """
     max_rank = 4
     gamma = 1e-5
@@ -1341,16 +1358,110 @@ def _reference_run_reset(rng_key, position, num_steps, n_dims):
     initial_step_size = 1.0
     target_acceptance_rate = 0.80
 
-    adapt_init_fn, adapt_step_fn, adapt_final_fn = base(
-        max_rank=max_rank,
-        target_acceptance_rate=target_acceptance_rate,
-        gamma=gamma,
-        cutoff=cutoff,
-        gradient_based_init=False,
-        buffer_policy="reset",
-        recompute_every=1,
-    )
+    da_init, da_update, da_final = dual_averaging_adaptation(target_acceptance_rate)
     mcmc_kernel = blackjax.nuts.build_kernel(mcmc.integrators.velocity_verlet)
+    schedule = build_schedule(num_steps)
+    buffer_size = max(_accumulating_buffer_capacity(schedule), 1)
+    d = n_dims
+
+    def fast_update(pos, grad, acc_rate, state):
+        del pos, grad
+        new_ss = da_update(state.ss_state, acc_rate)
+        return LowRankAdaptationState(
+            new_ss,
+            state.sigma,
+            state.mu_star,
+            state.U,
+            state.lam,
+            jnp.exp(new_ss.log_step_size),
+            state.draws_buffer,
+            state.grads_buffer,
+            state.buffer_idx,
+            state.background_split,
+            state.recompute_counter,
+        )
+
+    def slow_update(pos, grad, acc_rate, state):
+        pos_flat, _ = fu.ravel_pytree(pos)
+        grad_flat, _ = fu.ravel_pytree(grad)
+        B = state.draws_buffer.shape[0]
+        idx = state.buffer_idx % B
+        new_draws = jax.lax.dynamic_update_slice(
+            state.draws_buffer, pos_flat[None, :], (idx, 0)
+        )
+        new_grads = jax.lax.dynamic_update_slice(
+            state.grads_buffer, grad_flat[None, :], (idx, 0)
+        )
+        new_ss = da_update(state.ss_state, acc_rate)
+        return LowRankAdaptationState(
+            new_ss,
+            state.sigma,
+            state.mu_star,
+            state.U,
+            state.lam,
+            jnp.exp(new_ss.log_step_size),
+            new_draws,
+            new_grads,
+            state.buffer_idx + 1,
+            state.background_split,
+            state.recompute_counter + 1,
+        )
+
+    def slow_switch(state):
+        shift = state.background_split
+        new_draws = _shift_buffer_left(state.draws_buffer, shift)
+        new_grads = _shift_buffer_left(state.grads_buffer, shift)
+        new_n_valid = state.buffer_idx - shift
+
+        def _recompute():
+            return _compute_low_rank_metric(
+                new_draws, new_grads, new_n_valid, max_rank, gamma, cutoff
+            )
+
+        def _keep():
+            return state.sigma, state.mu_star, state.U, state.lam
+
+        sigma, mu_star, U, lam = jax.lax.cond(new_n_valid >= 3, _recompute, _keep)
+        new_ss = da_init(da_final(state.ss_state))
+        return LowRankAdaptationState(
+            new_ss,
+            sigma,
+            mu_star,
+            U,
+            lam,
+            jnp.exp(new_ss.log_step_size),
+            new_draws,
+            new_grads,
+            new_n_valid,
+            new_n_valid,
+            0,
+        )
+
+    def slow_recompute_only(state):
+        n = state.buffer_idx
+
+        def _recompute():
+            return _compute_low_rank_metric(
+                state.draws_buffer, state.grads_buffer, n, max_rank, gamma, cutoff
+            )
+
+        def _keep():
+            return state.sigma, state.mu_star, state.U, state.lam
+
+        sigma, mu_star, U, lam = jax.lax.cond(n >= 3, _recompute, _keep)
+        return LowRankAdaptationState(
+            state.ss_state,
+            sigma,
+            mu_star,
+            U,
+            lam,
+            state.step_size,
+            state.draws_buffer,
+            state.grads_buffer,
+            state.buffer_idx,
+            state.background_split,
+            0,
+        )
 
     def one_step(carry, xs):
         _, rng_key_, adaptation_stage = xs
@@ -1361,31 +1472,46 @@ def _reference_run_reset(rng_key, position, num_steps, n_dims):
         new_state, step_info = mcmc_kernel(
             rng_key_, state, std_normal_logdensity, adaptation_state.step_size, metric
         )
-        new_adaptation_state = adapt_step_fn(
-            adaptation_state,
-            adaptation_stage,
+        stage = adaptation_stage[0]
+        is_window_end = adaptation_stage[1].astype(bool)
+        new_adapt = jax.lax.switch(
+            stage,
+            (fast_update, slow_update),
             new_state.position,
             new_state.logdensity_grad,
             step_info.acceptance_rate,
+            adaptation_state,
+        )
+
+        def _maybe_periodic_recompute(s):
+            due = jnp.logical_and(
+                stage == 1, s.recompute_counter % recompute_every == 0
+            )
+            return jax.lax.cond(due, slow_recompute_only, lambda x: x, s)
+
+        new_adapt = jax.lax.cond(
+            is_window_end, slow_switch, _maybe_periodic_recompute, new_adapt
         )
         return (
-            (new_state, new_adaptation_state),
-            _default_low_rank_adaptation_info_fn(
-                new_state, step_info, new_adaptation_state
-            ),
+            (new_state, new_adapt),
+            _default_low_rank_adaptation_info_fn(new_state, step_info, new_adapt),
         )
 
+    ss_state = da_init(initial_step_size)
     init_state = blackjax.nuts.init(position, std_normal_logdensity)
-    schedule = build_schedule(num_steps)
-    typical_window = max(num_steps // 5, 128)
-    buffer_size = min(typical_window * 2, max(num_steps, 1))
-    init_adaptation_state = adapt_init_fn(
-        position,
-        init_state.logdensity_grad,
+    init_adaptation_state = LowRankAdaptationState(
+        ss_state,
+        jnp.ones(d),
+        jnp.zeros(d),
+        jnp.zeros((d, max_rank)),
+        jnp.ones(max_rank),
         initial_step_size,
-        buffer_size,
+        jnp.zeros((buffer_size, d)),
+        jnp.zeros((buffer_size, d)),
+        0,
+        0,
+        0,
     )
-
     keys = jax.random.split(rng_key, num_steps)
     last_state, info = jax.lax.scan(
         one_step,
@@ -1393,10 +1519,16 @@ def _reference_run_reset(rng_key, position, num_steps, n_dims):
         (jnp.arange(num_steps), keys, schedule),
     )
     _, last_warmup_state, *_ = last_state
-    step_size, sigma, mu_star, U, lam = adapt_final_fn(last_warmup_state)
-    inverse_mass_matrix = LowRankInverseMassMatrix(sigma=sigma, U=U, lam=lam)
+    step_size = jnp.exp(last_warmup_state.ss_state.log_step_size_avg)
+    inverse_mass_matrix = LowRankInverseMassMatrix(
+        sigma=last_warmup_state.sigma,
+        U=last_warmup_state.U,
+        lam=last_warmup_state.lam,
+    )
     _, unravel = fu.ravel_pytree(position)
-    mu_star_state = blackjax.nuts.init(unravel(mu_star), std_normal_logdensity)
+    mu_star_state = blackjax.nuts.init(
+        unravel(last_warmup_state.mu_star), std_normal_logdensity
+    )
     return (
         mu_star_state,
         {"step_size": step_size, "inverse_mass_matrix": inverse_mass_matrix},
@@ -1404,30 +1536,39 @@ def _reference_run_reset(rng_key, position, num_steps, n_dims):
     )
 
 
-class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
-    """Bit-exact parity: reset path via staged engine == reference base() runner."""
+class WindowAdaptationLowRankAccumulatingParityTest(BlackJAXTest):
+    """Bit-exact parity: accumulating path via engine == frozen reference scan loop.
+
+    Uses ``recompute_every=10**9`` (effectively infinite) so mid-window metric
+    recomputes do NOT fire in either path.  See ``_reference_run_accumulating``
+    docstring for the full bit-exactness argument.
+    """
 
     _N_DIMS = 5
     _NUM_STEPS = 200
 
-    def _run_shim(self, rng_key, position):
+    def _run_engine(self, rng_key, position):
         wu = window_adaptation_low_rank(
             blackjax.nuts,
             std_normal_logdensity,
             max_rank=4,
+            buffer_policy="accumulating",
+            recompute_every=10**9,
         )
         return wu.run(rng_key, position, num_steps=self._NUM_STEPS)
 
     def test_final_step_size_identical(self):
-        """Final step_size must be bit-identical between shim and reference."""
+        """Final step_size must be bit-identical between engine and reference."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_shim), _ = self._run_shim(key, pos)
-        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    params_shim["step_size"], params_ref["step_size"], atol=0.0
+                    params_engine["step_size"], params_ref["step_size"], atol=0.0
                 )
             )
         )
@@ -1435,12 +1576,14 @@ class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
     def test_final_sigma_identical(self):
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_shim), _ = self._run_shim(key, pos)
-        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    params_shim["inverse_mass_matrix"].sigma,
+                    params_engine["inverse_mass_matrix"].sigma,
                     params_ref["inverse_mass_matrix"].sigma,
                     atol=0.0,
                 )
@@ -1450,12 +1593,14 @@ class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
     def test_final_u_identical(self):
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_shim), _ = self._run_shim(key, pos)
-        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    params_shim["inverse_mass_matrix"].U,
+                    params_engine["inverse_mass_matrix"].U,
                     params_ref["inverse_mass_matrix"].U,
                     atol=0.0,
                 )
@@ -1465,12 +1610,14 @@ class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
     def test_final_lam_identical(self):
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_shim), _ = self._run_shim(key, pos)
-        _, params_ref, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, params_engine), _ = self._run_engine(key, pos)
+        _, params_ref, _ = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    params_shim["inverse_mass_matrix"].lam,
+                    params_engine["inverse_mass_matrix"].lam,
                     params_ref["inverse_mass_matrix"].lam,
                     atol=0.0,
                 )
@@ -1481,22 +1628,26 @@ class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
         """Returned chain state (mu_star re-init) must be bit-identical."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (state_shim, _), _ = self._run_shim(key, pos)
-        state_ref, _, _ = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (state_engine, _), _ = self._run_engine(key, pos)
+        state_ref, _, _ = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
-            bool(jnp.allclose(state_shim.position, state_ref.position, atol=0.0))
+            bool(jnp.allclose(state_engine.position, state_ref.position, atol=0.0))
         )
 
     def test_per_step_sigma_identical(self):
         """Per-step sigma trace must be bit-identical across all steps."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, _), info_shim = self._run_shim(key, pos)
-        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, _), info_engine = self._run_engine(key, pos)
+        _, _, info_ref = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    info_shim.adaptation_state.sigma,
+                    info_engine.adaptation_state.sigma,
                     info_ref.adaptation_state.sigma,
                     atol=0.0,
                 )
@@ -1507,12 +1658,14 @@ class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
         """Per-step mu_star trace must be bit-identical."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, _), info_shim = self._run_shim(key, pos)
-        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, _), info_engine = self._run_engine(key, pos)
+        _, _, info_ref = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    info_shim.adaptation_state.mu_star,
+                    info_engine.adaptation_state.mu_star,
                     info_ref.adaptation_state.mu_star,
                     atol=0.0,
                 )
@@ -1523,12 +1676,14 @@ class WindowAdaptationLowRankResetParityTest(BlackJAXTest):
         """Per-step step_size trace must be bit-identical."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, _), info_shim = self._run_shim(key, pos)
-        _, _, info_ref = _reference_run_reset(key, pos, self._NUM_STEPS, self._N_DIMS)
+        (_, _), info_engine = self._run_engine(key, pos)
+        _, _, info_ref = _reference_run_accumulating(
+            key, pos, self._NUM_STEPS, self._N_DIMS
+        )
         self.assertTrue(
             bool(
                 jnp.allclose(
-                    info_shim.adaptation_state.step_size,
+                    info_engine.adaptation_state.step_size,
                     info_ref.adaptation_state.step_size,
                     atol=0.0,
                 )

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -1341,7 +1341,7 @@ def _reference_run_accumulating(
     Inline rather than importing ``base()`` so that this reference survives
     independently of the production code and cannot be silently changed.
 
-    **Must NOT be modified** after the Slice-3 migration commit.
+    **Must NOT be modified** — this is the frozen pre-migration reference used by the parity gate.
 
     Bit-exact comparison works at ANY ``recompute_every`` value (default 1,
     matching nutpie's ``mass_matrix_update_freq=1``) after the engine fix that

--- a/tests/adaptation/test_low_rank_recipes.py
+++ b/tests/adaptation/test_low_rank_recipes.py
@@ -1333,7 +1333,7 @@ class LowRankX64SmokeTest(BlackJAXTest):
 
 
 def _reference_run_accumulating(
-    rng_key, position, num_steps, n_dims, recompute_every=10**9
+    rng_key, position, num_steps, n_dims, recompute_every=1
 ):
     """Frozen inline accumulating scan loop (verbatim copy of ``base(buffer_policy='accumulating')`` math).
 
@@ -1343,14 +1343,12 @@ def _reference_run_accumulating(
 
     **Must NOT be modified** after the Slice-3 migration commit.
 
-    Bit-exact comparison requires ``recompute_every=10**9`` (the default here).
-    With the engine path, mid-window metric recomputes (``slow_recompute_only``)
-    are stored in ``imm_state.inverse_mass_matrix`` but NOT forwarded to
-    ``StagedAdaptationState.inverse_mass_matrix`` (only ``slow_final`` at
-    window-end does that).  The old scan loop DID expose mid-window metrics to
-    the MCMC kernel immediately.  With ``recompute_every=10**9`` neither path
-    fires ``slow_recompute_only`` mid-window, so both see the same metric for
-    MCMC at every step and produce identical outputs.
+    Bit-exact comparison works at ANY ``recompute_every`` value (default 1,
+    matching nutpie's ``mass_matrix_update_freq=1``) after the engine fix that
+    changed ``slow_update()`` to return ``new_metric_st.inverse_mass_matrix``
+    instead of ``ws.inverse_mass_matrix``.  The engine now surfaces mid-window
+    metric recomputes to MCMC immediately, matching ``slow_recompute_only()``
+    in this reference.
     """
     max_rank = 4
     gamma = 1e-5
@@ -1539,156 +1537,202 @@ def _reference_run_accumulating(
 class WindowAdaptationLowRankAccumulatingParityTest(BlackJAXTest):
     """Bit-exact parity: accumulating path via engine == frozen reference scan loop.
 
-    Uses ``recompute_every=10**9`` (effectively infinite) so mid-window metric
-    recomputes do NOT fire in either path.  See ``_reference_run_accumulating``
-    docstring for the full bit-exactness argument.
+    Parametrized over ``recompute_every ∈ {1, 5, 25}`` — all three must pass at
+    ``atol=0.0``.  Verified against the 200-step Stan schedule (build_schedule(200)):
+
+    * Window 1: 25 slow steps (ends at global step 99).
+    * Window 2: 50 slow steps (ends at global step 149).
+    * Final fast phase: 50 steps (no mass-matrix updates).
+
+    With ``recompute_every=1`` : 73 mid-window + 2 at-window-end fires — exercises
+    every cadence combination.
+
+    With ``recompute_every=5`` : 13 mid-window + 2 at-window-end fires — exercises
+    the "spurious recompute at window-end, immediately overwritten by final()" path
+    (window 1 ends at slow_count=25, a multiple of 5; window 2 ends at 50=5×10).
+
+    With ``recompute_every=25`` : 1 mid-window + 2 at-window-end fires (per-window
+    counter resets: window-1 fires at counter=25=window-end; window-2 fires at
+    counter=25=mid and counter=50=window-end).  Exercises the infrequent-recompute
+    + at-window-boundary combination.
+
+    Note: ``recompute_every=100`` fires zero times in 75 total slow steps and is
+    equivalent to the degenerate ``10**9`` that was replaced — not included.
+
+    After the ``slow_update()`` engine fix (commit e2a4afa7d), mid-window metric
+    recomputes are forwarded to MCMC immediately (``new_metric_st.inverse_mass_matrix``
+    is returned, not ``ws.inverse_mass_matrix``), so the engine is bit-identical to
+    the legacy ``base()`` accumulating scan loop at ALL recompute cadences.
     """
 
     _N_DIMS = 5
     _NUM_STEPS = 200
+    _RECOMPUTE_CADENCES = (1, 5, 25)
 
-    def _run_engine(self, rng_key, position):
+    def _run_engine(self, rng_key, position, recompute_every):
         wu = window_adaptation_low_rank(
             blackjax.nuts,
             std_normal_logdensity,
             max_rank=4,
             buffer_policy="accumulating",
-            recompute_every=10**9,
+            recompute_every=recompute_every,
         )
         return wu.run(rng_key, position, num_steps=self._NUM_STEPS)
 
     def test_final_step_size_identical(self):
-        """Final step_size must be bit-identical between engine and reference."""
+        """Final step_size must be bit-identical for all recompute cadences."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_engine), _ = self._run_engine(key, pos)
-        _, params_ref, _ = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    params_engine["step_size"], params_ref["step_size"], atol=0.0
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, params_engine), _ = self._run_engine(key, pos, re)
+                _, params_ref, _ = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            params_engine["step_size"],
+                            params_ref["step_size"],
+                            atol=0.0,
+                        )
+                    )
+                )
 
     def test_final_sigma_identical(self):
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_engine), _ = self._run_engine(key, pos)
-        _, params_ref, _ = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    params_engine["inverse_mass_matrix"].sigma,
-                    params_ref["inverse_mass_matrix"].sigma,
-                    atol=0.0,
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, params_engine), _ = self._run_engine(key, pos, re)
+                _, params_ref, _ = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            params_engine["inverse_mass_matrix"].sigma,
+                            params_ref["inverse_mass_matrix"].sigma,
+                            atol=0.0,
+                        )
+                    )
+                )
 
     def test_final_u_identical(self):
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_engine), _ = self._run_engine(key, pos)
-        _, params_ref, _ = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    params_engine["inverse_mass_matrix"].U,
-                    params_ref["inverse_mass_matrix"].U,
-                    atol=0.0,
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, params_engine), _ = self._run_engine(key, pos, re)
+                _, params_ref, _ = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            params_engine["inverse_mass_matrix"].U,
+                            params_ref["inverse_mass_matrix"].U,
+                            atol=0.0,
+                        )
+                    )
+                )
 
     def test_final_lam_identical(self):
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, params_engine), _ = self._run_engine(key, pos)
-        _, params_ref, _ = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    params_engine["inverse_mass_matrix"].lam,
-                    params_ref["inverse_mass_matrix"].lam,
-                    atol=0.0,
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, params_engine), _ = self._run_engine(key, pos, re)
+                _, params_ref, _ = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            params_engine["inverse_mass_matrix"].lam,
+                            params_ref["inverse_mass_matrix"].lam,
+                            atol=0.0,
+                        )
+                    )
+                )
 
     def test_final_chain_state_position_identical(self):
         """Returned chain state (mu_star re-init) must be bit-identical."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (state_engine, _), _ = self._run_engine(key, pos)
-        state_ref, _, _ = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(jnp.allclose(state_engine.position, state_ref.position, atol=0.0))
-        )
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (state_engine, _), _ = self._run_engine(key, pos, re)
+                state_ref, _, _ = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
+                )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            state_engine.position, state_ref.position, atol=0.0
+                        )
+                    )
+                )
 
     def test_per_step_sigma_identical(self):
         """Per-step sigma trace must be bit-identical across all steps."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, _), info_engine = self._run_engine(key, pos)
-        _, _, info_ref = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    info_engine.adaptation_state.sigma,
-                    info_ref.adaptation_state.sigma,
-                    atol=0.0,
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, _), info_engine = self._run_engine(key, pos, re)
+                _, _, info_ref = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            info_engine.adaptation_state.sigma,
+                            info_ref.adaptation_state.sigma,
+                            atol=0.0,
+                        )
+                    )
+                )
 
     def test_per_step_mu_star_identical(self):
         """Per-step mu_star trace must be bit-identical."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, _), info_engine = self._run_engine(key, pos)
-        _, _, info_ref = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    info_engine.adaptation_state.mu_star,
-                    info_ref.adaptation_state.mu_star,
-                    atol=0.0,
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, _), info_engine = self._run_engine(key, pos, re)
+                _, _, info_ref = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            info_engine.adaptation_state.mu_star,
+                            info_ref.adaptation_state.mu_star,
+                            atol=0.0,
+                        )
+                    )
+                )
 
     def test_per_step_step_size_identical(self):
         """Per-step step_size trace must be bit-identical."""
         key = self.next_key()
         pos = jnp.zeros(self._N_DIMS)
-        (_, _), info_engine = self._run_engine(key, pos)
-        _, _, info_ref = _reference_run_accumulating(
-            key, pos, self._NUM_STEPS, self._N_DIMS
-        )
-        self.assertTrue(
-            bool(
-                jnp.allclose(
-                    info_engine.adaptation_state.step_size,
-                    info_ref.adaptation_state.step_size,
-                    atol=0.0,
+        for re in self._RECOMPUTE_CADENCES:
+            with self.subTest(recompute_every=re):
+                (_, _), info_engine = self._run_engine(key, pos, re)
+                _, _, info_ref = _reference_run_accumulating(
+                    key, pos, self._NUM_STEPS, self._N_DIMS, recompute_every=re
                 )
-            )
-        )
+                self.assertTrue(
+                    bool(
+                        jnp.allclose(
+                            info_engine.adaptation_state.step_size,
+                            info_ref.adaptation_state.step_size,
+                            atol=0.0,
+                        )
+                    )
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Change

The low-rank warmup's **accumulating** buffer policy (nutpie-style partial-forget with periodic
mid-window recomputes) now runs through the staged-adaptation engine, alongside the reset policy
that was migrated earlier. With both policies on the engine, `low_rank_adaptation.base()` — the
old hand-rolled scan loop — is no longer used and is removed, together with its now-orphaned
helpers. `low_rank_adaptation.py` shrinks by ~485 lines; there is one low-rank metric
implementation path instead of two.

`window_adaptation_low_rank`'s public surface and behaviour are unchanged.

### Engine consistency fix

Enabling the accumulating policy surfaced an inconsistency in the engine: `slow_update` returned
the *previous window-end* inverse mass matrix to the sampler, while `slow_final` returned the
freshly computed one. That is correct for the window-schedule policies (their metric only changes
at window ends) but wrong for a policy that recomputes the metric mid-window and needs the sampler
to use it. `slow_update` now returns the core's current inverse mass matrix each step, matching
`slow_final`. This is a no-op for every existing policy — their cores do not modify the inverse
mass matrix between window ends — and is what makes the accumulating migration exact.

## Behaviour-identical

Verified bit-identical (`atol=0.0`) through full `run()`:

- **The engine change is a no-op for existing policies**: `window_adaptation` (diagonal and dense),
  `window_adaptation_low_rank` (reset), and `staged_adaptation(metric="fisher_diag")` produce
  byte-identical step size, inverse mass matrix, and final position versus the previous
  implementation, at float32 and float64.
- **The accumulating migration is exact**: `window_adaptation_low_rank(buffer_policy="accumulating")`
  matches the previous scan-loop implementation byte-for-byte across recompute cadences (including
  the default, which recomputes every step), both the Stan and growing-window schedules, and both
  dtypes.

The accumulating parity test compares the engine path against an inline frozen copy of the previous
scan loop on an anisotropic target (so the low-rank correction is genuinely active), and is
mutation-verified load-bearing: reverting the engine fix or perturbing the accumulator math turns
it red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
