### PR TITLE
Separate meta-adaptation evidence from global exploration

### DIFF
--- a/blackjax/adaptation/meta/_detection.py
+++ b/blackjax/adaptation/meta/_detection.py
@@ -83,9 +83,18 @@ def _between_chain_detection(
 ) -> tuple[Array, Array, Array]:
     """Between-chain detection statistic via the M×M Gram.
 
-    Computes T = (n/(M−1))·ZᵀZ (rank ≤ M−1) via the M×M Gram ZZᵀ.
-    T's eigenvalues are the per-direction Gelman–Rubin B/W ratios (R̂²).
-    Null distribution has top eigenvalue → (1+√(d/(M−1)))² (the detection edge).
+    Computes T = (n/(M−1))·ZᵀZ (rank ≤ M−1) via the M×M Gram ZZᵀ,
+    where Z contains chain-mean deviations standardized by the diagonal of the
+    pooled within-chain covariance.  Equivalently,
+    T = D_W^{-1/2} B D_W^{-1/2}, where
+    B = n/(M−1) Σ_m (μ_m−μ̄)(μ_m−μ̄)ᵀ and D_W = diag(W).
+
+    T's eigenvalues measure diagonal-within-standardized between-chain scatter.
+    They are generally neither raw directional B/W ratios nor R̂²: the full
+    within-chain covariance is not used for whitening, and R̂² additionally
+    combines within- and between-chain terms with their finite-n weights.
+    Under the iid null, T's top eigenvalue approaches
+    (1+√(d/(M−1)))² (the detection edge).
 
     Parameters
     ----------
@@ -103,7 +112,8 @@ def _between_chain_detection(
     T_eigenvalues
         Shape ``(M,)`` — eigenvalues of T in descending order (last M−rank ≈ 0).
     V_top
-        Shape ``(d, M−1)`` — top M−1 directions of T in whitened space (columns).
+        Shape ``(d, min(M−1, d))`` — leading directions of T in whitened
+        space (columns).
     f1
         float32 scalar — collinearity score: fraction of total between-chain
         scatter variance in the leading direction (→1 for genuine slow dir,

--- a/blackjax/adaptation/meta/builders.py
+++ b/blackjax/adaptation/meta/builders.py
@@ -721,9 +721,9 @@ def build_multi_chain_meta_core(
         # is mutually exclusive with defer (confirmed_split resets flag_count → deferred=False).
         #
         # Non-monotone: recomputed each window; if mode flags clear, defer resets to False.
-        # Impossible combo (route=low_rank ∧ deferred ∧ detection_branch=between_means)
-        # remains impossible: T-escalation requires t_unimodality=True → any_mode_flag
-        # drives flag_count to 0 via the False branch → confirmed_split=False. ✓
+        # T escalation and T deferral are mutually exclusive within this update.
+        # ``detection_branch`` is historical, however, so a between-means route
+        # selected in an earlier window may legally coexist with later deferral.
         multimodality_signal = any_mode_flag | ~is_unimodal
         new_flag_count = jnp.where(
             multimodality_signal,

--- a/blackjax/adaptation/meta/verdict.py
+++ b/blackjax/adaptation/meta/verdict.py
@@ -32,6 +32,7 @@ from blackjax.adaptation.meta._calibration import (
     _DETECTION_BRANCH_POOLED_WITHIN,
     _LAM_NONTRIVIAL_TOL,
     _MC_COLLINEARITY_TOL,
+    _MC_UNIMODALITY_CONFIRM_WINDOWS,
     _R2_DEFERRED,
     _R2_FULL_AFFINE,
     _R2_PROJECTED,
@@ -92,13 +93,10 @@ def extract_meta_verdict(
     else:
         route = "diagonal"
 
-    # Confidence
+    # Confidence is scoped narrowly to historical structured-metric support.
+    # It is not evidence of ensemble equilibrium or global exploration.
     s_gap_valid = not np.isnan(s_gap)
-    confidence = (
-        "high"
-        if (has_esc and not r2_nan and r2 >= _R_MIN and s_gap_valid and s_gap >= _S_MIN)
-        else "low"
-    )
+    confidence = "high" if has_esc else "low"
 
     # Exit reason and advisory budget return
     airm_converged = (airm_v_prev < _AIRM_VELOCITY_TOL) and (
@@ -134,12 +132,29 @@ def extract_meta_verdict(
         _R2_FULL_AFFINE: "full_affine",
     }.get(mode_int, "deferred")
     marginal_s_gap = (not has_esc) and s_gap_valid and (_S_MIN <= s_gap < 2.0 * _S_MIN)
+    evidence_completed = s_gap_valid or not r2_nan
+    metric_route_status = (
+        "historical_gate_pass"
+        if has_esc
+        else "not_selected"
+        if evidence_completed
+        else "unassessed"
+    )
+    handoff = "reparameterize" if route == "reparam_suggested" else "none"
     flags = {
         "reparam_hint": route == "reparam_suggested",
         "marginal_s_gap": marginal_s_gap,
         "wall_cost_discount": k > 0,
         "high_d_r2_mode": high_d_r2_mode,
         "mode_coverage": "single_chain_uncertified",
+        "metric_route_status": metric_route_status,
+        "metric_route_basis": "single_chain_spectrum" if has_esc else "none",
+        "metric_scope": "route_conditional" if has_esc else "unassessed",
+        "observed_ensemble_evidence": "unassessed",
+        "global_exploration": "not_established",
+        "handoff": handoff,
+        "confidence_scope": "historical_route_selection_heuristic",
+        "initialization_design": "not_recorded_by_controller",
         # nominal_rank is the pre-filter count from the spectrum rank selector;
         # effective_rank (the top-level field) is the deployed count from
         # the Fisher metric's lam array.  Both are provided for diagnostics.
@@ -192,9 +207,10 @@ def extract_multi_chain_verdict(
     Returns
     -------
     MetaAdaptationVerdict
-        Verdict with multi-chain–specific flags: ``n_chains``,
-        ``chain_collinearity``, ``unimodality_gate``, ``deferred_to_ensemble``,
-        and ``mode_coverage="multi_chain_certified"`` when all gates passed.
+        Verdict with multi-chain–specific flags separating historical metric
+        route selection, observed ensemble disagreement, global exploration, and
+        any downstream handoff.  Multi-chain warmup never certifies global mode
+        coverage.
     """
     import numpy as np
 
@@ -213,6 +229,7 @@ def extract_multi_chain_verdict(
     chain_collinearity_raw = float(np.asarray(final_state.chain_collinearity))
     unimodality_passed_raw = bool(np.asarray(final_state.unimodality_passed))
     deferred_raw = bool(np.asarray(final_state.deferred_to_ensemble))
+    unimodality_flag_count_raw = int(np.asarray(final_state.unimodality_flag_count))
     n_chains_actual: int = final_state.draws_buffer.shape[0]  # static
 
     lam_np = np.asarray(final_state.inverse_mass_matrix.lam)
@@ -229,16 +246,14 @@ def extract_multi_chain_verdict(
     else:
         route = "diagonal"
 
-    # Confidence — collinearity gate replaces s_gap stability for multi-chain path
+    # Current-window collinearity is a diagnostic, not historical evidence for
+    # every escalation branch.  In particular, the pooled-within branch does not
+    # require the between-means collinearity gate.
     collinearity_valid = not np.isnan(chain_collinearity_raw)
     collinearity_passed = (
         collinearity_valid and chain_collinearity_raw >= _MC_COLLINEARITY_TOL
     )
-    confidence = (
-        "high"
-        if (has_esc and not r2_nan and r2 >= _R_MIN and collinearity_passed)
-        else "low"
-    )
+    confidence = "high" if has_esc else "low"
 
     # Exit reason and advisory budget return
     airm_converged = (airm_v_prev < _AIRM_VELOCITY_TOL) and (
@@ -270,27 +285,8 @@ def extract_multi_chain_verdict(
         _R2_FULL_AFFINE: "full_affine",
     }.get(mode_int, "deferred")
 
-    # "need_more_chains": non-escalation with collinearity below threshold
-    # (magnitude may have been present but gate didn't pass; more chains or
-    # better-dispersed starts would help).
-    spike_marginal = (not has_esc) and (nominal_rank > 0) and (not collinearity_passed)
-
-    # mode_coverage: multi_chain_certified iff collinearity gate passed
-    mode_coverage = (
-        "multi_chain_certified"
-        if (has_esc and collinearity_passed)
-        else "multi_chain_uncertified"
-        if n_chains_actual > 1
-        else "single_chain_uncertified"
-    )
-
-    # start_dispersion_adequacy: non-escalation is one-sided-safe (conservative);
-    # under-dispersed starts can miss slow directions but never over-escalate.
-    start_dispersion_adequacy = (
-        "adequate_if_overdispersed" if not has_esc else "not_applicable"
-    )
-
-    # W-branch/T-branch diagnostic fields
+    # W-branch/T-branch diagnostic fields.  The branch is historical: it records
+    # the most recent escalation branch, while the other diagnostics are current.
     within_lam1_raw = float(np.asarray(final_state.within_lam1))
     chain_consistency_psi_raw = float(np.asarray(final_state.chain_consistency_psi))
     r1_top_raw = float(np.asarray(final_state.r1_top))
@@ -303,18 +299,89 @@ def extract_multi_chain_verdict(
     }
     detection_branch_name = _BRANCH_NAMES.get(detection_branch_raw, "unknown")
 
+    # "need_more_chains": non-escalation with collinearity below threshold
+    # (magnitude may have been present but gate didn't pass; more chains or
+    # better-dispersed starts would help).
+    spike_marginal = (not has_esc) and (nominal_rank > 0) and (not collinearity_passed)
+
+    # These are descriptive statuses for the observed ensemble, not calibrated
+    # equilibrium tests.  A warning needs two consecutive windows before it is
+    # called persistent; a quiet window never establishes global exploration.
+    persistent_disagreement = (
+        deferred_raw or unimodality_flag_count_raw >= _MC_UNIMODALITY_CONFIRM_WINDOWS
+    )
+    disagreement_warning = (
+        persistent_disagreement
+        or not unimodality_passed_raw
+        or unimodality_flag_count_raw > 0
+    )
+    observed_ensemble_evidence = (
+        "persistent_disagreement_signal"
+        if collinearity_valid and persistent_disagreement
+        else "disagreement_warning"
+        if collinearity_valid and disagreement_warning
+        else "no_disagreement_detected"
+        if collinearity_valid
+        else "unassessed"
+    )
+
+    metric_route_status = (
+        "historical_gate_pass"
+        if has_esc
+        else "not_selected"
+        if collinearity_valid
+        else "unassessed"
+    )
+    within_chain_conditional_metric = (
+        has_esc
+        and detection_branch_name
+        in {
+            "pooled_within",
+            "both",
+        }
+        and disagreement_warning
+    )
+    metric_scope = (
+        "within_chain_conditional"
+        if within_chain_conditional_metric
+        else "route_conditional"
+        if has_esc
+        else "unassessed"
+    )
+    handoff = (
+        "population"
+        if deferred_raw
+        else "reparameterize"
+        if route == "reparam_suggested"
+        else "none"
+    )
+
+    # Warmup diagnostics neither record the initialization protocol nor establish
+    # that the ensemble explored every relevant region.
+    mode_coverage = (
+        "multi_chain_uncertified" if n_chains_actual > 1 else "single_chain_uncertified"
+    )
+
     flags = {
         "reparam_hint": route == "reparam_suggested",
         "marginal_s_gap": False,  # s_gap not primary signal in multi-chain path
         "wall_cost_discount": k > 0,
         "high_d_r2_mode": high_d_r2_mode,
         "mode_coverage": mode_coverage,
+        "metric_route_status": metric_route_status,
+        "metric_route_basis": detection_branch_name if has_esc else "none",
+        "metric_scope": metric_scope,
+        "observed_ensemble_evidence": observed_ensemble_evidence,
+        "global_exploration": "not_established",
+        "handoff": handoff,
+        "confidence_scope": "historical_route_selection_heuristic",
         "nominal_rank": nominal_rank,
         # Multi-chain specific
         "n_chains": n_chains_actual,
         "chain_collinearity": chain_collinearity_raw,
         "need_more_chains": spike_marginal,
-        "start_dispersion_adequacy": start_dispersion_adequacy,
+        "start_dispersion_adequacy": "not_assessed",
+        "initialization_design": "not_recorded_by_controller",
         "unimodality_gate": "pass" if unimodality_passed_raw else "flag",
         "deferred_to_ensemble": deferred_raw,
         "pooled_draws_by_window": pooled_draws_by_window,

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -53,7 +53,7 @@ def potential_scale_reduction(
     -----
     The diagnostic is computed by:
 
-    .. math:: \\hat{R} = \\frac{\\hat{V}}{W}
+    .. math:: \\hat{R} = \\sqrt{\\frac{\\hat{V}}{W}}
 
     where :math:`W` is the within-chain variance and :math:`\\hat{V}` is the posterior variance
     estimate for the pooled traces. This is the potential scale reduction factor, which

--- a/tests/adaptation/test_meta_builders_e2e.py
+++ b/tests/adaptation/test_meta_builders_e2e.py
@@ -17,7 +17,7 @@
 Coverage:
 - TestEscalationDecisionTable, TestStructuralE2ESmoke, TestRecovershClassical,
   TestDefaultWiringAndBudgetWarning: single-chain core tests.
-- TestImpossibleComboInvariant, TestNewStateFieldsPopulated, TestSharedEpsilonDA,
+- TestBranchCompatibilityInvariants, TestNewStateFieldsPopulated, TestSharedEpsilonDA,
   TestWBranchE2ESmoke, TestEndToEndEscalation: multi-chain e2e tests.
 """
 import warnings
@@ -32,6 +32,7 @@ from blackjax.adaptation.meta import (
     build_meta_adaptation_core,
     build_multi_chain_meta_core,
     extract_meta_verdict,
+    extract_multi_chain_verdict,
 )
 from blackjax.adaptation.meta._calibration import (
     _ASSUMED_AVG_LEAPFROGS_PER_STEP,
@@ -66,6 +67,7 @@ from tests.adaptation._meta_fixtures import (
     _make_mc_even_spread,
     _make_mc_isotropic,
     _make_mc_split_means,
+    _make_overdispersed_slow_chains,
 )
 from tests.fixtures import BlackJAXTest
 
@@ -1118,12 +1120,12 @@ class TestDefaultWiringAndBudgetWarning(BlackJAXTest):
             warmup.run(key, pos, num_steps=50)
 
 
-class TestImpossibleComboInvariant(BlackJAXTest):
-    """Impossible combo + legal coexistence invariants from the scoped latch rule.
+class TestBranchCompatibilityInvariants(BlackJAXTest):
+    """Regression checks for branch-local exclusion and legal coexistence.
 
-    The ONLY impossible combo: escalated=True AND detection_branch=between_means
-    AND deferred=True.  (T-branch escalation requires confirmed_split=True, but
-    confirmed_split=True ⟹ new_deferred=False algebraically.)
+    A T-branch escalation and deferral cannot fire in the same window under the
+    current latch.  Because ``detection_branch`` is historical, that local fact
+    must not be promoted to a theorem about all later windows.
 
     Cross-branch coexistence IS LEGAL: W-escalation (pooled_within) + T-defer.
     """
@@ -1218,14 +1220,29 @@ class TestImpossibleComboInvariant(BlackJAXTest):
             f"(W fired in window 1 -- T never escalated) -- got {branch}",
         )
 
-    def test_impossible_combo_never_occurs_over_windows(self):
-        """Three-window scan: escalated+between_means+deferred NEVER appears (F5).
+        verdict = extract_multi_chain_verdict(
+            result, max_grad_budget=80000, num_warmup_steps=2 * n
+        )
+        self.assertEqual(verdict.route, "low_rank")
+        self.assertEqual(verdict.flags["metric_route_status"], "historical_gate_pass")
+        self.assertEqual(verdict.flags["metric_route_basis"], "pooled_within")
+        self.assertEqual(verdict.flags["metric_scope"], "within_chain_conditional")
+        self.assertEqual(
+            verdict.flags["observed_ensemble_evidence"],
+            "persistent_disagreement_signal",
+        )
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+        self.assertEqual(verdict.flags["handoff"], "population")
+        self.assertEqual(verdict.flags["mode_coverage"], "multi_chain_uncertified")
+
+    def test_repeated_split_fixture_does_not_t_escalate_while_deferred(self):
+        """Repeated split evidence does not trigger T escalation in this fixture.
 
         Runs split-means draws through 3 consecutive windows.  Each window's
-        output is checked: IF has_escalated AND detection_branch=between_means
-        THEN deferred must be False.  The test is structurally rigorous because
-        we RUN windows until between_means escalation could reasonably occur
-        (not just checking a never-reached condition).
+        output checks that this persistent disagreement fixture never reports
+        simultaneous T-route support and deferral.  This is a fixture-level
+        regression check, not a claim about a historical T route followed by
+        different evidence in a later window.
         """
         M, n, d = 8, 150, 10
         core = build_multi_chain_meta_core(max_grad_budget=80000, n_chains=M)
@@ -1248,6 +1265,47 @@ class TestImpossibleComboInvariant(BlackJAXTest):
                     f"Window {window + 1}: impossible combo "
                     f"between_means+escalated+deferred occurred",
                 )
+
+    def test_historical_t_escalation_can_defer_on_later_split(self):
+        """A prior T-route selection may coexist with later split evidence."""
+        M, n, d = 8, 500, 20
+        core = build_multi_chain_meta_core(max_grad_budget=120000, n_chains=M)
+
+        draws_slow, grads_slow = _make_overdispersed_slow_chains(
+            d,
+            n,
+            M,
+            slow_offset_scale=5.0,
+            within_chain_noise=0.1,
+            seed=210,
+        )
+        state = _fill_mc_state(core.init(d), draws_slow, grads_slow)
+        state = core.final(state)
+        self.assertTrue(bool(np.asarray(state.has_escalated)))
+        self.assertEqual(
+            int(np.asarray(state.detection_branch)),
+            _DETECTION_BRANCH_BETWEEN_MEANS,
+        )
+
+        draws_split, grads_split = _make_mc_split_means(
+            M, n, d, split_scale=10.0, seed=45
+        )
+        for _ in range(2):
+            state = _fill_mc_state(state, draws_split, grads_split)
+            state = core.final(state)
+
+        self.assertTrue(bool(np.asarray(state.has_escalated)))
+        self.assertTrue(bool(np.asarray(state.deferred_to_ensemble)))
+        self.assertEqual(
+            int(np.asarray(state.detection_branch)),
+            _DETECTION_BRANCH_BETWEEN_MEANS,
+        )
+
+        verdict = extract_multi_chain_verdict(
+            state, max_grad_budget=120000, num_warmup_steps=3 * n
+        )
+        self.assertEqual(verdict.route, "low_rank")
+        self.assertEqual(verdict.flags["handoff"], "population")
 
 
 class TestNewStateFieldsPopulated(BlackJAXTest):

--- a/tests/adaptation/test_meta_detection.py
+++ b/tests/adaptation/test_meta_detection.py
@@ -470,7 +470,7 @@ class TestMultiChainGate(BlackJAXTest):
 
         After running overdispersed slow-chain data through final():
         - Non-escalated state: mode_coverage = 'multi_chain_uncertified' (M > 1)
-        - Escalated state: mode_coverage = 'multi_chain_certified'
+        - Escalated state: mode_coverage remains 'multi_chain_uncertified'
         - start_dispersion_adequacy and unimodality_gate keys are present
         """
         d, n, M = 20, 500, 8
@@ -502,7 +502,7 @@ class TestMultiChainGate(BlackJAXTest):
             "Non-escalated M>1 verdict: mode_coverage should be 'multi_chain_uncertified'",
         )
 
-        # Overdispersed slow chains → escalation → multi_chain_certified
+        # Overdispersed slow chains may support a metric, but never certify coverage.
         draws_ov, grads_ov = _make_overdispersed_slow_chains(
             d, n, M, slow_offset_scale=5.0, seed=221
         )
@@ -515,8 +515,8 @@ class TestMultiChainGate(BlackJAXTest):
         if bool(np.asarray(state_esc.has_escalated)):
             self.assertEqual(
                 verdict_esc.flags["mode_coverage"],
-                "multi_chain_certified",
-                "Escalated overdispersed verdict should be 'multi_chain_certified'",
+                "multi_chain_uncertified",
+                "Metric escalation must not certify global mode coverage",
             )
 
     def test_mode_split_no_false_escalate(self):
@@ -612,7 +612,7 @@ class TestMultiChainGate(BlackJAXTest):
 
         Checks:
         - has_escalated = False (conservative)
-        - start_dispersion_adequacy flag = 'adequate_if_overdispersed' (honesty layer)
+        - start_dispersion_adequacy flag = 'not_assessed'
         - mode_coverage = 'multi_chain_uncertified' (M > 1, no escalation)
         """
         d, n, M = 20, 500, 8
@@ -635,9 +635,9 @@ class TestMultiChainGate(BlackJAXTest):
         )
         self.assertEqual(
             verdict.flags["start_dispersion_adequacy"],
-            "adequate_if_overdispersed",
+            "not_assessed",
             "Non-escalation verdict must report start_dispersion_adequacy = "
-            "'adequate_if_overdispersed' (not a certificate of diagonal sufficiency)",
+            "'not_assessed' because the controller does not record the initialization design",
         )
         self.assertEqual(
             verdict.flags["mode_coverage"],

--- a/tests/adaptation/test_meta_verdict.py
+++ b/tests/adaptation/test_meta_verdict.py
@@ -16,6 +16,7 @@
 Coverage:
 - TestEffectiveRankHonesty: effective_rank vs nominal_rank reporting.
 - TestExtractMultiChainVerdictNewFields: v2.1 diagnostic flags in multi-chain verdict.
+- TestEvidenceSemantics: one-sided metric, equilibrium, and exploration evidence.
 """
 import jax
 import jax.numpy as jnp
@@ -26,6 +27,10 @@ from blackjax.adaptation.meta import (
     build_multi_chain_meta_core,
     extract_meta_verdict,
     extract_multi_chain_verdict,
+)
+from blackjax.adaptation.meta._calibration import (
+    _DETECTION_BRANCH_BETWEEN_MEANS,
+    _DETECTION_BRANCH_POOLED_WITHIN,
 )
 from tests.adaptation._meta_fixtures import _fill_mc_state, _make_mc_deep_spread
 from tests.fixtures import BlackJAXTest
@@ -203,3 +208,173 @@ class TestExtractMultiChainVerdictNewFields(BlackJAXTest):
             state, max_grad_budget=40000, num_warmup_steps=1000
         )
         self.assertEqual(verdict.flags["detection_branch"], "none")
+
+
+class TestEvidenceSemantics(BlackJAXTest):
+    """Verdicts separate route history, observed disagreement, and exploration."""
+
+    @staticmethod
+    def _single_verdict(state):
+        return extract_meta_verdict(state, max_grad_budget=40000, num_warmup_steps=1000)
+
+    @staticmethod
+    def _multi_verdict(state):
+        return extract_multi_chain_verdict(
+            state, max_grad_budget=40000, num_warmup_steps=1000
+        )
+
+    def test_single_chain_init_is_unassessed(self):
+        state = build_meta_adaptation_core(40000).init(10)
+        verdict = self._single_verdict(state)
+
+        self.assertEqual(verdict.confidence, "low")
+        self.assertEqual(verdict.flags["metric_route_status"], "unassessed")
+        self.assertEqual(verdict.flags["metric_route_basis"], "none")
+        self.assertEqual(verdict.flags["metric_scope"], "unassessed")
+        self.assertEqual(verdict.flags["observed_ensemble_evidence"], "unassessed")
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+        self.assertEqual(verdict.flags["handoff"], "none")
+        self.assertEqual(
+            verdict.flags["initialization_design"], "not_recorded_by_controller"
+        )
+
+    def test_single_chain_reparameterization_handoff_after_evidence(self):
+        state = (
+            build_meta_adaptation_core(40000)
+            .init(10)
+            ._replace(
+                s_gap_curr=jnp.array(3.0, dtype=jnp.float32),
+                r2_latest=jnp.array(0.1, dtype=jnp.float32),
+            )
+        )
+        verdict = self._single_verdict(state)
+
+        self.assertEqual(verdict.route, "reparam_suggested")
+        self.assertEqual(verdict.flags["metric_route_status"], "not_selected")
+        self.assertEqual(verdict.flags["metric_scope"], "unassessed")
+        self.assertEqual(verdict.flags["handoff"], "reparameterize")
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+
+    def test_single_chain_historical_escalation_supports_only_metric(self):
+        state = (
+            build_meta_adaptation_core(40000)
+            .init(10)
+            ._replace(
+                has_escalated=jnp.array(True, dtype=jnp.bool_),
+                escalation_rank=jnp.array(1, dtype=jnp.int32),
+            )
+        )
+        verdict = self._single_verdict(state)
+
+        self.assertEqual(verdict.confidence, "high")
+        self.assertEqual(
+            verdict.flags["confidence_scope"],
+            "historical_route_selection_heuristic",
+        )
+        self.assertEqual(verdict.flags["metric_route_status"], "historical_gate_pass")
+        self.assertEqual(verdict.flags["metric_route_basis"], "single_chain_spectrum")
+        self.assertEqual(verdict.flags["metric_scope"], "route_conditional")
+        self.assertEqual(verdict.flags["observed_ensemble_evidence"], "unassessed")
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+
+    def test_multi_chain_init_is_unassessed_and_never_certified(self):
+        state = build_multi_chain_meta_core(40000, n_chains=8).init(10)
+        verdict = self._multi_verdict(state)
+
+        self.assertEqual(verdict.confidence, "low")
+        self.assertEqual(verdict.flags["metric_route_status"], "unassessed")
+        self.assertEqual(verdict.flags["metric_scope"], "unassessed")
+        self.assertEqual(verdict.flags["observed_ensemble_evidence"], "unassessed")
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+        self.assertEqual(verdict.flags["mode_coverage"], "multi_chain_uncertified")
+        self.assertEqual(verdict.flags["start_dispersion_adequacy"], "not_assessed")
+        self.assertEqual(
+            verdict.flags["initialization_design"], "not_recorded_by_controller"
+        )
+
+    def test_observed_disagreement_scopes_pooled_metric_to_within_chain(self):
+        state = (
+            build_multi_chain_meta_core(40000, n_chains=8)
+            .init(10)
+            ._replace(
+                has_escalated=jnp.array(True, dtype=jnp.bool_),
+                escalation_rank=jnp.array(1, dtype=jnp.int32),
+                chain_collinearity=jnp.array(0.4, dtype=jnp.float32),
+                unimodality_passed=jnp.array(True, dtype=jnp.bool_),
+                unimodality_flag_count=jnp.array(1, dtype=jnp.int32),
+                deferred_to_ensemble=jnp.array(True, dtype=jnp.bool_),
+                detection_branch=jnp.array(
+                    _DETECTION_BRANCH_POOLED_WITHIN, dtype=jnp.int32
+                ),
+            )
+        )
+        verdict = self._multi_verdict(state)
+
+        self.assertEqual(verdict.route, "low_rank")
+        self.assertEqual(verdict.confidence, "high")
+        self.assertEqual(verdict.flags["metric_route_status"], "historical_gate_pass")
+        self.assertEqual(verdict.flags["metric_route_basis"], "pooled_within")
+        self.assertEqual(verdict.flags["metric_scope"], "within_chain_conditional")
+        self.assertEqual(
+            verdict.flags["observed_ensemble_evidence"],
+            "persistent_disagreement_signal",
+        )
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+        self.assertEqual(verdict.flags["handoff"], "population")
+        self.assertEqual(verdict.flags["mode_coverage"], "multi_chain_uncertified")
+
+    def test_no_observed_disagreement_is_only_descriptive(self):
+        state = (
+            build_multi_chain_meta_core(40000, n_chains=8)
+            .init(10)
+            ._replace(
+                has_escalated=jnp.array(True, dtype=jnp.bool_),
+                escalation_rank=jnp.array(1, dtype=jnp.int32),
+                chain_collinearity=jnp.array(0.9, dtype=jnp.float32),
+                unimodality_passed=jnp.array(True, dtype=jnp.bool_),
+                unimodality_flag_count=jnp.array(0, dtype=jnp.int32),
+                deferred_to_ensemble=jnp.array(False, dtype=jnp.bool_),
+                detection_branch=jnp.array(
+                    _DETECTION_BRANCH_BETWEEN_MEANS, dtype=jnp.int32
+                ),
+            )
+        )
+        verdict = self._multi_verdict(state)
+
+        self.assertEqual(verdict.flags["metric_route_status"], "historical_gate_pass")
+        self.assertEqual(verdict.flags["metric_route_basis"], "between_means")
+        self.assertEqual(verdict.flags["metric_scope"], "route_conditional")
+        self.assertEqual(
+            verdict.flags["observed_ensemble_evidence"],
+            "no_disagreement_detected",
+        )
+        self.assertEqual(verdict.flags["global_exploration"], "not_established")
+        self.assertEqual(verdict.flags["handoff"], "none")
+        self.assertEqual(verdict.flags["mode_coverage"], "multi_chain_uncertified")
+
+    def test_historical_between_route_can_coexist_with_later_defer(self):
+        """A historical T-route selection does not constrain a later window."""
+        state = (
+            build_multi_chain_meta_core(40000, n_chains=8)
+            .init(10)
+            ._replace(
+                has_escalated=jnp.array(True, dtype=jnp.bool_),
+                escalation_rank=jnp.array(1, dtype=jnp.int32),
+                chain_collinearity=jnp.array(0.9, dtype=jnp.float32),
+                unimodality_passed=jnp.array(False, dtype=jnp.bool_),
+                unimodality_flag_count=jnp.array(2, dtype=jnp.int32),
+                deferred_to_ensemble=jnp.array(True, dtype=jnp.bool_),
+                detection_branch=jnp.array(
+                    _DETECTION_BRANCH_BETWEEN_MEANS, dtype=jnp.int32
+                ),
+            )
+        )
+
+        verdict = self._multi_verdict(state)
+
+        self.assertEqual(verdict.flags["metric_route_basis"], "between_means")
+        self.assertEqual(
+            verdict.flags["observed_ensemble_evidence"],
+            "persistent_disagreement_signal",
+        )
+        self.assertEqual(verdict.flags["handoff"], "population")


### PR DESCRIPTION
## Description

Meta-adaptation verdicts currently conflate three different claims: a historical structured-metric route was selected, the current ensemble does or does not show disagreement, and global exploration has been established. In particular, a multi-chain verdict can report positive mode coverage even when a later window defers to a population method.

This change makes those claims explicit and one-sided:

- report the historical metric-route status and its evidence basis;
- state whether the fitted metric is route-conditional or within-chain-conditional;
- report observed ensemble disagreement separately from global exploration;
- remove positive mode-coverage certification, since the controller does not observe enough information to establish it;
- expose downstream handoffs to reparameterization or population sampling; and
- treat initialization dispersion as unassessed because it is not recorded by the controller.

It also corrects the documentation of the between-chain statistic: it is diagonal-within-standardized between-chain scatter, not a raw directional variance ratio or split-R̂. The controller's gates, thresholds, latches, metric updates, and sampler arithmetic are unchanged.

Regression coverage includes a historical between-means route followed by later population deferral, which is a legal state across different windows.

## Related issues / discussions

None.

## Validation

- `uv run pre-commit run --all-files`
- `JAX_PLATFORM_NAME=cpu uv run pytest tests/adaptation/test_meta_verdict.py tests/adaptation/test_meta_detection.py tests/adaptation/test_meta_builders_e2e.py -q --benchmark-disable` — 102 passed
- `JAX_PLATFORM_NAME=cpu uv run pytest -n 2 -q --benchmark-disable --cov=blackjax --cov-report=xml --cov-report=term tests` — 1,788 passed, 1 skipped, 36 subtests passed; 97% coverage

## Checklist

**General**
- [x] The branch is rebased on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes

**Code quality**
- [x] Public functions have docstrings following the NumPy style guide
- [x] Naming follows existing conventions
- [x] All new code is JIT-compatible

**New sampler / algorithm** *(not applicable)*
