### PR TITLE
Fix staged_adaptation(metric='auto', n_chains>1) crash on PyTree positions

### DIFF
--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -800,14 +800,8 @@ def staged_adaptation(
                 _MIN_TRAIN_K_RATIO,
             )
 
-            # For multi-chain, position has a leading M axis (on every leaf,
-            # for a general PyTree position); use one chain's size. Index via
-            # jax.tree.map rather than jnp.asarray(position)[0]: the latter
-            # crashes for a dict/PyTree position (e.g. every NumPyro-model
-            # position in tuningfork) because jnp.asarray cannot convert a
-            # dict of arrays directly -- jax.tree.map works uniformly for
-            # both a bare Array (a trivial one-leaf PyTree) and a structured
-            # PyTree.
+            # One chain's slice via jax.tree.map: works for bare (M, d) Arrays
+            # AND structured PyTree positions (jnp.asarray crashes on a dict).
             _pos_for_size = (
                 jax.tree.map(lambda x: x[0], position) if _is_multi_chain else position
             )
@@ -912,10 +906,8 @@ def staged_adaptation(
             init_states = jax.vmap(lambda pos: algorithm.init(pos, logdensity_fn))(
                 position
             )
-            # Adapt init uses one chain's position so pytree_size → d (not M*d).
-            # jax.tree.map (not jnp.asarray(position)[0]) so this also works for
-            # a dict/PyTree position -- see the identical fix + rationale above
-            # for the rank-detection support-floor warning check.
+            # Adapt init uses one chain's position so pytree_size → d (not M*d);
+            # jax.tree.map for PyTree positions (see the rank-support check above).
             init_adaptation_state = adapt_init(
                 jax.tree.map(lambda x: x[0], position), initial_step_size
             )

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -800,8 +800,17 @@ def staged_adaptation(
                 _MIN_TRAIN_K_RATIO,
             )
 
-            # For multi-chain, position has shape (M, d); use one chain's size.
-            _pos_for_size = jnp.asarray(position)[0] if _is_multi_chain else position
+            # For multi-chain, position has a leading M axis (on every leaf,
+            # for a general PyTree position); use one chain's size. Index via
+            # jax.tree.map rather than jnp.asarray(position)[0]: the latter
+            # crashes for a dict/PyTree position (e.g. every NumPyro-model
+            # position in tuningfork) because jnp.asarray cannot convert a
+            # dict of arrays directly -- jax.tree.map works uniformly for
+            # both a bare Array (a trivial one-leaf PyTree) and a structured
+            # PyTree.
+            _pos_for_size = (
+                jax.tree.map(lambda x: x[0], position) if _is_multi_chain else position
+            )
             d = pytree_size(_pos_for_size)
             _actual_rank = min(_MAX_RANK_CAP, max(d // 2, 1))
             _min_rank_support = 2 * _MIN_TRAIN_K_RATIO * (_actual_rank + 1)
@@ -904,8 +913,11 @@ def staged_adaptation(
                 position
             )
             # Adapt init uses one chain's position so pytree_size → d (not M*d).
+            # jax.tree.map (not jnp.asarray(position)[0]) so this also works for
+            # a dict/PyTree position -- see the identical fix + rationale above
+            # for the rank-detection support-floor warning check.
             init_adaptation_state = adapt_init(
-                jnp.asarray(position)[0], initial_step_size
+                jax.tree.map(lambda x: x[0], position), initial_step_size
             )
 
             def one_step_mc(carry, xs):

--- a/tests/adaptation/test_meta_builders_e2e.py
+++ b/tests/adaptation/test_meta_builders_e2e.py
@@ -1825,3 +1825,46 @@ class TestEndToEndEscalation(BlackJAXTest):
             f"escalation-eligible window.  Check _build_mc_window_schedule wiring in "
             f"staged_adaptation.py and the budget_remaining gate in final().",
         )
+
+
+class TestMultiChainAutoMetricPyTreePosition(BlackJAXTest):
+    """Regression: metric='auto' + n_chains>1 must accept a PyTree position.
+
+    ``run()``'s rank-detection support-floor warning check computed
+    ``jnp.asarray(position)[0]`` to get one chain's slice for a
+    ``pytree_size`` call.  ``jnp.asarray`` cannot convert a dict/PyTree
+    position (e.g. every NumPyro-model position used throughout tuningfork,
+    of the form ``{"x": array, ...}``) and raised ``ValueError: entry not a
+    2- or 3- tuple`` before any JAX tracing ever started — so
+    ``metric="auto"`` + multi-chain was unusable for any structured position,
+    only for a bare flat array.  Every existing e2e test in this file uses a
+    flat ``jnp.zeros(n_dims)`` position, so this gap went uncaught.
+    """
+
+    def test_dict_position_does_not_raise(self):
+        """A dict-of-arrays position must not crash the rank-support warning check."""
+        M, d1, d2 = 8, 3, 2
+
+        def logdensity_fn(position):
+            return -0.5 * jnp.sum(position["a"] ** 2) - 0.5 * jnp.sum(
+                position["b"] ** 2
+            )
+
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="auto",
+            max_grad_budget=5000,
+            n_chains=M,
+        )
+        key = jax.random.key(7)
+        position = {
+            "a": jnp.zeros((M, d1)),
+            "b": jnp.zeros((M, d2)),
+        }
+        # Must not raise; num_steps kept small for test speed.
+        results, _ = warmup.run(key, position, num_steps=20)
+
+        imm = results.parameters["inverse_mass_matrix"]
+        self.assertIsInstance(imm, LowRankInverseMassMatrix)
+        self.assertEqual(imm.sigma.shape, (d1 + d2,))


### PR DESCRIPTION
## Finding

`staged_adaptation(metric="auto", ...).run()` computed `jnp.asarray(position)[0]` at two non-traced preamble call sites (the rank-support warning check and the multi-chain `adapt_init` call). `jnp.asarray` cannot convert a dict/PyTree position — e.g. any NumPyro-style `{"site": array}` position — so `metric="auto"` + `n_chains>1` raised `ValueError: entry not a 2- or 3- tuple` before any tracing began. Every existing e2e test used a flat `jnp.zeros(n_dims)` position, which is how this shipped uncaught in #1011. The core update path (`build_multi_chain_meta_core`) already handles PyTrees via `ravel_pytree`; only the two preamble sites were wrong.

## Fix

`jax.tree.map(lambda x: x[0], position)` at both sites — uniform over bare `(M, d)` Arrays (a trivial one-leaf PyTree) and structured PyTree positions.

## Tests

- New `TestMultiChainAutoMetricPyTreePosition::test_dict_position_does_not_raise`: a two-site dict position through the full `metric="auto"` multi-chain preamble.
- **Red-check (executed):** on clean b12bedcf2 the new test fails with the exact `ValueError`; passes with the fix.
- Full suite at branch head: 1789 passed / 1 failed — the failure (`test_metric_buffers.py::LateStartTest::test_skips_first_offset_steps`) reproduces identically on clean b12bedcf2: pre-existing on main, unrelated, tracked separately.

## Scale validation

This branch has been the executed revision under an overnight 4-model x 4-arm benchmark harness (NumPyro dict positions, d up to 503, M=8): the exact code path this fixes ran hundreds of multi-chain adaptation invocations without incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
