### PR TITLE
Harden date-seeded flake in test_imm_shrinkage_seed_influence_persists_diagonal (300→1000 warmup steps)

### DIFF
--- a/tests/adaptation/test_staged_adaptation.py
+++ b/tests/adaptation/test_staged_adaptation.py
@@ -626,6 +626,9 @@ class StagedAdaptationIMMSeedBehavioralTest(BlackJAXTest):
 
         The assertion tolerates ~5% Monte-Carlo error (house standard) to robustly
         survive variation in the date-derived seed.
+
+        num_steps=1000 (was 300) stabilises the Welford estimate: 300 steps
+        flaked ~13% across date-seeds, 1000 → 0.38% (#989/#1006 flake class).
         """
         logdensity_fn, _ = self._setup_target()
         rng_key = self.next_key()
@@ -645,7 +648,7 @@ class StagedAdaptationIMMSeedBehavioralTest(BlackJAXTest):
             initial_step_size=0.5,
         )
         (_, params_no_shrink), _ = warmup_no_shrink.run(
-            rng_key, jnp.zeros(3), num_steps=300
+            rng_key, jnp.zeros(3), num_steps=1000
         )
         imm_no_shrink = params_no_shrink["inverse_mass_matrix"]
 
@@ -660,7 +663,7 @@ class StagedAdaptationIMMSeedBehavioralTest(BlackJAXTest):
             initial_step_size=0.5,
         )
         (_, params_with_shrink), _ = warmup_with_shrink.run(
-            rng_key, jnp.zeros(3), num_steps=300
+            rng_key, jnp.zeros(3), num_steps=1000
         )
         imm_with_shrink = params_with_shrink["inverse_mass_matrix"]
 


### PR DESCRIPTION
## Problem

`tests/adaptation/test_staged_adaptation.py::StagedAdaptationIMMSeedBehavioralTest::test_imm_shrinkage_seed_influence_persists_diagonal` is a **date-seeded flake**. `BlackJAXTest` seeds `self.key = jax.random.key(int(date.today().strftime("%Y%m%d")))`, so the test's realization rotates daily and crosses its tolerance on some dates. It failed the **JAX-Nightly run on `main`** (and a PR CI run) on 2026-07-23 — same class as the #989 / #1006 adaptation-flake fixes.

## Root cause

The test asserts `dist_with_shrink < 1.05 · dist_no_shrink` (shrinkage keeps the IMM closer to a deliberately-wrong seed, within ~5% MC error). With only **300** warmup steps, the Welford IMM estimate carries enough Monte-Carlo variance that the ordering flips on a meaningful fraction of date-seeds.

## Measurement

Empirical flake rate over **1,827 date-seeds (2024-01-01 → 2028-12-31)**, float32 (matching CI — the suite does not enable x64 globally):

| `num_steps` | flake rate |
|---|---|
| 300 (baseline) | **13.03%** (238/1827) |
| 600 | 2.63% |
| **1000 (this PR)** | **0.38%** (7/1827) |
| 1500 | 0.05% |
| 2000 | 0.00% |

`num_steps=1000` is the smallest value under a <1% margin (34× reduction from baseline), and comfortably under the ~5% acceptance criterion. The extra warmup is ~3.3× (still sub-second for this 3-D Gaussian target).

## Validation

- The previously-failing seed **20260723** now passes: `pytest ...::test_imm_shrinkage_seed_influence_persists_diagonal` → **passed** (float32).
- pre-commit clean.

## Scope notes

- **Test-only change** — no library code touched; the shrinkage behaviour and the assertion are unchanged, only the warmup length that stabilises the estimate.
- **`test_svgd::test_recover_posterior`** also date-flakes but at **0.60%** (within the ≤5% bar) and is **left untouched**.
- Both tests are float32-rounding-sensitive (x64 makes them pass) — this PR keeps the default-precision behaviour and fixes the flake via statistical power rather than forcing x64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)