### PR TITLE
fix(gist): use momentum pairing in the no-U-turn condition (affine equivariance)

### DIFF
--- a/blackjax/mcmc/gist_trajectory_length.py
+++ b/blackjax/mcmc/gist_trajectory_length.py
@@ -113,16 +113,16 @@ def num_steps_to_uturn(
     -- no tree/doubling data structure, no recursion, no sub-U-turn
     bookkeeping, unlike NUTS's ``1sub-U-turn`` criterion (section 3.5).
 
-    The dot product uses the **metric-corrected velocity**
-    ``M^{-1} rho`` (the gradient of the kinetic energy) rather than the raw
-    momentum, so the criterion generalizes correctly to a non-identity
-    ``inverse_mass_matrix`` (diagonal / dense / low-rank). This is eq. 33's
-    position-displacement-times-velocity condition, a *different* turning
-    criterion from NUTS's momentum-sum ``check_turning`` -- the analogy to
-    ``metrics.gaussian_euclidean``'s ``check_turning`` is only in *how* it
-    substitutes ``M^{-1} rho`` for raw momentum in a dot product, not that
-    the two criteria coincide. This changes no formula for the
-    identity-metric case the paper's own experiments use.
+    The dot product pairs the position displacement with the **raw momentum**
+    ``rho`` (GIST paper eq. 33), so the criterion generalizes correctly to
+    a non-identity ``inverse_mass_matrix`` (diagonal / dense / low-rank) in
+    an affine-equivariant manner: with p ~ N(0, G^-1) and K(p) = ½ pᵀGp,
+    whitening φ = G^{-1/2}θ and p_φ = G^{1/2}p gives (Δθ)ᵀp = Δφᵀp_φ,
+    which is exactly invariant under any change of basis G. This is a
+    *different* criterion from NUTS's momentum-sum ``check_turning``, which
+    uses the momentum sum (not position displacement) in the pairing. This
+    changes no formula for the identity-metric case the paper's own
+    experiments use.
 
     ``max_num_steps`` is a hard cap, exactly analogous to NUTS's
     ``max_num_doublings`` (except here it bounds a *linear* rollout, not
@@ -149,7 +149,6 @@ def num_steps_to_uturn(
     ``uturn_fn(state: IntegratorState, logdensity_fn) -> Array``, the
     (possibly capped) number of leapfrog steps to the no-return condition.
     """
-    velocity_fn = jax.grad(metric.kinetic_energy)
 
     def uturn_fn(state: IntegratorState, logdensity_fn: Callable) -> Array:
         symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
@@ -163,8 +162,8 @@ def num_steps_to_uturn(
             n, current, _ = carry
             nxt = symplectic_integrator(current, step_size)
             delta = ravel_pytree(nxt.position)[0] - theta0
-            velocity, _ = ravel_pytree(velocity_fn(nxt.momentum, nxt.position))
-            no_return = jnp.dot(delta, velocity) < 0.0
+            momentum, _ = ravel_pytree(nxt.momentum)
+            no_return = jnp.dot(delta, momentum) < 0.0
             return n + 1, nxt, no_return
 
         n_final, _, _ = jax.lax.while_loop(

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -120,7 +120,6 @@ class _PartialPreconditioningFixture(NamedTuple):
     """
 
     dim: int
-    kappa: float
     kappa_res: float
     step_size: float
     metric: metrics.Metric
@@ -171,7 +170,6 @@ def _partial_preconditioning_fixture():
 
     return _PartialPreconditioningFixture(
         dim=d,
-        kappa=float(np.linalg.cond(Sigma)),
         kappa_res=float(residual_eigvals.max() / residual_eigvals.min()),
         step_size=step_size,
         metric=metrics.default_metric(jnp.asarray(np.diag(Sigma))),

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -239,71 +239,81 @@ class RegressionNonIdentityMetricTest(BlackJAXTest):
 
     The no-U-turn condition must pair position displacement with raw momentum
     (not metric-corrected velocity) to be affine-equivariant. With p ~ N(0, G^-1),
-    whitening φ = G^{-1/2}θ and p_φ = G^{1/2}p gives (Δθ)ᵀp = Δφᵀp_φ, which
-    is exactly invariant under change of basis G.
+    whitening φ = Σ^{-1/2}θ and p_φ = Σ^{1/2}p gives (Δθ)ᵀp = Δφᵀp_φ, which
+    is EXACTLY invariant under any change of basis (i.e., under metric changes).
 
-    This test runs the same Gaussian target in two forms:
-    1. With a non-identity anisotropic mass matrix Σ
-    2. Whitened version with G = I (equivalent problem in rotated coordinates)
-
-    The no-U-turn step counts must agree (within the rounding of capping).
-    Under the old velocity-pairing code, they diverge.
+    This test verifies that num_steps_to_uturn behaves consistently when the
+    metric parameter changes, by using a correlated target Σ and a partial
+    preconditioner G = diag(Σ). This leaves residual anisotropy κ_res ≈ 900
+    and mirrors real diagonal window adaptation. The test demonstrates that
+    the corrected momentum-pairing form computes U-turns deterministically,
+    independent of the specific metric parameterization (a key requirement
+    for affine equivariance).
     """
 
-    def test_uturn_invariant_to_whitening(self):
-        # Anisotropic Gaussian: Σ = [[2.0, 1.2], [1.2, 1.0]], κ_res ≈ 72
-        # (high anisotropy; the velocity form biases SHORT proportionally).
-        Sigma = jnp.array([[2.0, 1.2], [1.2, 1.0]])
-        Sinv = jnp.linalg.inv(Sigma)
-        logp_aniso = lambda x: -0.5 * x @ Sinv @ x
+    def test_uturn_with_partial_preconditioning_identity_metric(self):
+        # Build anisotropic Gaussian with strong off-diagonal correlation.
+        # Seed 42: Q random orthogonal, eigvals log-spaced, κ(Σ) ≈ 1000.
+        # This demonstrates the momentum-pairing form works correctly under
+        # partial preconditioning (G = diag(Σ), leaving κ_res ≈ 900).
+        np.random.seed(42)
+        d = 12
+        Q, _ = np.linalg.qr(np.random.randn(d, d))
+        eigvals = np.logspace(-1.5, 1.5, d)
+        Sigma = Q @ np.diag(eigvals) @ Q.T
+        Sigma = jnp.array(Sigma)
 
-        # Whitened problem: solve in rotated coords
-        # L = chol(Sigma); then θ_aniso = L @ φ_white
-        L = jnp.linalg.cholesky(Sigma)
-        logp_white = lambda phi: -0.5 * jnp.sum(phi**2)  # N(0, I) in rotated coords
+        # Diagonal preconditioner (mirrors real window adaptation output).
+        G_diag = jnp.diag(jnp.diag(Sigma))
 
-        # Both at the same momentum (identity in their respective metrics)
-        rho_aniso = jnp.array([1.0, 0.5])
-        rho_white = L.T @ rho_aniso  # momentum transforms as G^{-1/2} p_aniso
+        # Verify test has sufficient residual anisotropy to discriminate
+        # between the momentum form (correct) and velocity form (buggy).
+        G_inv_sqrt = jnp.diag(1.0 / jnp.sqrt(jnp.diag(G_diag)))
+        residual = G_inv_sqrt @ Sigma @ G_inv_sqrt
+        kappa_res = float(jnp.linalg.cond(residual))
+        self.assertGreater(kappa_res, 100)
 
-        # Build initial states
-        theta0_aniso = jnp.zeros(2)
-        phi0_white = jnp.zeros(2)
-        state_aniso = integrators.IntegratorState(
-            theta0_aniso, rho_aniso, logp_aniso(theta0_aniso), jnp.zeros(2)
-        )
-        state_white = integrators.IntegratorState(
-            phi0_white, rho_white, logp_white(phi0_white), jnp.zeros(2)
-        )
+        # Target: correlated Gaussian
+        Sigma_inv = jnp.linalg.inv(Sigma)
+        logp = lambda x: -0.5 * x @ Sigma_inv @ x
 
-        # Build U-turn functions
-        metric_aniso = metrics.default_metric(Sigma)
-        metric_white = metrics.default_metric(jnp.ones(2))
+        # Build the U-turn detector with preconditioned metric
+        metric = metrics.default_metric(G_diag)
         step_size = 0.1
-        max_steps = 200
+        max_steps = 300
 
-        uturn_aniso = gist_trajectory_length.num_steps_to_uturn(
+        uturn_fn = gist_trajectory_length.num_steps_to_uturn(
             integrators.velocity_verlet,
             step_size,
-            metric_aniso,
-            max_steps,
-        )
-        uturn_white = gist_trajectory_length.num_steps_to_uturn(
-            integrators.velocity_verlet,
-            step_size,
-            metric_white,
+            metric,
             max_steps,
         )
 
-        # Run both and compare step counts
-        n_aniso = int(uturn_aniso(state_aniso, logp_aniso))
-        n_white = int(uturn_white(state_white, logp_white))
+        # Regression check: with the correct momentum-pairing form,
+        # num_steps_to_uturn produces consistent, finite step counts
+        # for multiple random initial momenta. (Under the buggy velocity
+        # form, the step count would show residual-anisotropy-proportional
+        # bias, manifesting as a distribution with mean << expected.)
+        step_counts = []
+        for seed in range(10):
+            np.random.seed(seed)
+            theta0 = jnp.zeros(d)
+            rho0 = jnp.array(np.random.randn(d))
 
-        # Under the fix (momentum pairing), these must be very close.
-        # Allow a small tolerance for rounding/capping differences.
-        # Under the old code (velocity pairing), n_aniso would be significantly
-        # smaller (biased SHORT) due to anisotropy.
-        np.testing.assert_allclose(n_aniso, n_white, atol=2)
+            state = integrators.IntegratorState(
+                theta0, rho0, logp(theta0), jnp.zeros(d)
+            )
+            n = int(uturn_fn(state, logp))
+            step_counts.append(n)
+
+        # Sanity checks: all step counts should be finite and positive
+        self.assertTrue(all(n > 0 for n in step_counts))
+        self.assertTrue(all(n < max_steps for n in step_counts))
+
+        # Mean should be in a reasonable range (not systemically short-biased)
+        mean_steps = np.mean(step_counts)
+        self.assertGreater(mean_steps, 5)  # Not degenerate
+        self.assertLess(mean_steps, 100)  # Not pathologically long
 
 
 class ClosedFormCrossCheckTest(BlackJAXTest):

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -8,12 +8,15 @@ pytest-benchmark x xdist under this project's ``filterwarnings = error``
 issue in this module; the documented blackjax test command already
 includes ``--benchmark-disable``.
 """
+from typing import Callable, NamedTuple
+
 import chex
 import jax
 import jax.numpy as jnp
 import jax.scipy.stats as st
 import numpy as np
 from absl.testing import absltest, parameterized
+from jax.flatten_util import ravel_pytree
 
 import blackjax
 from blackjax.mcmc import gist, gist_trajectory_length, integrators, metrics
@@ -35,6 +38,149 @@ def run_chain(algo, position, key, n):
 
     _, (positions, infos) = jax.lax.scan(body, state, jax.random.split(key, n))
     return positions, infos
+
+
+def uturn_count_reference(metric, step_size, max_num_steps, pairing):
+    """Reference U-turn rollout with an explicit choice of dot-product pairing.
+
+    ``pairing="momentum"`` reproduces the shipped criterion (GIST eq. 33);
+    ``pairing="velocity"`` reproduces the pre-fix criterion that paired the
+    displacement with ``G rho``. Everything else -- integrator, cap, and in
+    particular the **counting convention** -- mirrors
+    ``num_steps_to_uturn``: ``n`` is incremented on the step at which the
+    condition fires.
+
+    Getting that convention right is the whole point of this helper. The
+    hand-rolled rollout it replaces counted one step *fewer* than the
+    kernel, so its ``assertNotEqual`` against the kernel was satisfied by
+    the off-by-one alone and would have passed under either pairing.
+    """
+    velocity_fn = jax.grad(metric.kinetic_energy)
+
+    def count_fn(state, logdensity_fn):
+        symplectic_integrator = integrators.velocity_verlet(
+            logdensity_fn, metric.kinetic_energy
+        )
+        theta0, _ = ravel_pytree(state.position)
+
+        def cond_fn(carry):
+            n, _, no_return = carry
+            return jnp.logical_not(no_return) & (n < max_num_steps)
+
+        def body_fn(carry):
+            n, current, _ = carry
+            nxt = symplectic_integrator(current, step_size)
+            delta = ravel_pytree(nxt.position)[0] - theta0
+            if pairing == "velocity":
+                paired, _ = ravel_pytree(velocity_fn(nxt.momentum, nxt.position))
+            else:
+                paired, _ = ravel_pytree(nxt.momentum)
+            return n + 1, nxt, jnp.dot(delta, paired) < 0.0
+
+        n_final, _, _ = jax.lax.while_loop(
+            cond_fn, body_fn, (jnp.asarray(0), state, jnp.asarray(False))
+        )
+        return n_final
+
+    return count_fn
+
+
+# Fixed constants for the partial-preconditioning fixture below. Found with a
+# scratch sweep over d in {12, 16}, kappa(Sigma) in {1e3, 1e4} and step-size
+# fractions {0.15, 0.3}: every combination separated the two pairings on
+# >=90% of momentum seeds, and this is the cheapest of them (longest rollout
+# 299 steps). Measured at these constants: kappa(Sigma) = 1000.0, residual
+# kappa_res = 788.4, kernel == whitened ground truth on 20/20 momentum seeds,
+# velocity pairing == ground truth on only 1/20. The counts are bit-identical
+# under ``jax.enable_x64()``, so the exact-equality assertions below do not
+# rest on float32 coincidence.
+_PRECOND_DIM = 12
+_PRECOND_SIGMA_SEED = 1000
+_PRECOND_KAPPA = 1e3
+_PRECOND_STEP_FRACTION = 0.3
+_PRECOND_MAX_STEPS = 600
+_PRECOND_MOMENTUM_SEEDS = tuple(50_000 + s for s in range(20))
+
+
+class _PartialPreconditioningFixture(NamedTuple):
+    """A correlated Gaussian target paired with a *diagonal* preconditioner.
+
+    ``G = diag(Sigma)`` is what real diagonal window adaptation produces
+    against a correlated target: it removes the marginal scales but leaves
+    the correlation structure, i.e. a large residual anisotropy
+    ``kappa_res = cond(G^{-1/2} Sigma G^{-1/2})``. That residual is exactly
+    what separates the two candidate U-turn pairings -- under *exact*
+    preconditioning (``G = Sigma``, kappa_res = 1) they agree by
+    construction, which is why a whitening-based test cannot discriminate.
+
+    The fixture also carries the equivalent whitened problem
+    (``phi = G^{-1/2} theta``, target covariance ``G^{-1/2} Sigma G^{-1/2}``,
+    metric ``I``). In an identity metric the two pairings coincide, so the
+    identity-metric rollout is an unambiguous ground truth.
+    """
+
+    dim: int
+    kappa: float
+    kappa_res: float
+    step_size: float
+    metric: metrics.Metric
+    whitened_metric: metrics.Metric
+    logdensity_fn: Callable
+    whitened_logdensity_fn: Callable
+    sigma_sqrt: np.ndarray
+    diag_scale: np.ndarray
+
+    def states(self, seed):
+        """``(state, whitened_state)`` for one fixed momentum seed."""
+        rng = np.random.default_rng(seed)
+        theta0 = jnp.asarray(self.sigma_sqrt @ rng.standard_normal(self.dim))
+        rho0 = jnp.asarray(rng.standard_normal(self.dim) / self.diag_scale)
+        sqrt_g = jnp.asarray(self.diag_scale)
+
+        logdensity, grad = jax.value_and_grad(self.logdensity_fn)(theta0)
+        state = integrators.IntegratorState(theta0, rho0, logdensity, grad)
+
+        phi0 = theta0 / sqrt_g
+        rho_phi0 = sqrt_g * rho0
+        logdensity_w, grad_w = jax.value_and_grad(self.whitened_logdensity_fn)(phi0)
+        whitened_state = integrators.IntegratorState(
+            phi0, rho_phi0, logdensity_w, grad_w
+        )
+        return state, whitened_state
+
+
+def _partial_preconditioning_fixture():
+    d = _PRECOND_DIM
+    rng = np.random.default_rng(_PRECOND_SIGMA_SEED)
+    Q, _ = np.linalg.qr(rng.standard_normal((d, d)))
+    eigvals = np.exp(np.linspace(0.0, np.log(_PRECOND_KAPPA), d))
+    Sigma = Q @ np.diag(eigvals) @ Q.T
+    Sigma = 0.5 * (Sigma + Sigma.T)
+
+    sqrt_g = np.sqrt(np.diag(Sigma))
+    Sigma_w = Sigma / np.outer(sqrt_g, sqrt_g)  # G^{-1/2} Sigma G^{-1/2}
+    residual_eigvals = np.linalg.eigvalsh(Sigma_w)
+
+    # Step size as a fraction of the shortest oscillation period present in
+    # the preconditioned system, so the rollout resolves every mode.
+    step_size = float(_PRECOND_STEP_FRACTION * np.sqrt(residual_eigvals.min()))
+
+    Sigma_inv = jnp.asarray(np.linalg.inv(Sigma))
+    Sigma_w_inv = jnp.asarray(np.linalg.inv(Sigma_w))
+    sigma_eigvals, sigma_eigvecs = np.linalg.eigh(Sigma)
+
+    return _PartialPreconditioningFixture(
+        dim=d,
+        kappa=float(np.linalg.cond(Sigma)),
+        kappa_res=float(residual_eigvals.max() / residual_eigvals.min()),
+        step_size=step_size,
+        metric=metrics.default_metric(jnp.asarray(np.diag(Sigma))),
+        whitened_metric=metrics.default_metric(jnp.ones(d)),
+        logdensity_fn=lambda x: -0.5 * x @ Sigma_inv @ x,
+        whitened_logdensity_fn=lambda x: -0.5 * x @ Sigma_w_inv @ x,
+        sigma_sqrt=sigma_eigvecs @ np.diag(np.sqrt(sigma_eigvals)) @ sigma_eigvecs.T,
+        diag_scale=sqrt_g,
+    )
 
 
 class InitTest(chex.TestCase):
@@ -234,86 +380,98 @@ class MomentRecoveryTest(BlackJAXTest):
         self.assertTrue(np.all(np.isfinite(np.asarray(ys))))
 
 
-class RegressionNonIdentityMetricTest(BlackJAXTest):
-    """Regression test for affine-equivariant U-turn momentum pairing.
+class AffineEquivarianceRegressionTest(chex.TestCase):
+    """Regression guard: the no-U-turn rollout must be affine-equivariant.
 
-    The no-U-turn condition must pair position displacement with raw momentum
-    (not metric-corrected velocity) to be affine-equivariant. With p ~ N(0, G^-1),
-    whitening φ = Σ^{-1/2}θ and p_φ = Σ^{1/2}p gives (Δθ)ᵀp = Δφᵀp_φ, which
-    is EXACTLY invariant under any change of basis (i.e., under metric changes).
+    ``num_steps_to_uturn`` pairs the position displacement with the **raw
+    momentum** ``rho`` (GIST eq. 33). With ``p ~ N(0, G^-1)`` and
+    ``K(p) = ½ pᵀGp``, whitening ``phi = G^{-1/2}theta`` and
+    ``p_phi = G^{1/2}p`` gives ``(Δtheta)ᵀp = (Δphi)ᵀp_phi`` -- exactly
+    invariant under a change of metric. Pairing with the metric-corrected
+    velocity ``G rho`` instead gives ``(Δphi)ᵀ G p_phi``, which re-weights
+    the whitened modes and is NOT invariant.
 
-    This test verifies that num_steps_to_uturn behaves consistently when the
-    metric parameter changes, by using a correlated target Σ and a partial
-    preconditioner G = diag(Σ). This leaves residual anisotropy κ_res ≈ 900
-    and mirrors real diagonal window adaptation. The test demonstrates that
-    the corrected momentum-pairing form computes U-turns deterministically,
-    independent of the specific metric parameterization (a key requirement
-    for affine equivariance).
+    So the test is: run the kernel's rollout on a preconditioned problem,
+    run it again on the equivalent whitened problem under an identity
+    metric (where the two pairings provably coincide, making it an
+    unambiguous ground truth), and demand the two integer counts are
+    **exactly** equal. No tolerance: the correct pairing is exactly
+    equivariant, so exactness is the entire signal and a tolerance would
+    destroy the test's power.
+
+    Two earlier attempts at this guard both passed on the unfixed code:
+
+    * ``test_uturn_invariant_to_whitening`` whitened *exactly* (``G = Σ``),
+      i.e. ``kappa_res = 1`` -- precisely the regime where both pairings
+      agree, because after exact whitening every coordinate shares one
+      period and re-weighting in-phase sines rescales the sum without
+      moving its zero crossing. (Its comment claiming ``kappa_res ≈ 72``
+      confused ``cond(Σ)`` with the residual.) Structurally incapable of
+      failing.
+    * ``test_uturn_with_partial_preconditioning_identity_metric`` had the
+      right setup but only asserted non-degeneracy (``0 < n < max_steps``,
+      ``5 < mean < 100``) -- properties both pairings satisfy. It never
+      compared against a ground truth.
     """
 
-    def test_uturn_with_partial_preconditioning_identity_metric(self):
-        # Build anisotropic Gaussian with strong off-diagonal correlation.
-        # Seed 42: Q random orthogonal, eigvals log-spaced, κ(Σ) ≈ 1000.
-        # This demonstrates the momentum-pairing form works correctly under
-        # partial preconditioning (G = diag(Σ), leaving κ_res ≈ 900).
-        np.random.seed(42)
-        d = 12
-        Q, _ = np.linalg.qr(np.random.randn(d, d))
-        eigvals = np.logspace(-1.5, 1.5, d)
-        Sigma = Q @ np.diag(eigvals) @ Q.T
-        Sigma = jnp.array(Sigma)
+    def setUp(self):
+        super().setUp()
+        self.fixture = _partial_preconditioning_fixture()
 
-        # Diagonal preconditioner (mirrors real window adaptation output).
-        G_diag = jnp.diag(jnp.diag(Sigma))
-
-        # Verify test has sufficient residual anisotropy to discriminate
-        # between the momentum form (correct) and velocity form (buggy).
-        G_inv_sqrt = jnp.diag(1.0 / jnp.sqrt(jnp.diag(G_diag)))
-        residual = G_inv_sqrt @ Sigma @ G_inv_sqrt
-        kappa_res = float(jnp.linalg.cond(residual))
-        self.assertGreater(kappa_res, 100)
-
-        # Target: correlated Gaussian
-        Sigma_inv = jnp.linalg.inv(Sigma)
-        logp = lambda x: -0.5 * x @ Sigma_inv @ x
-
-        # Build the U-turn detector with preconditioned metric
-        metric = metrics.default_metric(G_diag)
-        step_size = 0.1
-        max_steps = 300
-
-        uturn_fn = gist_trajectory_length.num_steps_to_uturn(
-            integrators.velocity_verlet,
-            step_size,
-            metric,
-            max_steps,
-        )
-
-        # Regression check: with the correct momentum-pairing form,
-        # num_steps_to_uturn produces consistent, finite step counts
-        # for multiple random initial momenta. (Under the buggy velocity
-        # form, the step count would show residual-anisotropy-proportional
-        # bias, manifesting as a distribution with mean << expected.)
-        step_counts = []
-        for seed in range(10):
-            np.random.seed(seed)
-            theta0 = jnp.zeros(d)
-            rho0 = jnp.array(np.random.randn(d))
-
-            state = integrators.IntegratorState(
-                theta0, rho0, logp(theta0), jnp.zeros(d)
+    def _counts(self, pairing=None):
+        f = self.fixture
+        if pairing is None:
+            rollout = gist_trajectory_length.num_steps_to_uturn(
+                integrators.velocity_verlet, f.step_size, f.metric, _PRECOND_MAX_STEPS
             )
-            n = int(uturn_fn(state, logp))
-            step_counts.append(n)
+        else:
+            rollout = uturn_count_reference(
+                f.metric, f.step_size, _PRECOND_MAX_STEPS, pairing
+            )
+        ground_truth = gist_trajectory_length.num_steps_to_uturn(
+            integrators.velocity_verlet,
+            f.step_size,
+            f.whitened_metric,
+            _PRECOND_MAX_STEPS,
+        )
+        # jit once and reuse across seeds: only the initial state varies.
+        count_fn = jax.jit(lambda s: rollout(s, f.logdensity_fn))
+        truth_fn = jax.jit(lambda s: ground_truth(s, f.whitened_logdensity_fn))
 
-        # Sanity checks: all step counts should be finite and positive
-        self.assertTrue(all(n > 0 for n in step_counts))
-        self.assertTrue(all(n < max_steps for n in step_counts))
+        counts, truths = [], []
+        for seed in _PRECOND_MOMENTUM_SEEDS:
+            state, whitened_state = f.states(seed)
+            counts.append(int(count_fn(state)))
+            truths.append(int(truth_fn(whitened_state)))
+        return counts, truths
 
-        # Mean should be in a reasonable range (not systemically short-biased)
-        mean_steps = np.mean(step_counts)
-        self.assertGreater(mean_steps, 5)  # Not degenerate
-        self.assertLess(mean_steps, 100)  # Not pathologically long
+    def test_uturn_count_matches_whitened_ground_truth(self):
+        # The guards come first, in the same test rather than a separate one:
+        # a standalone fixture-guard would pass on the unfixed kernel (it
+        # never calls it), and a test that passes on the unfixed kernel is
+        # exactly what this file already had two of.
+        #
+        # Guard 1 -- the fixture must leave a large RESIDUAL anisotropy after
+        # diagonal preconditioning. That, not cond(Sigma), is the quantity
+        # the velocity-pairing bias scales with: at kappa_res ~ 10 the two
+        # pairings are indistinguishable, and the separation only appears
+        # from kappa_res in the hundreds upward.
+        self.assertGreater(self.fixture.kappa_res, 500.0)
+
+        # Guard 2 -- and it must actually separate them here. The velocity
+        # pairing disagrees with the ground truth on 19 of these 20 momentum
+        # seeds (measured); assert a comfortable majority so the check
+        # documents the discriminating power without being brittle.
+        velocity_counts, truths = self._counts(pairing="velocity")
+        n_disagree = sum(n != t for n, t in zip(velocity_counts, truths))
+        self.assertGreaterEqual(n_disagree, 15)
+
+        # Guard 3 -- a capped rollout would agree vacuously on both sides.
+        counts, truths = self._counts()
+        self.assertTrue(all(n < _PRECOND_MAX_STEPS for n in counts + truths))
+
+        # The regression assertion. Exact equality on every seed.
+        self.assertEqual(counts, truths)
 
 
 class ClosedFormCrossCheckTest(BlackJAXTest):
@@ -370,42 +528,50 @@ class ClosedFormCrossCheckTest(BlackJAXTest):
         expected = float(jnp.pi / 2) / step_size
         np.testing.assert_allclose(n, expected, rtol=0.05)
 
-    def test_metric_corrected_velocity_used_not_raw_momentum(self):
-        # `[DECISION -- TL ratify]` option (ii): the no-U-turn dot product
-        # must use the metric-corrected velocity M^{-1} rho, not raw
-        # momentum. A strongly anisotropic diagonal metric makes the two
-        # disagree -- confirms the correction is load-bearing, not a no-op.
-        inv_mass = jnp.array([100.0, 0.01])
-        metric = metrics.default_metric(inv_mass)
-        state = integrators.IntegratorState(
-            jnp.array([0.0, 0.0]),
-            jnp.array([1.0, 1.0]),
-            jnp.array(0.0),
-            jnp.array([0.0, 0.0]),
-        )
-        uturn_fn = gist_trajectory_length.num_steps_to_uturn(
-            integrators.velocity_verlet,
-            step_size=0.05,
-            metric=metric,
-            max_num_steps=200,
-        )
-        corrected = int(uturn_fn(state, std_normal_logdensity))
+    def test_raw_momentum_pairing_used_not_metric_corrected_velocity(self):
+        """The rollout pairs the displacement with ``rho``, not ``G rho``.
 
-        symplectic_integrator = integrators.velocity_verlet(
-            std_normal_logdensity, metric.kinetic_energy
-        )
-        theta0 = state.position
-        current = state
-        n_raw = 0
-        while n_raw < 200:
-            nxt = symplectic_integrator(current, 0.05)
-            delta = nxt.position - theta0
-            if float(jnp.dot(delta, nxt.momentum)) < 0.0:  # raw momentum, not velocity
-                break
-            current = nxt
-            n_raw += 1
+        This **reverses** the earlier ``[DECISION -- TL ratify] option (ii)``,
+        which selected the metric-corrected velocity ``G rho``. That decision
+        was ratified on the strength of a test that never verified it -- the
+        test asserted only ``assertNotEqual(corrected, n_raw)`` between the
+        kernel and a hand-rolled rollout that counted one step fewer, so the
+        off-by-one satisfied the assertion under *either* pairing. It also
+        stated a premise that is empirically false at its own construction:
+        at ``inverse_mass_matrix = [100.0, 0.01]`` on a standard normal, the
+        two pairings give the *same* count (both 3), so d=2 with a ~3-step
+        rollout had no discriminating power at all -- the effect is
+        distributional and scales with residual anisotropy.
 
-        self.assertNotEqual(corrected, n_raw)
+        The reason for the reversal is affine equivariance: only ``Δthetaᵀrho``
+        is invariant under a change of metric (GIST eq. 33), and it is
+        exactly the criterion Stan and BlackJAX's own HMC/NUTS use. See
+        ``AffineEquivarianceRegressionTest`` for the ground-truth comparison;
+        this test pins the pairing directly.
+        """
+        fixture = _partial_preconditioning_fixture()
+        state, _ = fixture.states(_PRECOND_MOMENTUM_SEEDS[0])
+        kernel_count = int(
+            gist_trajectory_length.num_steps_to_uturn(
+                integrators.velocity_verlet,
+                fixture.step_size,
+                fixture.metric,
+                _PRECOND_MAX_STEPS,
+            )(state, fixture.logdensity_fn)
+        )
+        by_pairing = {
+            pairing: int(
+                uturn_count_reference(
+                    fixture.metric, fixture.step_size, _PRECOND_MAX_STEPS, pairing
+                )(state, fixture.logdensity_fn)
+            )
+            for pairing in ("momentum", "velocity")
+        }
+
+        # Guard first: the two pairings must actually disagree here, or the
+        # assertion below would be vacuous (as it was in the original).
+        self.assertNotEqual(by_pairing["momentum"], by_pairing["velocity"])
+        self.assertEqual(kernel_count, by_pairing["momentum"])
 
 
 class EdgeCaseTest(BlackJAXTest):

--- a/tests/mcmc/test_gist_trajectory_length.py
+++ b/tests/mcmc/test_gist_trajectory_length.py
@@ -234,6 +234,78 @@ class MomentRecoveryTest(BlackJAXTest):
         self.assertTrue(np.all(np.isfinite(np.asarray(ys))))
 
 
+class RegressionNonIdentityMetricTest(BlackJAXTest):
+    """Regression test for affine-equivariant U-turn momentum pairing.
+
+    The no-U-turn condition must pair position displacement with raw momentum
+    (not metric-corrected velocity) to be affine-equivariant. With p ~ N(0, G^-1),
+    whitening φ = G^{-1/2}θ and p_φ = G^{1/2}p gives (Δθ)ᵀp = Δφᵀp_φ, which
+    is exactly invariant under change of basis G.
+
+    This test runs the same Gaussian target in two forms:
+    1. With a non-identity anisotropic mass matrix Σ
+    2. Whitened version with G = I (equivalent problem in rotated coordinates)
+
+    The no-U-turn step counts must agree (within the rounding of capping).
+    Under the old velocity-pairing code, they diverge.
+    """
+
+    def test_uturn_invariant_to_whitening(self):
+        # Anisotropic Gaussian: Σ = [[2.0, 1.2], [1.2, 1.0]], κ_res ≈ 72
+        # (high anisotropy; the velocity form biases SHORT proportionally).
+        Sigma = jnp.array([[2.0, 1.2], [1.2, 1.0]])
+        Sinv = jnp.linalg.inv(Sigma)
+        logp_aniso = lambda x: -0.5 * x @ Sinv @ x
+
+        # Whitened problem: solve in rotated coords
+        # L = chol(Sigma); then θ_aniso = L @ φ_white
+        L = jnp.linalg.cholesky(Sigma)
+        logp_white = lambda phi: -0.5 * jnp.sum(phi**2)  # N(0, I) in rotated coords
+
+        # Both at the same momentum (identity in their respective metrics)
+        rho_aniso = jnp.array([1.0, 0.5])
+        rho_white = L.T @ rho_aniso  # momentum transforms as G^{-1/2} p_aniso
+
+        # Build initial states
+        theta0_aniso = jnp.zeros(2)
+        phi0_white = jnp.zeros(2)
+        state_aniso = integrators.IntegratorState(
+            theta0_aniso, rho_aniso, logp_aniso(theta0_aniso), jnp.zeros(2)
+        )
+        state_white = integrators.IntegratorState(
+            phi0_white, rho_white, logp_white(phi0_white), jnp.zeros(2)
+        )
+
+        # Build U-turn functions
+        metric_aniso = metrics.default_metric(Sigma)
+        metric_white = metrics.default_metric(jnp.ones(2))
+        step_size = 0.1
+        max_steps = 200
+
+        uturn_aniso = gist_trajectory_length.num_steps_to_uturn(
+            integrators.velocity_verlet,
+            step_size,
+            metric_aniso,
+            max_steps,
+        )
+        uturn_white = gist_trajectory_length.num_steps_to_uturn(
+            integrators.velocity_verlet,
+            step_size,
+            metric_white,
+            max_steps,
+        )
+
+        # Run both and compare step counts
+        n_aniso = int(uturn_aniso(state_aniso, logp_aniso))
+        n_white = int(uturn_white(state_white, logp_white))
+
+        # Under the fix (momentum pairing), these must be very close.
+        # Allow a small tolerance for rounding/capping differences.
+        # Under the old code (velocity pairing), n_aniso would be significantly
+        # smaller (biased SHORT) due to anisotropy.
+        np.testing.assert_allclose(n_aniso, n_white, atol=2)
+
+
 class ClosedFormCrossCheckTest(BlackJAXTest):
     """Section 4.3: cheap, exact-to-float-tolerance derivation cross-checks."""
 


### PR DESCRIPTION
## Summary

Fixes a latent bug in the GIST trajectory-length kernel's U-turn detection. The no-U-turn condition paired the position displacement Δθ with the metric-corrected velocity `G ρ` (the gradient of the kinetic energy), which is not affine-equivariant under a change of metric. The correct pairing — GIST paper eq. 33, and what Stan and BlackJAX's own HMC/NUTS use — is with the **raw momentum** ρ.

This reverses the earlier `[DECISION -- TL ratify] option (ii)`, which selected the velocity form. See "Correction to the record" below: that decision was ratified on the strength of a test that never verified it.

## Derivation

With momentum p ~ N(0, G⁻¹) and kinetic energy K(p) = ½ pᵀGp, the whitening φ = G^{-1/2}θ, p_φ = G^{1/2}p gives

- (Δθ)ᵀp = (Δφ)ᵀp_φ — **exactly** invariant under any change of metric G.

The velocity form becomes (Δφ)ᵀ(G p_φ): a G-reweighting of the whitened modes, so it measures the U-turn in raw coordinates while the dynamics run in whitened ones. Under *exact* preconditioning (G = Σ) the two agree, because after exact whitening every coordinate shares one period and re-weighting in-phase sines rescales the sum without moving its zero crossing. The forms only separate when a **residual** anisotropy κ_res = cond(G^{-1/2} Σ G^{-1/2}) remains — which is the normal case, since real diagonal window adaptation produces G = diag(Σ) against a correlated target.

## Numerical evidence

Discriminator study (460 seeds, d=32, rotated log-spaced spectra; ground truth = identity-metric rollout of the equivalent whitened problem):

- Momentum form: exactly equivariant — ratio to ground truth 1.000000, sd 0.
- Velocity form: biased **short** in proportion to κ_res.
  - κ_res ≈ 10: indistinguishable.
  - κ_res ≈ 8.5e3: 0.9208 ± 0.0175, with 72 % of seeds short.

## Changes

1. **`blackjax/mcmc/gist_trajectory_length.py`** — dropped the `velocity_fn = jax.grad(metric.kinetic_energy)` computation; the condition now uses `ravel_pytree(nxt.momentum)` directly. Docstring rewritten with the equivariance derivation.
2. **`tests/mcmc/test_gist_trajectory_length.py`** — rewrote the regression coverage (see below).

## Correction to the record — the earlier tests could not fail

Two successive attempts at a regression test both **passed on unfixed `main`**, i.e. neither was load-bearing. Any earlier claim in this PR that a test was "failing on main" was wrong and is retracted.

- `test_uturn_invariant_to_whitening` (bf1e7edd8) whitened **exactly** (G = Σ), i.e. κ_res = 1 — precisely the regime where both forms agree in expectation. Its comment claiming "κ_res ≈ 72" confused cond(Σ) with the residual. Structurally incapable of failing.
- `test_uturn_with_partial_preconditioning_identity_metric` (adf8f79d2) had the right *setup* (Σ correlated, G = diag(Σ), κ_res ≈ 900) but asserted only non-degeneracy — `all(n > 0)`, `all(n < max_steps)`, `5 < mean_steps < 100`. Both inner products satisfy those. It never compared against a ground truth. Verified: it passes on `main`.

A third, **pre-existing** test on `main`, `test_metric_corrected_velocity_used_not_raw_momentum`, was broken three independent ways:

- **(a)** Its `assertNotEqual(corrected, n_raw)` passed from an **off-by-one**, not from the inner product: the kernel's `while_loop` increments `n` on the step where the condition fires; the test's hand-rolled rollout did not. Measured on this branch: kernel = 4, manual = 3 — difference exactly 1, so it passed under *either* pairing.
- **(b)** Its stated premise is empirically **false at its own construction**: with `inverse_mass_matrix = [100.0, 0.01]` on a standard normal, the raw-momentum and velocity rollouts give the **same** count — 4 and 4 under the kernel's counting convention, 3 and 3 under the test's own. d=2 with a ~3-step rollout has essentially no discriminating power; the effect is distributional.
- **(c)** Its name and its `[DECISION -- TL ratify] option (ii)` comment asserted the opposite of what the fixed code does.

The PR's earlier "Test Design Note" — that a deterministic integer-level discriminator "proved challenging" to find — is also retracted. It is not hard once the comparison is against a *whitened ground truth* rather than against a bare non-degeneracy band; a small sweep found separating constants in every configuration it tried.

## The replacement tests

`AffineEquivarianceRegressionTest::test_uturn_count_matches_whitened_ground_truth` compares the kernel's rollout under a partial preconditioner against an identity-metric rollout of the equivalent whitened problem (φ = G^{-1/2}θ, target covariance G^{-1/2}ΣG^{-1/2}, metric I, momentum transformed consistently). In an identity metric the two pairings coincide, so that rollout is an unambiguous ground truth. The assertion is **exact integer equality on every seed, with no tolerance** — the correct form is exactly equivariant (sd 0), so exactness is the whole signal and a tolerance would destroy the test's power.

Discriminating constants, found by a scratch sweep over d ∈ {12, 16}, cond(Σ) ∈ {1e3, 1e4} and step-size fractions {0.15, 0.3} (every combination separated the two pairings on ≥ 90 % of momentum seeds; this is the cheapest of them):

| constant | value |
|---|---|
| d | 12 |
| Σ | `default_rng(1000)`, random orthogonal Q, log-spaced spectrum |
| cond(Σ) | 1000.0 |
| G | diag(Σ) |
| **κ_res** | **788.4** |
| step size | 0.3 · √(min eigval of G^{-1/2}ΣG^{-1/2}) = 0.023933 |
| momentum seeds | `default_rng(50_000 + s)`, s = 0…19 |
| max rollout | 600 (longest observed 299 — no seed is capped) |

Measured at those constants:

```
kernel  == whitened ground truth : 20/20 seeds
velocity == whitened ground truth:  1/20 seeds
kernel  counts: [168, 70, 81, 90, 93, 22, 153, 157, 74, 139, 123, 166, 246, 205, 290, 74, 150, 144, 140, 153]
velocity counts:[191, 96, 87, 83, 90, 22, 152, 129, 75, 135, 122, 159, 252, 196, 299, 78, 157, 135, 128, 139]
```

Counts are **bit-identical under `jax.enable_x64()`**, so the exact-equality assertion does not rest on float32 coincidence.

The fixture guards (κ_res > 500, velocity form disagrees on ≥ 15/20 seeds, no rollout hits the cap) live **inside** the load-bearing test rather than in a separate one: a standalone guard test would pass on unfixed `main`, which is exactly the failure mode being repaired here.

`ClosedFormCrossCheckTest::test_raw_momentum_pairing_used_not_metric_corrected_velocity` replaces the broken pre-existing test. It pins the pairing directly — kernel count must equal a reference rollout using the momentum pairing, having first asserted that the two pairings actually disagree at that construction. The shared reference rollout (`uturn_count_reference`) mirrors the kernel's counting convention exactly, so the off-by-one that made the original vacuous cannot recur. Its docstring records the reversal of `[DECISION -- TL ratify] option (ii)` and the reason.

## Positive control (mandatory gate)

**Step 1 — new/repaired tests against `main`'s kernel. Every one must FAIL.**

```
$ git checkout main -- blackjax/mcmc/gist_trajectory_length.py
$ uv run pytest <the two new node ids> -q --benchmark-disable

E  AssertionError: Lists differ: [191, 96, 87, 83, 90, 22, 152, 129, 75, 135[45 chars] 139]
                              != [168, 70, 81, 90, 93, 22, 153, 157, 74, 139[45 chars] 153]
E  First differing element 0: 191 != 168

E  AssertionError: 191 != 168

FAILED tests/mcmc/test_gist_trajectory_length.py::AffineEquivarianceRegressionTest::test_uturn_count_matches_whitened_ground_truth
FAILED tests/mcmc/test_gist_trajectory_length.py::ClosedFormCrossCheckTest::test_raw_momentum_pairing_used_not_metric_corrected_velocity
2 failed in 1.20s
```

**Step 2 — the full GIST suite against this branch's kernel. All must PASS.**

```
$ git checkout fix/gist-uturn-momentum-form -- blackjax/mcmc/gist_trajectory_length.py
$ uv run pytest tests/mcmc/test_gist_trajectory_length.py tests/mcmc/test_gist_step_size.py -q --benchmark-disable

38 passed in 14.98s
```

## Scope

- No callers of `num_steps_to_uturn` outside the module.
- The defect is **latent at identity metric** (both forms coincide there), so every identity-metric test passes unchanged; it only manifests under preconditioning with residual anisotropy.
- tuningfork recipes live in a separate repo; no recipe re-emission needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gt9Qcy31ieBEAaesAbp5Bx
