### PR TITLE
Make memory improvements to Pathfinder

### DIFF
--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -335,9 +335,9 @@ def lbfgs_recover_alpha(alpha_lm1, s_l, z_l, epsilon=1e-12):
     """
 
     def compute_next_alpha(s_l, z_l, alpha_lm1):
-        a = z_l.T @ jnp.diag(alpha_lm1) @ z_l
-        b = z_l.T @ s_l
-        c = s_l.T @ jnp.diag(1.0 / alpha_lm1) @ s_l
+        a = jnp.sum(alpha_lm1 * z_l**2)
+        b = jnp.dot(z_l, s_l)
+        c = jnp.sum(s_l**2 / alpha_lm1)
         inv_alpha_l = (
             a / (b * alpha_lm1)
             + z_l**2 / b
@@ -371,10 +371,10 @@ def lbfgs_inverse_hessian_factors(S, Z, alpha):
 
     eta = jnp.diag(StZ)
 
-    beta = jnp.hstack([jnp.diag(alpha) @ Z, S])
+    beta = jnp.hstack((alpha[:, None] * Z, S))
 
     minvR = -jnp.linalg.inv(R)
-    alphaZ = jnp.diag(jnp.sqrt(alpha)) @ Z
+    alphaZ = jnp.sqrt(alpha)[:, None] * Z
     block_dd = minvR.T @ (alphaZ.T @ alphaZ + jnp.diag(eta)) @ minvR
     gamma = jnp.block(
         [[jnp.zeros((param_dims, param_dims)), minvR], [minvR.T, block_dd]]
@@ -420,20 +420,20 @@ def bfgs_sample(rng_key, num_samples, position, grad_position, alpha, beta, gamm
     if not isinstance(num_samples, tuple):
         num_samples = (num_samples,)
 
-    Q, R = jnp.linalg.qr(jnp.diag(jnp.sqrt(1 / alpha)) @ beta)
+    Q, R = jnp.linalg.qr(beta / jnp.sqrt(alpha)[:, None], mode="reduced")
     param_dims = beta.shape[0]
     Id = jnp.identity(R.shape[0])
     L = jnp.linalg.cholesky(Id + R @ gamma @ R.T)
 
-    logdet = jnp.log(jnp.prod(alpha)) + 2 * jnp.log(jnp.linalg.det(L))
+    logdet = jnp.sum(jnp.log(alpha)) + 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
     mu = (
         position
-        + jnp.diag(alpha) @ grad_position
-        + beta @ gamma @ beta.T @ grad_position
+        + alpha * grad_position
+        + beta @ (gamma @ (beta.T @ grad_position))
     )
 
     u = jax.random.normal(rng_key, num_samples + (param_dims, 1))
-    phi = mu[..., None] + jnp.diag(jnp.sqrt(alpha)) @ (Q @ (L - Id) @ (Q.T @ u) + u)
+    phi = mu[..., None] + jnp.sqrt(alpha)[:, None] * (Q @ (L - Id) @ (Q.T @ u) + u)
 
     logdensity = -0.5 * (
         logdet

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -339,7 +339,9 @@ def lbfgs_recover_alpha(alpha_lm1, s_l, z_l, epsilon=1e-12):
         b = jnp.dot(z_l, s_l)
         c = jnp.sum(s_l**2 / alpha_lm1)
         inv_alpha_l = (
-            a / (b * alpha_lm1) + z_l**2 / b - (a * s_l**2) / (b * c * alpha_lm1**2)
+            a / (b * alpha_lm1)
+            + z_l**2 / b
+            - (a * s_l**2) / (b * c * alpha_lm1**2)
         )
         return 1.0 / inv_alpha_l
 

--- a/blackjax/optimizers/lbfgs.py
+++ b/blackjax/optimizers/lbfgs.py
@@ -339,9 +339,7 @@ def lbfgs_recover_alpha(alpha_lm1, s_l, z_l, epsilon=1e-12):
         b = jnp.dot(z_l, s_l)
         c = jnp.sum(s_l**2 / alpha_lm1)
         inv_alpha_l = (
-            a / (b * alpha_lm1)
-            + z_l**2 / b
-            - (a * s_l**2) / (b * c * alpha_lm1**2)
+            a / (b * alpha_lm1) + z_l**2 / b - (a * s_l**2) / (b * c * alpha_lm1**2)
         )
         return 1.0 / inv_alpha_l
 
@@ -426,11 +424,7 @@ def bfgs_sample(rng_key, num_samples, position, grad_position, alpha, beta, gamm
     L = jnp.linalg.cholesky(Id + R @ gamma @ R.T)
 
     logdet = jnp.sum(jnp.log(alpha)) + 2.0 * jnp.sum(jnp.log(jnp.diag(L)))
-    mu = (
-        position
-        + alpha * grad_position
-        + beta @ (gamma @ (beta.T @ grad_position))
-    )
+    mu = position + alpha * grad_position + beta @ (gamma @ (beta.T @ grad_position))
 
     u = jax.random.normal(rng_key, num_samples + (param_dims, 1))
     phi = mu[..., None] + jnp.sqrt(alpha)[:, None] * (Q @ (L - Id) @ (Q.T @ u) + u)

--- a/blackjax/vi/pathfinder.py
+++ b/blackjax/vi/pathfinder.py
@@ -148,34 +148,42 @@ def approximate(
     # Pad 0 to leading dimension so we have constant shape output
     s_padded = jnp.pad(s_masked, ((maxcor, 0), (0, 0)), mode="constant")
     z_padded = jnp.pad(z_masked, ((maxcor, 0), (0, 0)), mode="constant")
-
-    def path_finder_body_fn(rng_key, S, Z, alpha_l, theta, theta_grad):
+    
+    def path_finder_body_fn(args: tuple[int, jax.Array]):
         """The for loop body in Algorithm 1 of the Pathfinder paper."""
+        
+        i, key_i = args
+        
+        # lazy sliding window
+        window_idx = i + jnp.arange(maxcor)
+        S = s_padded[window_idx].reshape(maxcor, -1)
+        Z = z_padded[window_idx].reshape(maxcor, -1)
+        theta = position[i]
+        theta_grad = grad_position[i]
+        alpha_l = alpha[i]
+        
         beta, gamma = lbfgs_inverse_hessian_factors(S.T, Z.T, alpha_l)
         phi, logq = bfgs_sample(
-            rng_key=rng_key,
-            num_samples=num_samples,
-            position=theta,
+            rng_key=key_i, 
+            num_samples=num_samples, 
+            position=theta, 
             grad_position=theta_grad,
-            alpha=alpha_l,
-            beta=beta,
-            gamma=gamma,
+            alpha=alpha_l, 
+            beta=beta, 
+            gamma=gamma
         )
+        
         logp = -jax.vmap(objective_fn)(phi)
-        elbo = (logp - logq).mean()  # Algorithm 7 of the paper
+        elbo = (logp - logq).mean()
+        
         return elbo, beta, gamma
-
-    # Index and reshape S and Z to be sliding window view shape=(maxiter,
-    # maxcor, param_dim), so we can vmap over all the iterations.
-    # This is in effect numpy.lib.stride_tricks.sliding_window_view
+        
     path_size = maxiter + 1
-    index = jnp.arange(path_size)[:, None] + jnp.arange(maxcor)[None, :]
-    s_j = s_padded[index.reshape(path_size, maxcor)].reshape(path_size, maxcor, -1)
-    z_j = z_padded[index.reshape(path_size, maxcor)].reshape(path_size, maxcor, -1)
     rng_keys = jax.random.split(rng_key, path_size)
-    elbo, beta, gamma = jax.vmap(path_finder_body_fn)(
-        rng_keys, s_j, z_j, alpha, position, grad_position
-    )
+    path_indices = jnp.arange(path_size)    
+    
+    elbo, beta, gamma = jax.vmap(path_finder_body_fn)((path_indices, rng_keys))
+        
     elbo = jnp.where(
         (jnp.arange(path_size) < (status.iter_num)) & jnp.isfinite(elbo),
         elbo,

--- a/blackjax/vi/pathfinder.py
+++ b/blackjax/vi/pathfinder.py
@@ -121,7 +121,9 @@ def approximate(
 
     """
     initial_position_flatten, unravel_fn = ravel_pytree(initial_position)
-    objective_fn = lambda x: -logdensity_fn(unravel_fn(x))
+
+    def objective_fn(x):
+        return -logdensity_fn(unravel_fn(x))
 
     (_, status), history = _minimize_lbfgs(
         objective_fn,
@@ -148,12 +150,12 @@ def approximate(
     # Pad 0 to leading dimension so we have constant shape output
     s_padded = jnp.pad(s_masked, ((maxcor, 0), (0, 0)), mode="constant")
     z_padded = jnp.pad(z_masked, ((maxcor, 0), (0, 0)), mode="constant")
-    
+
     def path_finder_body_fn(args: tuple[int, jax.Array]):
         """The for loop body in Algorithm 1 of the Pathfinder paper."""
-        
+
         i, key_i = args
-        
+
         # lazy sliding window
         window_idx = i + jnp.arange(maxcor)
         S = s_padded[window_idx].reshape(maxcor, -1)
@@ -161,29 +163,29 @@ def approximate(
         theta = position[i]
         theta_grad = grad_position[i]
         alpha_l = alpha[i]
-        
+
         beta, gamma = lbfgs_inverse_hessian_factors(S.T, Z.T, alpha_l)
         phi, logq = bfgs_sample(
-            rng_key=key_i, 
-            num_samples=num_samples, 
-            position=theta, 
+            rng_key=key_i,
+            num_samples=num_samples,
+            position=theta,
             grad_position=theta_grad,
-            alpha=alpha_l, 
-            beta=beta, 
-            gamma=gamma
+            alpha=alpha_l,
+            beta=beta,
+            gamma=gamma,
         )
-        
+
         logp = -jax.vmap(objective_fn)(phi)
         elbo = (logp - logq).mean()
-        
+
         return elbo, beta, gamma
-        
+
     path_size = maxiter + 1
     rng_keys = jax.random.split(rng_key, path_size)
-    path_indices = jnp.arange(path_size)    
-    
+    path_indices = jnp.arange(path_size)
+
     elbo, beta, gamma = jax.vmap(path_finder_body_fn)((path_indices, rng_keys))
-        
+
     elbo = jnp.where(
         (jnp.arange(path_size) < (status.iter_num)) & jnp.isfinite(elbo),
         elbo,

--- a/tests/optimizers/test_pathfinder.py
+++ b/tests/optimizers/test_pathfinder.py
@@ -5,10 +5,11 @@ import chex
 import jax
 import jax.numpy as jnp
 import jax.scipy.stats as stats
+import numpy as np
 from absl.testing import absltest, parameterized
 
 import blackjax
-from blackjax.optimizers.lbfgs import bfgs_sample
+from blackjax.optimizers.lbfgs import bfgs_sample, lbfgs_inverse_hessian_factors
 
 
 class PathfinderTest(chex.TestCase):
@@ -89,6 +90,80 @@ class PathfinderTest(chex.TestCase):
         kl = (log_p - log_q).mean()
         # TODO(junpenglao): Make this test more robust.
         self.assertAlmostEqual(kl, 0.0, delta=2.5)
+
+    def test_bfgs_sample_logdet_finite_large_n(self):
+        """Regression pin for the -inf logdet overflow (issue #1007).
+
+        The old formula ``jnp.log(jnp.prod(alpha))`` overflows to inf for large N
+        (``2.0 ** 3000`` exceeds any IEEE 754 float range).  The PR replaces it with
+        ``jnp.sum(jnp.log(alpha))`` which is numerically stable.
+
+        Setting beta=0 / gamma=0 isolates the logdet term so only the
+        sum(log(alpha)) path is exercised.  Asserts the returned logdensity is finite.
+        """
+        N = 3000
+        alpha = 2.0 * jnp.ones(N)
+        # beta=0 / gamma=0: only the logdet = sum(log(alpha)) term is non-trivial.
+        beta = jnp.zeros((N, 2))
+        gamma = jnp.zeros((2, 2))
+        position = jnp.zeros(N)
+        grad_position = jnp.zeros(N)
+
+        _phi, logq = bfgs_sample(
+            jax.random.key(0), 1, position, grad_position, alpha, beta, gamma
+        )
+        self.assertTrue(jnp.all(jnp.isfinite(logq)))
+
+    def test_bfgs_sample_mu_reassociation(self):
+        """Regression pin for the mu re-association (issue #1007).
+
+        The PR rewrites the O(N²) form:
+            position + diag(alpha) @ grad + beta @ gamma @ beta.T @ grad
+        as the memory-efficient factored form:
+            position + alpha * grad + beta @ (gamma @ (beta.T @ grad))
+
+        Exercises the bfgs_sample code path by reproducing the internal noise
+        tensor with the same key, subtracting it from the samples to recover the
+        deterministic mu, then comparing to the dense reference.
+        Z = S satisfies the curvature condition s^T z = ||s||^2 > 0, guaranteeing
+        valid L-BFGS inverse-Hessian factors and a positive-definite Cholesky target.
+        """
+        with jax.enable_x64():
+            N, J = 50, 5
+
+            k0, k1, k2, k3, k4, k5 = jax.random.split(jax.random.key(42), 6)
+            alpha = jnp.abs(jax.random.normal(k0, (N,))) + 0.5
+            S = jax.random.normal(k1, (N, J))
+            Z = S  # curvature condition: s^T z = ||s||^2 > 0
+            beta, gamma = lbfgs_inverse_hessian_factors(S, Z, alpha)
+            position = jax.random.normal(k3, (N,))
+            grad_position = jax.random.normal(k4, (N,))
+
+            num_samples = 4
+            phi, _ = bfgs_sample(
+                k5, num_samples, position, grad_position, alpha, beta, gamma
+            )
+
+            # Reproduce the noise term with the same key to recover mu from phi.
+            u = jax.random.normal(k5, (num_samples,) + (N, 1))
+            Q, R = jnp.linalg.qr(beta / jnp.sqrt(alpha)[:, None], mode="reduced")
+            Id = jnp.identity(R.shape[0])
+            L = jnp.linalg.cholesky(Id + R @ gamma @ R.T)
+            noise = jnp.sqrt(alpha)[:, None] * (Q @ (L - Id) @ (Q.T @ u) + u)
+            mu_from_phi = phi - noise[..., 0]  # (num_samples, N)
+
+            # Dense reference: the pre-PR formula using the O(N²) diag(alpha) intermediate.
+            mu_ref = (
+                position
+                + jnp.diag(alpha) @ grad_position
+                + beta @ gamma @ beta.T @ grad_position
+            )
+            np.testing.assert_allclose(
+                mu_from_phi,
+                jnp.broadcast_to(mu_ref, (num_samples, N)),
+                rtol=1e-10,
+                atol=1e-10,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Obvious memory changes were implemented. For now, `vmap`s in `pathfinder/approximate` are not changed, but making one or both of `logp = -jax.vmap(objective_fn)(phi)` and `elbo, beta, gamma = jax.vmap(path_finder_body_fn)((path_indices, rng_keys))` into `jax.lax.map` with some smart/user-defined batch size might be nice. 

## Related issues / discussions

Addresses the major issues outlined in #1007. 

## Checklist

**General**
- [x] The branch is rebased on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes (`mamba run -n blackjax python -m pytest tests/`)

**Code quality**
- [x] Public functions have docstrings following the [NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Naming follows existing conventions (`logdensity`, `jax.tree.map`, `jax.random.key()`, `jnp.clip(min=, max=)`)
- [x] All new code is JIT-compatible

**New sampler / algorithm** *(skip if not applicable)*
- [ ] There is an open issue discussing this algorithm (use the [sampler proposal template](https://github.com/blackjax-devs/blackjax/issues/new?template=sampler_proposal.yml))
- [ ] Follows the three-layer pattern: `init` / `build_kernel` / `as_top_level_api`
- [ ] Registered in `blackjax/__init__.py`
- [ ] An example notebook has been added or updated

Consider opening a **Draft PR** first if you want early feedback on the design.
