### PR TITLE
P1 per-chain post-warmup start-state safety: LOO state gate + healthy-anchor redraw + probation window

### DIFF
--- a/blackjax/adaptation/meta/_calibration.py
+++ b/blackjax/adaptation/meta/_calibration.py
@@ -35,6 +35,11 @@ Router: _GAIN_THRESHOLD, _GAIN_READABILITY_FLOOR.
 Detection-branch codes: _DETECTION_BRANCH_NONE/POOLED_WITHIN/BETWEEN_MEANS/BOTH.
 R²-mode codes: _R2_DEFERRED/PROJECTED/FULL_AFFINE.
 
+Start-state probation (multi-chain post-warmup safety, Issue#1064):
+_STATE_GATE_LOO_Z_THRESHOLD, _STATE_GATE_MIN_CHAINS, _STATE_GATE_REDRAW_JITTER_SCALE,
+_PROBATION_WINDOW_DEFAULT, _PROBATION_BACKOFF_FACTOR, _PROBATION_RECOVERY_RATE,
+_PROBATION_RESOLVED_TOL.
+
 Swappable calibration functions
 --------------------------------
 :func:`_mc_detection_edge`, :func:`_mc_unimodality_threshold`,
@@ -208,6 +213,75 @@ Below this threshold the fits are garbage (starved / transient chains) and
 the result is abstain (route = diagonal, confidence = low) rather than
 reparam.  Equals _R_MIN by construction (same curvature semantics).
 """
+
+
+# ---------------------------------------------------------------------------
+# Start-state probation (multi-chain post-warmup safety margin; Issue#1064).
+#
+# Stage 1 (proactive): a leave-one-out calibrated typical-region gate on each
+# chain's post-warmup potential energy, applying the SAME LOO-reference
+# principle the T-branch magnitude gate already uses at the route level
+# (see meta/_detection.py:_loo_detection_passes), one level down (route ->
+# parameter -> state calibration).
+# Stage 2a (reactive, primary correction): re-draw a flagged chain near the
+# healthiest chain's actual position.
+# Stage 2b (reactive, unconditional fallback): per-chain probation window
+# with divergence-triggered step-size backoff and exponential recovery to
+# the shared step size.  See blackjax.adaptation.meta._start_state and
+# blackjax.adaptation.staged_adaptation._apply_start_state_probation.
+# ---------------------------------------------------------------------------
+
+_STATE_GATE_LOO_Z_THRESHOLD: float = 3.0
+"""Leave-one-out z-score magnitude above which a chain's post-warmup
+potential energy (-logdensity) is flagged as outside the ensemble-calibrated
+typical region.  Reference mean/std is built from the OTHER M-1 chains only
+(never includes the chain under test), matching the LOO convention already
+used by :func:`~blackjax.adaptation.meta._detection._loo_detection_passes`.
+z=3.0 with dof=M-2 (M=8 default -> dof=6) is close to the two-sided
+t_{0.995,6}=3.71 critical value -- moderately conservative, favoring few
+false positives (each one costs a redraw + relies on stage 2b to catch
+anything still wrong) over aggressive flagging.
+"""
+
+_STATE_GATE_MIN_CHAINS: int = 4
+"""Minimum chain count for the state gate to fire at all (dof = M-2 >= 2).
+Below this the leave-one-out variance estimate from only 1-2 other chains is
+too noisy to be a meaningful reference region; the gate is skipped (all
+chains pass) rather than act on a degenerate statistic."""
+
+_STATE_GATE_REDRAW_JITTER_SCALE: float = 0.1
+"""Fraction of the shared metric's mass-matrix-consistent scale used to
+jitter a re-drawn chain away from its healthy anchor.  Large enough to avoid
+placing two chains at a literally identical point (which would break the
+independent-chains assumption early sampling diagnostics rely on); small
+enough that the redraw stays in the anchor's neighborhood rather than
+wandering back toward an arbitrary new region."""
+
+_PROBATION_WINDOW_DEFAULT: int = 50
+"""Default number of extra per-chain kernel steps run after warmup, at the
+frozen shared metric, before start-state probation hands off to sampling.
+Same order of magnitude as the existing `_STEP_SIZE_READAPT_BUFFER=50`
+budget-reserve convention in this file -- a small, fixed, honestly-charged
+warmup-cost tax (concatenated into the returned info stream) regardless of
+whether any chain actually needed rehabilitation."""
+
+_PROBATION_BACKOFF_FACTOR: float = 0.3
+"""Multiplicative step-size shrink applied to a chain's OWN probation step
+size the step immediately after that chain diverges."""
+
+_PROBATION_RECOVERY_RATE: float = 1.15
+"""Multiplicative growth applied to a chain's probation step size every
+probation step (capped at the shared step size).  ~9-10 steps to recover
+from one full backoff, well inside a `_PROBATION_WINDOW_DEFAULT`-step
+window even after a couple of re-triggered divergences."""
+
+_PROBATION_RESOLVED_TOL: float = 0.95
+"""A chain's probation step size must reach at least this fraction of the
+shared step size by the end of the window to count as "resolved"; chains
+that don't are reported as `n_chains_unresolved` in the probation
+diagnostics -- the routine's loud failure channel for that chain (see
+:func:`~blackjax.adaptation.staged_adaptation._apply_start_state_probation`
+docstring for what a practitioner should do when this fires)."""
 
 
 # ---------------------------------------------------------------------------

--- a/blackjax/adaptation/meta/_start_state.py
+++ b/blackjax/adaptation/meta/_start_state.py
@@ -1,0 +1,243 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Post-warmup per-chain start-state safety (Issue#1064): stages 1 and 2a.
+
+Stage 1 -- ensemble-calibrated typical-region gate (:func:`loo_state_gate`).
+The multi-chain meta-adaptation controller already calibrates its ROUTE
+decision from the ensemble (the between-chain magnitude/collinearity/
+leave-one-out gates in :mod:`~blackjax.adaptation.meta._detection` decide
+*whether the emitted metric should escalate*).  This module applies the
+identical leave-one-out calibration principle one level down, to the
+per-chain STATE the warmup hands off to sampling: each chain's post-warmup
+potential energy (``-logdensity``, already cached on the warmup's final
+``HMCState`` -- zero extra gradient cost) is compared against a reference
+typical region built from the OTHER ``M-1`` chains only.  A chain whose
+energy falls outside that region is flagged as having landed somewhere the
+rest of the ensemble does not corroborate as typical under the emitted
+products.  This is only possible because the routine is multi-chain -- the
+ensemble supplies the reference distribution that a single chain cannot
+supply for itself.  The gate is an empirical, operational stand-in for a
+state-level calibration statistic; it is deliberately NOT the trigger for
+:mod:`~blackjax.adaptation.staged_adaptation`'s reactive step-size-backoff
+fallback (stage 2b there runs unconditionally regardless of this gate's
+verdict), only for the proactive redraw in stage 2a below.
+
+Stage 2a -- redraw near a healthy anchor (:func:`redraw_flagged_chains`).
+A flagged chain's position is replaced by the ACTUAL position of the
+non-flagged chain closest to ensemble consensus, plus a small
+mass-matrix-consistent jitter (drawn through the emitted metric's own
+``scale`` operator, so the perturbation respects the warmup's geometry
+rather than an arbitrary isotropic nudge).  Anchoring on a genuine sampled
+position (not a synthetic mean/median across chains) avoids landing outside
+the typical set in high dimension, where averaging points is not guaranteed
+to stay typical.
+
+Both functions are pure (no kernel calls, no MCMC state threading) so they
+can be tested and reasoned about independently of
+:mod:`~blackjax.adaptation.staged_adaptation`, which owns stage 2b (the
+per-chain probation scan) because that stage needs the built kernel and an
+rng stream neither of these functions require.
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+
+from blackjax.mcmc.metrics import MetricTypes, default_metric
+from blackjax.types import Array, ArrayLikeTree, PRNGKey
+from blackjax.util import generate_gaussian_noise
+
+__all__ = [
+    "loo_logdensity_z_scores",
+    "loo_state_gate",
+    "select_healthy_anchor",
+    "redraw_flagged_chains",
+    "compute_chain_energies",
+]
+
+
+def loo_logdensity_z_scores(logdensities: Array) -> Array:
+    """Leave-one-out z-score of each chain's logdensity vs. the other M-1 chains.
+
+    For chain ``i``, the reference mean/std is computed from the ``M-1``
+    OTHER chains only (never including chain ``i`` itself) -- the same
+    leave-one-out convention used by
+    :func:`~blackjax.adaptation.meta._detection._loo_detection_passes` for
+    the route-level between-chain gate.  Excluding the chain under test from
+    its own reference avoids the "swamping" failure mode where a genuine
+    outlier inflates the very statistic meant to detect it.
+
+    Parameters
+    ----------
+    logdensities
+        Shape ``(M,)``, one scalar per chain.
+
+    Returns
+    -------
+    Array
+        Shape ``(M,)`` z-scores.  Degenerate (not meaningful) for ``M < 4``;
+        callers should gate on :data:`~blackjax.adaptation.meta._calibration._STATE_GATE_MIN_CHAINS`.
+    """
+    M = logdensities.shape[0]
+    ld = logdensities.astype(jnp.float32)
+    total = jnp.sum(ld)
+    total_sq = jnp.sum(ld**2)
+    loo_sum = total - ld
+    loo_mean = loo_sum / jnp.float32(M - 1)
+    loo_sumsq = total_sq - ld**2
+    # Sample variance of the OTHER M-1 values (ddof=1 -> divide by M-2).
+    loo_var = (loo_sumsq - (M - 1) * loo_mean**2) / jnp.float32(max(M - 2, 1))
+    loo_std = jnp.sqrt(jnp.maximum(loo_var, jnp.float32(1e-12)))
+    return (ld - loo_mean) / loo_std
+
+
+def loo_state_gate(logdensities: Array, threshold: float, min_chains: int) -> Array:
+    """Ensemble-calibrated typical-region gate (stage 1).
+
+    Parameters
+    ----------
+    logdensities
+        Shape ``(M,)`` post-warmup potential-energy proxy (``-logdensity``
+        sign convention is irrelevant here; only relative spread matters).
+    threshold
+        Absolute leave-one-out z-score above which a chain is flagged.
+    min_chains
+        Below this many chains the leave-one-out reference is too noisy
+        (dof = M-2 too small); the gate is skipped and no chain is flagged.
+
+    Returns
+    -------
+    Array
+        Boolean mask, shape ``(M,)``. ``True`` = outside the calibrated
+        typical region.
+    """
+    M = logdensities.shape[0]
+    if M < min_chains:
+        return jnp.zeros((M,), dtype=jnp.bool_)
+    z = loo_logdensity_z_scores(logdensities)
+    return jnp.abs(z) > threshold
+
+
+def select_healthy_anchor(logdensities: Array, flagged_mask: Array) -> Array:
+    """Index of the non-flagged chain closest to ensemble consensus.
+
+    Flagged chains are excluded from consideration (their |z| is treated as
+    infinite for the purposes of selection).  If every chain happens to be
+    flagged, falls back to the least-extreme chain (defensive; not expected
+    in practice given the LOO construction).
+    """
+    z = loo_logdensity_z_scores(logdensities)
+    z_for_selection = jnp.where(flagged_mask, jnp.inf, jnp.abs(z))
+    return jnp.argmin(z_for_selection)
+
+
+def redraw_flagged_chains(
+    position: ArrayLikeTree,
+    flagged_mask: Array,
+    anchor_idx: Array,
+    metric: MetricTypes,
+    rng_key: PRNGKey,
+    jitter_scale: float,
+) -> ArrayLikeTree:
+    """Replace flagged chains' positions with a jittered copy of the anchor's (stage 2a).
+
+    Works uniformly for a bare flat-array position or a structured PyTree
+    position (e.g. a dict of per-site arrays), matching every other position
+    shape blackjax supports elsewhere in the multi-chain path.
+
+    Parameters
+    ----------
+    position
+        PyTree with a leading ``(M, ...)`` per-chain batch dimension on every
+        leaf.
+    flagged_mask
+        Shape ``(M,)`` boolean; ``True`` chains get replaced.
+    anchor_idx
+        Scalar index of the chain to anchor the redraw on (see
+        :func:`select_healthy_anchor`).
+    metric
+        The emitted shared metric (e.g. a
+        :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`); the
+        jitter is drawn through this metric's ``scale`` operator so the
+        perturbation is mass-matrix-consistent rather than an arbitrary
+        isotropic nudge.
+    rng_key
+        RNG key for the per-chain jitter draws.
+    jitter_scale
+        Fraction of the metric's scale used for the jitter (see
+        :data:`~blackjax.adaptation.meta._calibration._STATE_GATE_REDRAW_JITTER_SCALE`).
+
+    Returns
+    -------
+    ArrayLikeTree
+        Same PyTree structure and leading ``(M, ...)`` shape as ``position``.
+    """
+    M = flagged_mask.shape[0]
+    anchor_position = jax.tree.map(lambda x: x[anchor_idx], position)
+    metric_obj = default_metric(metric)
+    chain_keys = jax.random.split(rng_key, M)
+    noise = jax.vmap(lambda k: generate_gaussian_noise(k, anchor_position))(chain_keys)
+    jitter = jax.vmap(
+        lambda n: metric_obj.scale(anchor_position, n, inv=False, trans=False)
+    )(noise)
+
+    def _select(orig_leaf, anchor_leaf, jitter_leaf):
+        redrawn_leaf = anchor_leaf[None, ...] + jitter_scale * jitter_leaf
+        mask_shape = (M,) + (1,) * (orig_leaf.ndim - 1)
+        mask_b = flagged_mask.reshape(mask_shape)
+        return jnp.where(mask_b, redrawn_leaf, orig_leaf)
+
+    return jax.tree.map(_select, position, anchor_position, jitter)
+
+
+def compute_chain_energies(
+    position: ArrayLikeTree,
+    logdensity: Array,
+    metric: MetricTypes,
+    rng_key: PRNGKey,
+) -> Array:
+    """Per-chain Hamiltonian energy ``-logdensity + kinetic(fresh momentum)``.
+
+    NOT a gate trigger -- an OBSERVABLE recorded in the probation
+    diagnostics (per TL amendment A) so the ensemble's energy spread is
+    visible for future calibration work, presenting the empirical LOO probe
+    above as one operational form of a broader state-level calibration idea
+    (the same principle the controller already applies at the route level,
+    one level down: route -> parameter -> state).  Momentum is freshly
+    resampled per call, which is why this is an observable rather than a
+    trigger: the LOO gate uses the noise-free potential energy already
+    cached on the warmup state, not this stochastic quantity.
+
+    Parameters
+    ----------
+    position
+        PyTree with leading ``(M, ...)`` batch dimension.
+    logdensity
+        Shape ``(M,)``.
+    metric
+        The emitted shared metric.
+    rng_key
+        RNG key for the per-chain momentum draw.
+
+    Returns
+    -------
+    Array
+        Shape ``(M,)`` energies.
+    """
+    M = logdensity.shape[0]
+    metric_obj = default_metric(metric)
+    chain_keys = jax.random.split(rng_key, M)
+    momentum = jax.vmap(metric_obj.sample_momentum)(chain_keys, position)
+    kinetic = jax.vmap(metric_obj.kinetic_energy)(momentum)
+    return -logdensity + kinetic

--- a/blackjax/adaptation/meta/verdict.py
+++ b/blackjax/adaptation/meta/verdict.py
@@ -207,10 +207,14 @@ def extract_multi_chain_verdict(
     probation_result
         Optional diagnostics dict from
         :func:`~blackjax.adaptation.staged_adaptation._apply_start_state_probation`
-        (i.e. ``results.parameters.get("start_state_probation")`` after a
-        ``staged_adaptation(..., start_state_probation=True)`` run).  ``None``
-        (default) — no change to ``flags`` for any existing caller.  When
-        provided, its fields are folded into ``flags`` under a
+        (i.e. ``info.diagnostics``, where ``info`` is the
+        :class:`~blackjax.adaptation.staged_adaptation.StagedAdaptationInfo`
+        that ``staged_adaptation(..., start_state_probation=True)``'s
+        ``run()`` returns as its second value — NOT
+        ``results.parameters``, which stays a pure sampler-kwargs dict;
+        Issue#1090 fix 1).  ``None`` (default) — no change to ``flags`` for
+        any existing caller.  When provided, its fields are folded into
+        ``flags`` under a
         ``start_state_probation_*`` prefix — the "no silent interventions"
         surface for this mechanism: whether the ensemble-calibrated state
         gate flagged any chain, whether a redraw was applied, and whether any

--- a/blackjax/adaptation/meta/verdict.py
+++ b/blackjax/adaptation/meta/verdict.py
@@ -185,6 +185,7 @@ def extract_multi_chain_verdict(
     adaptation_info: Any = None,
     *,
     pooled_draws_by_window: Any = None,
+    probation_result: dict | None = None,
 ) -> MetaAdaptationVerdict:
     """Build a :class:`~blackjax.adaptation.meta._state.MetaAdaptationVerdict` from a multi-chain final core state.
 
@@ -203,6 +204,19 @@ def extract_multi_chain_verdict(
         (shape ``(n_chains, n_per_window, d)`` per window).  Not used internally
         — passed through as ``flags["pooled_draws_by_window"]`` for the
         evaluation layer.
+    probation_result
+        Optional diagnostics dict from
+        :func:`~blackjax.adaptation.staged_adaptation._apply_start_state_probation`
+        (i.e. ``results.parameters.get("start_state_probation")`` after a
+        ``staged_adaptation(..., start_state_probation=True)`` run).  ``None``
+        (default) — no change to ``flags`` for any existing caller.  When
+        provided, its fields are folded into ``flags`` under a
+        ``start_state_probation_*`` prefix — the "no silent interventions"
+        surface for this mechanism: whether the ensemble-calibrated state
+        gate flagged any chain, whether a redraw was applied, and whether any
+        chain's probation step size never recovered
+        (``start_state_probation_n_chains_unresolved`` — see that function's
+        docstring for what a practitioner should do when this is nonzero).
 
     Returns
     -------
@@ -391,6 +405,10 @@ def extract_multi_chain_verdict(
         "r1_top": r1_top_raw,
         "detection_branch": detection_branch_name,
     }
+
+    if probation_result is not None:
+        for _key, _val in probation_result.items():
+            flags[f"start_state_probation_{_key}"] = _val
 
     return MetaAdaptationVerdict(
         route=route,

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -565,6 +565,20 @@ def _apply_start_state_probation(
     are bit-identical to what they already had, since redraw is a
     ``jnp.where`` selection on position before re-evaluating).
 
+    Honest caveat: a redrawn chain starts CORRELATED with its anchor (same
+    position plus a small jitter), so any early-window between-chain
+    diagnostic computed on a short post-warmup prefix (e.g. split-R-hat on
+    the first few sampling draws) is ANTI-CONSERVATIVE for that specific
+    pair of chains -- it will underestimate their disagreement because they
+    are not yet independent draws.  This is not silently swept under the
+    rug: ``diagnostics["flagged_chain_idx"]`` identifies exactly which
+    chain(s) started this way, so a practitioner computing early-window
+    diagnostics can exclude or down-weight that chain if it matters for
+    their use case.  The correlation is a transient of the redrawn chain's
+    OWN subsequent dynamics (not of the anchor, which is untouched) and
+    washes out as the chain decorrelates from its start over the run, the
+    same way any single chain forgets its initialisation.
+
     **Stage 2b -- per-chain probation (reactive, unconditional fallback).**
     Every chain -- flagged or not -- runs ``window`` extra real kernel steps
     at the FROZEN shared metric, with a per-chain step size that backs off
@@ -597,17 +611,41 @@ def _apply_start_state_probation(
     is only ever invoked when the feature is enabled, so the main scan's own
     key derivation is never perturbed by this call existing).
 
-    ``n_chains_unresolved`` in the diagnostics dict means: this chain's
-    probation step size had NOT recovered to
-    :data:`~blackjax.adaptation.meta._calibration._PROBATION_RESOLVED_TOL`
-    of the shared step size by the end of the window, i.e. it kept
-    re-triggering the backoff.  This is the routine's LOUD FAILURE CHANNEL
-    for that chain: a practitioner seeing it set should not trust that
-    chain's early sampling draws at face value.  The recommended action is
-    to re-run warmup with a larger ``probation_window``, or inspect that
-    chain's post-warmup trajectory directly (e.g. via the ``is_divergent``
-    trace in the concatenated ``info``) -- not to silently proceed as if
-    nothing happened.
+    Actionable diagnostics -- what a practitioner should DO when each fires:
+
+    - ``n_chains_flagged_by_state_gate > 0`` -- stage 1 found a chain whose
+      post-warmup potential energy the rest of the ensemble does not
+      corroborate as typical.  This is informational once stage 2a/2b have
+      run (the chain was already corrected); a practitioner auditing a run
+      should treat it as confirmation the mechanism found something to fix,
+      and can cross-check ``pre_probation_logdensity`` /
+      ``post_probation_logdensity`` (below) for that chain to see the
+      before/after.
+    - ``redraw_applied`` -- ``True`` means stage 2a actually rewrote a
+      chain's starting position (not just a no-op pass-through).  See the
+      correlated-anchor caveat above for what this implies for early-window
+      diagnostics on that specific chain.
+    - ``n_chains_unresolved`` -- this chain's probation step size had NOT
+      recovered to
+      :data:`~blackjax.adaptation.meta._calibration._PROBATION_RESOLVED_TOL`
+      of the shared step size by the end of the window, i.e. it kept
+      re-triggering the backoff.  This is the routine's LOUD FAILURE CHANNEL
+      for that chain: a practitioner seeing it set should not trust that
+      chain's early sampling draws at face value.  The recommended action
+      is to re-run warmup with a larger ``probation_window``, or inspect
+      that chain's post-warmup trajectory directly (e.g. via the
+      ``is_divergent`` trace in the concatenated ``info``) -- not to
+      silently proceed as if nothing happened.
+
+    ``pre_probation_logdensity`` / ``post_probation_logdensity`` in the
+    diagnostics dict are the per-chain ``(M,)`` logdensity values BEFORE
+    stage 1 acts and AFTER stage 2b completes -- both free (already cached
+    on the relevant ``HMCState``, no extra evaluation).  Unlike an energy
+    computed from a freshly resampled momentum, these are EXACTLY the
+    quantity stage 1's gate itself operates on, so the pair is directly
+    auditable against the gate's own decision: a practitioner can confirm a
+    flagged chain's logdensity actually moved toward the ensemble's range
+    after rehabilitation.
 
     Returns
     -------
@@ -730,6 +768,13 @@ def _apply_start_state_probation(
         "unresolved_chain_idx": tuple(
             int(i) for i in np.nonzero(np.asarray(unresolved))[0]
         ),
+        # Free (already cached), and exactly the quantity stage 1's gate
+        # acts on -- directly auditable against the gate's own decision.
+        "pre_probation_logdensity": np.asarray(logdensities).tolist(),
+        "post_probation_logdensity": np.asarray(final_states.logdensity).tolist(),
+        # Hamiltonian energy (logdensity + kinetic at a freshly resampled
+        # momentum) -- a supplementary, noisier observable kept alongside
+        # the logdensity pair above (not a trigger for either stage).
         "pre_probation_energy": np.asarray(pre_energy).tolist(),
         "post_probation_energy": np.asarray(post_energy).tolist(),
         "extra_grad_evals": extra_grad_evals,

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -516,6 +516,228 @@ def _resolve_metric_and_schedule(
     return metric_core, resolved_schedule
 
 
+# ---------------------------------------------------------------------------
+# Start-state probation (multi-chain post-warmup safety margin; Issue#1064).
+# Stages 1 (ensemble-calibrated typical-region gate) and 2a (redraw near a
+# healthy anchor) are pure functions in blackjax.adaptation.meta._start_state
+# -- no kernel access needed there.  Stage 2b (the per-chain probation scan)
+# needs the built kernel and an rng stream, so it lives here.
+# ---------------------------------------------------------------------------
+
+
+def _apply_start_state_probation(
+    rng_key: PRNGKey,
+    last_chain_state: Any,
+    mcmc_kernel: Callable,
+    algorithm_init: Callable,
+    logdensity_fn: Callable,
+    step_size: Array,
+    inverse_mass_matrix: Any,
+    n_chains: int,
+    window: int,
+    extra_parameters: dict,
+    adaptation_info_fn: Callable,
+    frozen_adaptation_state: Any,
+) -> tuple[Any, Any, dict]:
+    """Post-warmup per-chain start-state safety (Issue#1064).
+
+    Runs once, after the shared warmup products (``step_size``,
+    ``inverse_mass_matrix``) are finalised.  Three stages:
+
+    **Stage 1 -- ensemble-calibrated state gate (proactive).**
+    :func:`~blackjax.adaptation.meta._start_state.loo_state_gate` compares
+    each chain's ALREADY-CACHED post-warmup potential energy
+    (``-logdensity``) against a leave-one-out reference typical region built
+    from the OTHER ``n_chains - 1`` chains -- the same calibration principle
+    the controller already applies at the route level (between-chain
+    magnitude/collinearity/leave-one-out gates), one level down: route ->
+    parameter -> state.  Zero extra gradient cost.  This is a proactive
+    GATE, not a decision that skips stage 2b -- stage 2b always runs
+    regardless of this gate's verdict (see below).
+
+    **Stage 2a -- redraw near a healthy anchor (reactive, primary
+    correction).** A chain flagged by stage 1 is re-initialised at the
+    ACTUAL position of the healthiest non-flagged chain plus a small
+    mass-matrix-consistent jitter
+    (:func:`~blackjax.adaptation.meta._start_state.redraw_flagged_chains`).
+    Costs one extra ``(logdensity, grad)`` evaluation per chain (computed
+    for all ``n_chains`` for simplicity -- the non-flagged chains' values
+    are bit-identical to what they already had, since redraw is a
+    ``jnp.where`` selection on position before re-evaluating).
+
+    **Stage 2b -- per-chain probation (reactive, unconditional fallback).**
+    Every chain -- flagged or not -- runs ``window`` extra real kernel steps
+    at the FROZEN shared metric, with a per-chain step size that backs off
+    by :data:`~blackjax.adaptation.meta._calibration._PROBATION_BACKOFF_FACTOR`
+    immediately after that chain diverges and recovers geometrically at
+    :data:`~blackjax.adaptation.meta._calibration._PROBATION_RECOVERY_RATE`
+    per step, capped at the shared step size.  This runs unconditionally
+    (not just for flagged chains) because under ``vmap`` all chains execute
+    in lockstep regardless of masking, and because stage 1's energy proxy is
+    necessarily imperfect -- a chain can sit at a perfectly typical energy
+    level while still being in a locally stiff neighbourhood (e.g.
+    heteroskedastic volatility states in stochastic-volatility models).
+    Stage 2b is the reactive complement to stage 1's proactive correction,
+    not an alternative to it.
+
+    The deployed ``step_size`` / ``inverse_mass_matrix`` this function is
+    called with are NEVER changed or returned differently -- only the
+    per-chain STARTING POSITION handed to sampling is touched.  Every
+    probation-phase kernel call's info record (built via the caller's own
+    ``adaptation_info_fn``, so any custom slimming is respected) is
+    concatenated onto the caller's main-loop ``info`` stream on the step
+    axis, so a caller already computing
+    ``sum(info.info.num_integration_steps)`` for a gradient ledger, or
+    ``sum(info.info.is_divergent)`` for a warmup-divergence count,
+    automatically and correctly charges this phase as WARMUP cost -- no
+    caller-side ledger changes are required.
+
+    RNG discipline: ``rng_key`` is split HERE, independently of whatever the
+    caller already derived from it for the main warmup scan (this function
+    is only ever invoked when the feature is enabled, so the main scan's own
+    key derivation is never perturbed by this call existing).
+
+    ``n_chains_unresolved`` in the diagnostics dict means: this chain's
+    probation step size had NOT recovered to
+    :data:`~blackjax.adaptation.meta._calibration._PROBATION_RESOLVED_TOL`
+    of the shared step size by the end of the window, i.e. it kept
+    re-triggering the backoff.  This is the routine's LOUD FAILURE CHANNEL
+    for that chain: a practitioner seeing it set should not trust that
+    chain's early sampling draws at face value.  The recommended action is
+    to re-run warmup with a larger ``probation_window``, or inspect that
+    chain's post-warmup trajectory directly (e.g. via the ``is_divergent``
+    trace in the concatenated ``info``) -- not to silently proceed as if
+    nothing happened.
+
+    Returns
+    -------
+    tuple[Any, Any, dict]
+        ``(rehabilitated_chain_state, probation_info, diagnostics)`` where
+        ``probation_info`` has the same PyTree structure as one step of the
+        caller's main-loop ``info`` (leading axis = ``window``), ready to be
+        concatenated onto it, and ``diagnostics`` is a JSON-safe dict.
+    """
+    import numpy as np
+
+    from blackjax.adaptation.meta._calibration import (
+        _PROBATION_BACKOFF_FACTOR,
+        _PROBATION_RECOVERY_RATE,
+        _PROBATION_RESOLVED_TOL,
+        _STATE_GATE_LOO_Z_THRESHOLD,
+        _STATE_GATE_MIN_CHAINS,
+        _STATE_GATE_REDRAW_JITTER_SCALE,
+    )
+    from blackjax.adaptation.meta._start_state import (
+        compute_chain_energies,
+        loo_state_gate,
+        redraw_flagged_chains,
+        select_healthy_anchor,
+    )
+
+    M = n_chains
+    logdensities = last_chain_state.logdensity  # (M,), already cached -- free
+
+    # ---- Stage 1: ensemble-calibrated state gate ----
+    flagged_mask = loo_state_gate(
+        logdensities, _STATE_GATE_LOO_Z_THRESHOLD, _STATE_GATE_MIN_CHAINS
+    )
+    anchor_idx = select_healthy_anchor(logdensities, flagged_mask)
+
+    (
+        redraw_key,
+        energy_key_pre,
+        energy_key_post,
+        probation_master_key,
+    ) = jax.random.split(rng_key, 4)
+
+    pre_energy = compute_chain_energies(
+        last_chain_state.position, logdensities, inverse_mass_matrix, energy_key_pre
+    )
+
+    # ---- Stage 2a: redraw flagged chains near the healthy anchor ----
+    redrawn_position = redraw_flagged_chains(
+        last_chain_state.position,
+        flagged_mask,
+        anchor_idx,
+        inverse_mass_matrix,
+        redraw_key,
+        _STATE_GATE_REDRAW_JITTER_SCALE,
+    )
+    rehabilitated_state = jax.vmap(lambda pos: algorithm_init(pos, logdensity_fn))(
+        redrawn_position
+    )
+
+    # ---- Stage 2b: per-chain probation with divergence-triggered backoff ----
+    probation_keys = jax.random.split(probation_master_key, window)
+    init_step_sizes = jnp.full((M,), step_size, dtype=jnp.asarray(step_size).dtype)
+    init_ever_diverged = jnp.zeros((M,), dtype=jnp.bool_)
+
+    def _probation_step(carry, key):
+        states_p, step_sizes_p, ever_diverged_p = carry
+        chain_keys = jax.random.split(key, M)
+
+        def _step_one(k, state, h_i):
+            return mcmc_kernel(
+                k, state, logdensity_fn, h_i, inverse_mass_matrix, **extra_parameters
+            )
+
+        new_states_p, infos_p = jax.vmap(_step_one)(chain_keys, states_p, step_sizes_p)
+        is_div = infos_p.is_divergent
+        backed_off = jnp.where(
+            is_div, step_sizes_p * jnp.asarray(_PROBATION_BACKOFF_FACTOR), step_sizes_p
+        )
+        recovered = jnp.minimum(
+            backed_off * jnp.asarray(_PROBATION_RECOVERY_RATE), step_size
+        )
+        new_ever_diverged = ever_diverged_p | is_div
+        record = adaptation_info_fn(new_states_p, infos_p, frozen_adaptation_state)
+        return (new_states_p, recovered, new_ever_diverged), record
+
+    (final_states, final_step_sizes, ever_diverged), probation_info = jax.lax.scan(
+        _probation_step,
+        (rehabilitated_state, init_step_sizes, init_ever_diverged),
+        probation_keys,
+    )
+
+    post_energy = compute_chain_energies(
+        final_states.position,
+        final_states.logdensity,
+        inverse_mass_matrix,
+        energy_key_post,
+    )
+
+    unresolved = final_step_sizes < (jnp.asarray(_PROBATION_RESOLVED_TOL) * step_size)
+
+    try:
+        extra_grad_evals = int(jnp.sum(probation_info.info.num_integration_steps))
+    except AttributeError:
+        extra_grad_evals = -1
+
+    diagnostics = {
+        "enabled": True,
+        "window": window,
+        "backoff_factor": _PROBATION_BACKOFF_FACTOR,
+        "recovery_rate": _PROBATION_RECOVERY_RATE,
+        "resolved_tol": _PROBATION_RESOLVED_TOL,
+        "state_gate_z_threshold": _STATE_GATE_LOO_Z_THRESHOLD,
+        "n_chains_flagged_by_state_gate": int(jnp.sum(flagged_mask)),
+        "flagged_chain_idx": tuple(
+            int(i) for i in np.nonzero(np.asarray(flagged_mask))[0]
+        ),
+        "redraw_applied": bool(jnp.any(flagged_mask)),
+        "n_chains_diverged_during_probation": int(jnp.sum(ever_diverged)),
+        "n_chains_unresolved": int(jnp.sum(unresolved)),
+        "unresolved_chain_idx": tuple(
+            int(i) for i in np.nonzero(np.asarray(unresolved))[0]
+        ),
+        "pre_probation_energy": np.asarray(pre_energy).tolist(),
+        "post_probation_energy": np.asarray(post_energy).tolist(),
+        "extra_grad_evals": extra_grad_evals,
+    }
+
+    return final_states, probation_info, diagnostics
+
+
 def staged_adaptation(
     algorithm,
     logdensity_fn: Callable,
@@ -531,6 +753,8 @@ def staged_adaptation(
     integrator=mcmc.integrators.velocity_verlet,
     schedule_fn: Callable | None = None,
     initial_metric_state: Any = None,
+    start_state_probation: bool = False,
+    probation_window: int | None = None,
     **extra_parameters,
 ) -> AdaptationAlgorithm:
     """Adapt the step size and inverse mass matrix for HMC-family algorithms.
@@ -631,6 +855,40 @@ def staged_adaptation(
         that seed the initial state from external data (e.g., gradient-based
         diagonal-scale initialisation); ``None`` (the default) reproduces
         the standard identity/zero initialisation.
+    start_state_probation
+        Opt-in (default ``False``) per-chain post-warmup start-state safety
+        margin for the multi-chain path (Issue#1064).  Requires ``n_chains >
+        1`` (raises ``ValueError`` otherwise).  When enabled, after the
+        shared ``step_size`` / ``inverse_mass_matrix`` are finalised: (1) an
+        ensemble-calibrated leave-one-out gate flags any chain whose
+        post-warmup potential energy falls outside the region the other
+        chains corroborate as typical; (2) a flagged chain's position is
+        redrawn near the healthiest chain's actual position; (3)
+        UNCONDITIONALLY (regardless of stage 1's verdict), every chain runs
+        ``probation_window`` extra real kernel steps at the frozen shared
+        metric with a per-chain step size that backs off on divergence and
+        anneals back toward the shared value.  See
+        :func:`~blackjax.adaptation.staged_adaptation._apply_start_state_probation`
+        for the full mechanism.  The deployed ``step_size`` /
+        ``inverse_mass_matrix`` returned in ``parameters`` are never changed
+        by this — only the starting position for sampling is.  All extra
+        kernel calls are folded into the returned ``info`` stream (same step
+        axis as the main warmup loop), so any caller already summing
+        ``info.info.num_integration_steps`` for a gradient ledger, or
+        ``info.info.is_divergent`` for a warmup-divergence count,
+        automatically and correctly charges this phase as warmup cost.
+        Diagnostics land at ``parameters["start_state_probation"]`` (present
+        only when enabled); see
+        :func:`~blackjax.adaptation.meta.verdict.extract_multi_chain_verdict`'s
+        ``probation_result`` argument to fold them into a verdict's
+        ``flags``.  Requires the algorithm's kernel info to expose
+        ``is_divergent`` (true for HMC and NUTS, the only algorithms
+        currently exercised through the multi-chain path).
+    probation_window
+        Number of extra per-chain steps for the ``start_state_probation``
+        window.  ``None`` (default) uses
+        :data:`~blackjax.adaptation.meta._calibration._PROBATION_WINDOW_DEFAULT`.
+        Ignored when ``start_state_probation=False``.
     **extra_parameters
         Algorithm-specific parameters forwarded to the MCMC kernel at every step,
         e.g. ``num_integration_steps`` for HMC/MHMC (divides budget when
@@ -670,6 +928,13 @@ def staged_adaptation(
             "(the multi-chain pooled gate is implemented in the meta-adaptation "
             "controller). For other metric strings pass n_chains=1 (default) and "
             "vmap the warmup call externally."
+        )
+    if start_state_probation and n_chains <= 1:
+        raise ValueError(
+            "staged_adaptation: start_state_probation=True requires n_chains > 1 "
+            "-- per-chain rehabilitation needs a multi-chain ensemble to supply "
+            "the reference typical region. Pass n_chains>1 (with metric='auto') "
+            "or leave start_state_probation at its default False."
         )
 
     metric_core, _resolved_schedule_fn = _resolve_metric_and_schedule(
@@ -966,11 +1231,52 @@ def staged_adaptation(
             last_chain_state, last_warmup_state, *_ = last_state
 
         step_size, inverse_mass_matrix = adapt_final(last_warmup_state)
+
+        probation_diagnostics: dict | None = None
+        if start_state_probation:
+            from blackjax.adaptation.meta._calibration import _PROBATION_WINDOW_DEFAULT
+
+            _probation_window = (
+                probation_window
+                if probation_window is not None
+                else _PROBATION_WINDOW_DEFAULT
+            )
+            # Independent derivation from rng_key -- only ever taken when this
+            # feature is enabled, so the main scan's own key derivation above
+            # (`keys = jax.random.split(rng_key, num_steps)`) is never
+            # perturbed by this branch existing.
+            probation_key = jax.random.fold_in(rng_key, 0x1064)
+            (
+                last_chain_state,
+                probation_info,
+                probation_diagnostics,
+            ) = _apply_start_state_probation(
+                probation_key,
+                last_chain_state,
+                mcmc_kernel,
+                algorithm.init,
+                logdensity_fn,
+                step_size,
+                inverse_mass_matrix,
+                _n_chains,
+                _probation_window,
+                _warmup_extra_params,
+                adaptation_info_fn,
+                last_warmup_state,
+            )
+            info = jax.tree.map(
+                lambda main, extra: jnp.concatenate([main, extra], axis=0),
+                info,
+                probation_info,
+            )
+
         parameters = {
             "step_size": step_size,
             "inverse_mass_matrix": inverse_mass_matrix,
             **extra_parameters,
         }
+        if probation_diagnostics is not None:
+            parameters["start_state_probation"] = probation_diagnostics
 
         return (
             AdaptationResults(

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -55,6 +55,7 @@ from blackjax.util import pytree_size
 
 __all__ = [
     "StagedAdaptationState",
+    "StagedAdaptationInfo",
     "build_schedule",
     "staged_adaptation",
 ]
@@ -525,6 +526,60 @@ def _resolve_metric_and_schedule(
 # ---------------------------------------------------------------------------
 
 
+class StagedAdaptationInfo(NamedTuple):
+    """Second return value of ``run()`` when ``start_state_probation=True``.
+
+    Routes the start-state-probation diagnostics dict alongside the info
+    stream instead of polluting ``AdaptationResults.parameters`` (Issue#1090
+    fix 1) -- ``parameters`` is fed directly into ``algorithm(logdensity_fn,
+    **result.parameters)`` (the documented sampler-deploy pattern), and a
+    ``"start_state_probation"`` dict value there is not a valid sampler
+    kwarg, so it must live on the OTHER side of ``run()``'s ``(results,
+    info)`` return pair, not inside ``results``.  Extending
+    ``AdaptationResults`` itself (adding a third field) was considered and
+    rejected: ``state, params = result`` positional-unpacking of
+    ``AdaptationResults`` is a documented pattern already in the wild, and a
+    third field breaks that 2-unpack regardless of any default value: this
+    wrapper instead grows the SECOND element of ``run()``'s own top-level
+    ``(results, info)`` pair, whose arity is untouched (``results, info =
+    warmup.run(...)`` still 2-unpacks correctly; only ``info``'s internal
+    type varies with ``start_state_probation``, and only for this brand-new,
+    still-unreleased opt-in feature -- no caller of the disabled path can
+    observe this).
+
+    When ``start_state_probation=False`` (the default), ``run()``'s second
+    return value is the bare ``info`` stream (bit-identical to the pre-#1064
+    contract) -- this wrapper is NEVER constructed on the disabled path.
+
+    Parameters
+    ----------
+    trace
+        The concatenated per-step adaptation info stream: the caller's
+        ``adaptation_info_fn`` applied to every main-warmup step AND every
+        probation step -- same PyTree structure ``run()`` returns when the
+        feature is disabled.  Its leading (step) axis has length
+        ``num_steps + probation_window``, longer than the caller's declared
+        ``num_steps`` (Issue#1090 fix 2).  A consumer that needs exactly the
+        prescribed-schedule prefix (e.g. to index schedule boundaries) MUST
+        slice ``trace`` to ``diagnostics["warmup_boundary_index"]`` first,
+        e.g. ``jax.tree.map(lambda x: x[:diagnostics["warmup_boundary_index"]],
+        trace)``.  A caller that wants the automatic warmup-cost ledger
+        (e.g. ``sum(trace.info.num_integration_steps)`` charging the
+        probation phase as warmup cost too) uses ``trace`` unsliced.
+    diagnostics
+        The start-state-probation diagnostics dict from
+        :func:`_apply_start_state_probation`, plus ``warmup_boundary_index``
+        (the index into ``trace`` where the probation tail begins -- i.e.
+        ``trace[:warmup_boundary_index]`` is exactly the prescribed
+        schedule).  Pass this dict as
+        :func:`~blackjax.adaptation.meta.verdict.extract_multi_chain_verdict`'s
+        ``probation_result`` argument to fold it into a verdict's ``flags``.
+    """
+
+    trace: Any
+    diagnostics: dict
+
+
 def _apply_start_state_probation(
     rng_key: PRNGKey,
     last_chain_state: Any,
@@ -709,9 +764,10 @@ def _apply_start_state_probation(
     probation_keys = jax.random.split(probation_master_key, window)
     init_step_sizes = jnp.full((M,), step_size, dtype=jnp.asarray(step_size).dtype)
     init_ever_diverged = jnp.zeros((M,), dtype=jnp.bool_)
+    init_grad_evals = jnp.asarray(0, dtype=jnp.int32)
 
     def _probation_step(carry, key):
-        states_p, step_sizes_p, ever_diverged_p = carry
+        states_p, step_sizes_p, ever_diverged_p, grad_evals_p = carry
         chain_keys = jax.random.split(key, M)
 
         def _step_one(k, state, h_i):
@@ -728,12 +784,30 @@ def _apply_start_state_probation(
             backed_off * jnp.asarray(_PROBATION_RECOVERY_RATE), step_size
         )
         new_ever_diverged = ever_diverged_p | is_div
+        # Accumulate from infos_p -- the algorithm's OWN raw kernel Info
+        # (HMCInfo/NUTSInfo, the only two algorithms this multi-chain path
+        # supports; see the start_state_probation docstring) -- never from
+        # `record` below.  `record` is shaped by the caller's
+        # adaptation_info_fn and can be a bare tuple or a slimmed NamedTuple
+        # (e.g. via get_filter_adapt_info_fn) that drops
+        # num_integration_steps entirely; deriving the grad ledger from it
+        # made this silently fall back to a -1 sentinel whenever a caller's
+        # info_fn shape didn't match (Issue#1090 fix 3 -- "no silent
+        # interventions" failing silently itself). infos_p is unaffected by
+        # adaptation_info_fn by construction, so this ledger is now correct
+        # regardless of what the caller passes there.
+        new_grad_evals = grad_evals_p + jnp.sum(infos_p.num_integration_steps)
         record = adaptation_info_fn(new_states_p, infos_p, frozen_adaptation_state)
-        return (new_states_p, recovered, new_ever_diverged), record
+        return (new_states_p, recovered, new_ever_diverged, new_grad_evals), record
 
-    (final_states, final_step_sizes, ever_diverged), probation_info = jax.lax.scan(
+    (
+        final_states,
+        final_step_sizes,
+        ever_diverged,
+        extra_grad_evals_total,
+    ), probation_info = jax.lax.scan(
         _probation_step,
-        (rehabilitated_state, init_step_sizes, init_ever_diverged),
+        (rehabilitated_state, init_step_sizes, init_ever_diverged, init_grad_evals),
         probation_keys,
     )
 
@@ -746,10 +820,10 @@ def _apply_start_state_probation(
 
     unresolved = final_step_sizes < (jnp.asarray(_PROBATION_RESOLVED_TOL) * step_size)
 
-    try:
-        extra_grad_evals = int(jnp.sum(probation_info.info.num_integration_steps))
-    except AttributeError:
-        extra_grad_evals = -1
+    # Computed above from the raw kernel info (infos_p), independent of
+    # adaptation_info_fn's shape -- always a real count, never a -1 sentinel
+    # (Issue#1090 fix 3).
+    extra_grad_evals = int(extra_grad_evals_total)
 
     diagnostics = {
         "enabled": True,
@@ -916,19 +990,34 @@ def staged_adaptation(
         :func:`~blackjax.adaptation.staged_adaptation._apply_start_state_probation`
         for the full mechanism.  The deployed ``step_size`` /
         ``inverse_mass_matrix`` returned in ``parameters`` are never changed
-        by this — only the starting position for sampling is.  All extra
-        kernel calls are folded into the returned ``info`` stream (same step
-        axis as the main warmup loop), so any caller already summing
-        ``info.info.num_integration_steps`` for a gradient ledger, or
-        ``info.info.is_divergent`` for a warmup-divergence count,
-        automatically and correctly charges this phase as warmup cost.
-        Diagnostics land at ``parameters["start_state_probation"]`` (present
-        only when enabled); see
+        by this — only the starting position for sampling is, and
+        ``parameters`` stays a pure sampler-kwargs dict either way (safe to
+        splat as ``algorithm(logdensity_fn, **result.parameters)``, the
+        documented deploy pattern; Issue#1090 fix 1).
+
+        **Return-value contract change when enabled** (Issue#1090 fix 1 &
+        2): ``run()``'s second return value becomes a
+        :class:`StagedAdaptationInfo` instead of the bare info stream.
+        ``info.trace`` is the concatenated per-step stream (same PyTree
+        structure as the disabled-path ``info``, so
+        ``info.trace.info.num_integration_steps`` /
+        ``info.trace.info.is_divergent`` sums still automatically and
+        correctly charge the probation phase as warmup cost); ``info.trace``
+        is ``probation_window`` steps LONGER than the caller's declared
+        ``num_steps`` — a consumer that indexes prescribed schedule
+        boundaries must first slice ``info.trace`` to
+        ``info.diagnostics["warmup_boundary_index"]``.
+        ``info.diagnostics`` carries the probation diagnostics dict
+        (``parameters["start_state_probation"]`` no longer exists — see
         :func:`~blackjax.adaptation.meta.verdict.extract_multi_chain_verdict`'s
-        ``probation_result`` argument to fold them into a verdict's
-        ``flags``.  Requires the algorithm's kernel info to expose
-        ``is_divergent`` (true for HMC and NUTS, the only algorithms
-        currently exercised through the multi-chain path).
+        ``probation_result`` argument to fold ``info.diagnostics`` into a
+        verdict's ``flags``).  When disabled (the default), ``info`` is the
+        bare stream, bit-identical to the pre-#1064 contract —
+        :class:`StagedAdaptationInfo` is never constructed on the disabled
+        path.  Requires the algorithm's kernel info to expose
+        ``is_divergent`` and ``num_integration_steps`` (true for HMC and
+        NUTS, the only algorithms currently exercised through the
+        multi-chain path).
     probation_window
         Number of extra per-chain steps for the ``start_state_probation``
         window.  ``None`` (default) uses
@@ -944,7 +1033,10 @@ def staged_adaptation(
     AdaptationAlgorithm
         An :class:`~blackjax.base.AdaptationAlgorithm` wrapping a ``run``
         function with signature ``(rng_key, position, num_steps=1000)`` that
-        returns ``(AdaptationResults, info)``.
+        returns ``(AdaptationResults, info)``.  ``info`` is the bare
+        per-step info stream, or a :class:`StagedAdaptationInfo` when
+        ``start_state_probation=True`` — see that parameter's docstring for
+        the contract.
 
     Notes
     -----
@@ -1320,8 +1412,22 @@ def staged_adaptation(
             "inverse_mass_matrix": inverse_mass_matrix,
             **extra_parameters,
         }
+
         if probation_diagnostics is not None:
-            parameters["start_state_probation"] = probation_diagnostics
+            # Route diagnostics through `info` (the run's dedicated
+            # auxiliary-info channel), never through `parameters` --
+            # `parameters` must stay a pure sampler-kwargs dict so the
+            # documented deploy pattern `algorithm(logdensity_fn,
+            # **result.parameters)` keeps working (Issue#1090 fix 1; see
+            # StagedAdaptationInfo's docstring for the full argument).
+            # `num_steps` here is the per-chain main-warmup step count --
+            # the index in `info` where the probation tail begins
+            # (Issue#1090 fix 2).
+            probation_diagnostics = {
+                **probation_diagnostics,
+                "warmup_boundary_index": num_steps,
+            }
+            info = StagedAdaptationInfo(trace=info, diagnostics=probation_diagnostics)
 
         return (
             AdaptationResults(

--- a/blackjax/adaptation/staged_adaptation.py
+++ b/blackjax/adaptation/staged_adaptation.py
@@ -566,6 +566,21 @@ class StagedAdaptationInfo(NamedTuple):
         trace)``.  A caller that wants the automatic warmup-cost ledger
         (e.g. ``sum(trace.info.num_integration_steps)`` charging the
         probation phase as warmup cost too) uses ``trace`` unsliced.
+
+        Design note: a separately-shaped ``(main_trace, probation_trace)``
+        pair -- instead of one concatenated ``trace`` plus a boundary index
+        -- was considered and rejected.  Concatenation is not a defect for a
+        SUMMING consumer (a caller reducing over the full step axis, e.g. a
+        gradient ledger, gets the probation phase folded in automatically,
+        exactly as documented above); it only breaks a schedule-boundary
+        INDEXING consumer that implicitly assumes ``trace.shape[0] ==
+        num_steps``.  Splitting the return in two would force EVERY caller,
+        including the summing ones, to explicitly concatenate before
+        reducing, in exchange for saving the (one-line) slice only the
+        indexing consumers need.  Keeping ``trace`` concatenated and adding
+        ``warmup_boundary_index`` gives both consumer shapes a supported,
+        one-line path with no default-case regression for the common
+        (summing) one.
     diagnostics
         The start-state-probation diagnostics dict from
         :func:`_apply_start_state_probation`, plus ``warmup_boundary_index``
@@ -764,10 +779,9 @@ def _apply_start_state_probation(
     probation_keys = jax.random.split(probation_master_key, window)
     init_step_sizes = jnp.full((M,), step_size, dtype=jnp.asarray(step_size).dtype)
     init_ever_diverged = jnp.zeros((M,), dtype=jnp.bool_)
-    init_grad_evals = jnp.asarray(0, dtype=jnp.int32)
 
     def _probation_step(carry, key):
-        states_p, step_sizes_p, ever_diverged_p, grad_evals_p = carry
+        states_p, step_sizes_p, ever_diverged_p = carry
         chain_keys = jax.random.split(key, M)
 
         def _step_one(k, state, h_i):
@@ -784,7 +798,7 @@ def _apply_start_state_probation(
             backed_off * jnp.asarray(_PROBATION_RECOVERY_RATE), step_size
         )
         new_ever_diverged = ever_diverged_p | is_div
-        # Accumulate from infos_p -- the algorithm's OWN raw kernel Info
+        # Read from infos_p -- the algorithm's OWN raw kernel Info
         # (HMCInfo/NUTSInfo, the only two algorithms this multi-chain path
         # supports; see the start_state_probation docstring) -- never from
         # `record` below.  `record` is shaped by the caller's
@@ -795,19 +809,29 @@ def _apply_start_state_probation(
         # info_fn shape didn't match (Issue#1090 fix 3 -- "no silent
         # interventions" failing silently itself). infos_p is unaffected by
         # adaptation_info_fn by construction, so this ledger is now correct
-        # regardless of what the caller passes there.
-        new_grad_evals = grad_evals_p + jnp.sum(infos_p.num_integration_steps)
+        # regardless of what the caller passes there. Returned as a scan
+        # OUTPUT (stacked, summed after the scan) rather than folded into the
+        # carry: a carry component's output dtype must exactly match its
+        # input dtype every iteration, and jnp.sum's integer-promotion rules
+        # differ from the per-step field's own dtype under
+        # jax.config.jax_enable_x64 -- accumulating in the carry raised
+        # "carry input and carry output must have equal types" (int32 in,
+        # int64 out) under x64. A stacked scan output has no such
+        # input/output dtype constraint.
+        per_step_grad_evals = jnp.sum(infos_p.num_integration_steps)
         record = adaptation_info_fn(new_states_p, infos_p, frozen_adaptation_state)
-        return (new_states_p, recovered, new_ever_diverged, new_grad_evals), record
+        return (new_states_p, recovered, new_ever_diverged), (
+            record,
+            per_step_grad_evals,
+        )
 
     (
         final_states,
         final_step_sizes,
         ever_diverged,
-        extra_grad_evals_total,
-    ), probation_info = jax.lax.scan(
+    ), (probation_info, grad_evals_per_step) = jax.lax.scan(
         _probation_step,
-        (rehabilitated_state, init_step_sizes, init_ever_diverged, init_grad_evals),
+        (rehabilitated_state, init_step_sizes, init_ever_diverged),
         probation_keys,
     )
 
@@ -823,7 +847,7 @@ def _apply_start_state_probation(
     # Computed above from the raw kernel info (infos_p), independent of
     # adaptation_info_fn's shape -- always a real count, never a -1 sentinel
     # (Issue#1090 fix 3).
-    extra_grad_evals = int(extra_grad_evals_total)
+    extra_grad_evals = int(jnp.sum(grad_evals_per_step))
 
     diagnostics = {
         "enabled": True,

--- a/tests/adaptation/test_start_state_probation.py
+++ b/tests/adaptation/test_start_state_probation.py
@@ -1,0 +1,160 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the post-warmup per-chain start-state safety mechanism (Issue#1064).
+
+Coverage (this file grows in a follow-up commit that wires the mechanism into
+:mod:`blackjax.adaptation.staged_adaptation`):
+- TestLooStateGate: stage 1 (ensemble-calibrated LOO gate) as a pure function.
+- TestRedrawFlaggedChains: stage 2a (redraw near a healthy anchor), including
+  a dict/PyTree position case (guards the blind spot fixed in PR #1013).
+- TestComputeChainEnergies: the energy OBSERVABLE (amendment A; not a trigger).
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from blackjax.adaptation.meta._calibration import (
+    _STATE_GATE_LOO_Z_THRESHOLD,
+    _STATE_GATE_MIN_CHAINS,
+)
+from blackjax.adaptation.meta._start_state import (
+    compute_chain_energies,
+    loo_state_gate,
+    redraw_flagged_chains,
+    select_healthy_anchor,
+)
+from blackjax.mcmc.metrics import LowRankInverseMassMatrix
+from tests.adaptation._meta_fixtures import _make_mc_isotropic
+from tests.fixtures import BlackJAXTest
+
+_IDENTITY_METRIC = lambda d: LowRankInverseMassMatrix(  # noqa: E731
+    sigma=jnp.ones(d), U=jnp.zeros((d, 1)), lam=jnp.ones(1)
+)
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: ensemble-calibrated LOO state gate
+# ---------------------------------------------------------------------------
+
+
+class TestLooStateGate(BlackJAXTest):
+    def test_flags_clear_outlier(self):
+        """A single far outlier among 7 tightly-clustered chains gets flagged."""
+        ld = jnp.array([-10.0, -10.2, -9.8, -10.1, -9.9, -10.05, -9.95, -50.0])
+        mask = loo_state_gate(ld, _STATE_GATE_LOO_Z_THRESHOLD, _STATE_GATE_MIN_CHAINS)
+        self.assertTrue(bool(mask[7]), "Clear outlier chain must be flagged")
+        self.assertFalse(
+            bool(jnp.any(mask[:7])), "Tightly-clustered chains must not be flagged"
+        )
+
+    def test_no_flag_when_uniform(self):
+        """No chain is flagged when the ensemble's logdensities are all comparable."""
+        key = jax.random.key(0)
+        ld = -10.0 + 0.1 * jax.random.normal(key, (8,))
+        mask = loo_state_gate(ld, _STATE_GATE_LOO_Z_THRESHOLD, _STATE_GATE_MIN_CHAINS)
+        self.assertFalse(bool(jnp.any(mask)))
+
+    def test_skipped_below_min_chains(self):
+        """Below _STATE_GATE_MIN_CHAINS the gate is skipped (no flags), even
+        for data that would otherwise clearly flag -- the LOO reference from
+        only 1-2 other chains is too noisy to act on."""
+        ld = jnp.array([-10.0, -10.0, -1000.0])  # M=3 < _STATE_GATE_MIN_CHAINS=4
+        mask = loo_state_gate(ld, _STATE_GATE_LOO_Z_THRESHOLD, _STATE_GATE_MIN_CHAINS)
+        self.assertFalse(bool(jnp.any(mask)))
+
+    def test_healthy_anchor_excludes_flagged(self):
+        """select_healthy_anchor never returns a flagged chain's index."""
+        ld = jnp.array([-10.0, -10.2, -9.8, -10.1, -9.9, -10.05, -9.95, -50.0])
+        mask = loo_state_gate(ld, _STATE_GATE_LOO_Z_THRESHOLD, _STATE_GATE_MIN_CHAINS)
+        anchor = int(select_healthy_anchor(ld, mask))
+        self.assertNotEqual(anchor, 7, "Anchor must not be the flagged outlier")
+        self.assertIn(anchor, range(7))
+
+
+# ---------------------------------------------------------------------------
+# Stage 2a: redraw near a healthy anchor
+# ---------------------------------------------------------------------------
+
+
+class TestRedrawFlaggedChains(BlackJAXTest):
+    def test_redraw_moves_flagged_near_anchor_flat_array(self):
+        M, d = 8, 4
+        position = jnp.zeros((M, d)).at[7].set(50.0)
+        flagged = jnp.zeros((M,), dtype=bool).at[7].set(True)
+        anchor_idx = jnp.array(0)
+        key = jax.random.key(1)
+
+        new_pos = redraw_flagged_chains(
+            position, flagged, anchor_idx, _IDENTITY_METRIC(d), key, 0.1
+        )
+
+        np.testing.assert_array_equal(
+            np.asarray(new_pos[:7]),
+            np.asarray(position[:7]),
+            err_msg="Non-flagged chains must be bit-identical after redraw",
+        )
+        dist_before = float(jnp.linalg.norm(position[7] - position[0]))
+        dist_after = float(jnp.linalg.norm(new_pos[7] - position[0]))
+        self.assertGreater(dist_before, 40.0, "sanity: chain 7 was far before redraw")
+        self.assertLess(
+            dist_after, 2.0, f"Redrawn chain should land near the anchor: {dist_after}"
+        )
+
+    def test_redraw_dict_position(self):
+        """PyTree (dict) position case -- guards the blind spot fixed in PR #1013."""
+        M = 8
+        position = {
+            "a": jnp.zeros((M, 3)).at[3].set(20.0),
+            "b": jnp.zeros((M, 2)).at[3].set(-20.0),
+        }
+        flagged = jnp.zeros((M,), dtype=bool).at[3].set(True)
+        anchor_idx = jnp.array(0)
+        key = jax.random.key(2)
+
+        new_pos = redraw_flagged_chains(
+            position, flagged, anchor_idx, _IDENTITY_METRIC(5), key, 0.1
+        )
+
+        self.assertEqual(set(new_pos.keys()), {"a", "b"})
+        np.testing.assert_array_equal(
+            np.asarray(new_pos["a"][0]), np.asarray(position["a"][0])
+        )
+        np.testing.assert_array_equal(
+            np.asarray(new_pos["b"][2]), np.asarray(position["b"][2])
+        )
+        dist_a = float(jnp.linalg.norm(new_pos["a"][3] - position["a"][0]))
+        dist_b = float(jnp.linalg.norm(new_pos["b"][3] - position["b"][0]))
+        self.assertLess(dist_a, 2.0)
+        self.assertLess(dist_b, 2.0)
+
+
+# ---------------------------------------------------------------------------
+# Energy observable (amendment A)
+# ---------------------------------------------------------------------------
+
+
+class TestComputeChainEnergies(BlackJAXTest):
+    def test_shape_and_finite(self):
+        M, d = 8, 5
+        draws_mc, _ = _make_mc_isotropic(M, 10, d, seed=3)
+        position = draws_mc[:, 0, :]
+        logdensity = -0.5 * jnp.sum(position**2, axis=1)
+        key = jax.random.key(4)
+
+        energies = compute_chain_energies(
+            position, logdensity, _IDENTITY_METRIC(d), key
+        )
+
+        self.assertEqual(energies.shape, (M,))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(energies))))

--- a/tests/adaptation/test_start_state_probation.py
+++ b/tests/adaptation/test_start_state_probation.py
@@ -473,6 +473,49 @@ class TestIssue1090ExtraGradEvalsTupleInfoFnRegression(BlackJAXTest):
         )
 
 
+class TestIssue1090ExtraGradEvalsX64Regression(BlackJAXTest):
+    """Regression for a scan-carry dtype mismatch caught by the downstream
+    consumer's own repro convention (``JAX_ENABLE_X64=1``, matching the
+    paper1 harness).  An earlier version of the fix 3 patch accumulated
+    ``extra_grad_evals`` in the probation scan's CARRY
+    (``grad_evals_p + jnp.sum(infos_p.num_integration_steps)``), which raised
+    ``jax.lax.scan``'s "carry input and carry output must have equal types"
+    (``int32[]`` in, ``int64[]`` out) once 64-bit ints were enabled --
+    ``jnp.sum``'s integer-promotion result dtype does not match a hardcoded
+    ``jnp.int32`` carry dtype under x64.  Exercises the full multi-chain
+    probation path inside ``jax.enable_x64()`` (the repo's established x64
+    test idiom; see ``StagedAdaptationX64SmokeTest`` in
+    ``test_staged_adaptation.py``)."""
+
+    def test_probation_scan_does_not_raise_under_x64(self):
+        n_chains = 8
+
+        def logdensity_fn(x):
+            return -0.5 * jnp.sum(x**2)
+
+        with jax.enable_x64():
+            position = jnp.zeros((n_chains, 4), dtype=jnp.float64)
+            warmup = blackjax.staged_adaptation(
+                blackjax.nuts,
+                logdensity_fn,
+                metric="auto",
+                max_grad_budget=8000,
+                n_chains=n_chains,
+                start_state_probation=True,
+                probation_window=10,
+            )
+            results, info = warmup.run(jax.random.key(44), position, num_steps=40)
+
+            self.assertIsInstance(info, StagedAdaptationInfo)
+            extra_grad_evals = info.diagnostics["extra_grad_evals"]
+            self.assertGreater(
+                extra_grad_evals,
+                0,
+                "the probation scan must complete under x64 and produce a "
+                "real positive grad-eval count",
+            )
+
+
 # ---------------------------------------------------------------------------
 # Red-check: engineered bad post-warmup start state (ratified design note)
 # ---------------------------------------------------------------------------

--- a/tests/adaptation/test_start_state_probation.py
+++ b/tests/adaptation/test_start_state_probation.py
@@ -11,20 +11,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the post-warmup per-chain start-state safety mechanism (Issue#1064).
+"""Tests for the post-warmup per-chain start-state probation mechanism (Issue#1064).
 
-Coverage (this file grows in a follow-up commit that wires the mechanism into
-:mod:`blackjax.adaptation.staged_adaptation`):
+Coverage:
 - TestLooStateGate: stage 1 (ensemble-calibrated LOO gate) as a pure function.
 - TestRedrawFlaggedChains: stage 2a (redraw near a healthy anchor), including
   a dict/PyTree position case (guards the blind spot fixed in PR #1013).
 - TestComputeChainEnergies: the energy OBSERVABLE (amendment A; not a trigger).
+- TestStagedAdaptationProbationWiring: opt-in validation, RNG-disable-path
+  identity (amendment B), and a dict-position smoke test through the full
+  vmapped probation scan (amendment C).
+- TestApplyStartStateProbationRedCheck: the red-check promised in the
+  ratified design note -- an engineered bad post-warmup start state (i)
+  reproduces a divergence-storm transient in miniature when the mechanism is
+  disabled, and (ii) is materially rehabilitated when it is enabled.
+- TestExtractMultiChainVerdictProbationResult: the verdict/flags fold-in.
 """
 import jax
 import jax.numpy as jnp
 import numpy as np
 
+import blackjax
+from blackjax.adaptation.base import return_all_adapt_info
 from blackjax.adaptation.meta._calibration import (
+    _PROBATION_WINDOW_DEFAULT,
     _STATE_GATE_LOO_Z_THRESHOLD,
     _STATE_GATE_MIN_CHAINS,
 )
@@ -34,6 +44,8 @@ from blackjax.adaptation.meta._start_state import (
     redraw_flagged_chains,
     select_healthy_anchor,
 )
+from blackjax.adaptation.meta.verdict import extract_multi_chain_verdict
+from blackjax.adaptation.staged_adaptation import _apply_start_state_probation
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.adaptation._meta_fixtures import _make_mc_isotropic
 from tests.fixtures import BlackJAXTest
@@ -158,3 +170,294 @@ class TestComputeChainEnergies(BlackJAXTest):
 
         self.assertEqual(energies.shape, (M,))
         self.assertTrue(bool(jnp.all(jnp.isfinite(energies))))
+
+
+# ---------------------------------------------------------------------------
+# staged_adaptation wiring: validation, RNG discipline, dict-position smoke
+# ---------------------------------------------------------------------------
+
+
+class TestStagedAdaptationProbationWiring(BlackJAXTest):
+    def _logdensity(self, x):
+        return -0.5 * jnp.sum(x**2)
+
+    def test_requires_multichain(self):
+        with self.assertRaisesRegex(ValueError, "start_state_probation"):
+            blackjax.staged_adaptation(
+                blackjax.nuts,
+                self._logdensity,
+                metric="auto",
+                max_grad_budget=5000,
+                n_chains=1,
+                start_state_probation=True,
+            )
+
+    def test_disabled_path_bit_identical_kwarg_omitted_vs_explicit_false(self):
+        """RNG discipline (amendment B): the disabled path never touches the
+        probation-only RNG split, so omitting the kwarg and passing it
+        explicitly as False must give bit-identical results."""
+        n_dims, n_chains = 5, 8
+        key = jax.random.key(20)
+        pos = jnp.zeros((n_chains, n_dims))
+
+        warmup_omitted = blackjax.staged_adaptation(
+            blackjax.nuts,
+            self._logdensity,
+            metric="auto",
+            max_grad_budget=8000,
+            n_chains=n_chains,
+        )
+        warmup_explicit = blackjax.staged_adaptation(
+            blackjax.nuts,
+            self._logdensity,
+            metric="auto",
+            max_grad_budget=8000,
+            n_chains=n_chains,
+            start_state_probation=False,
+        )
+
+        results_omitted, info_omitted = warmup_omitted.run(key, pos, num_steps=40)
+        results_explicit, info_explicit = warmup_explicit.run(key, pos, num_steps=40)
+
+        np.testing.assert_array_equal(
+            np.asarray(results_omitted.state.position),
+            np.asarray(results_explicit.state.position),
+            err_msg="Disabled path: omitted vs explicit False must be bit-identical",
+        )
+        np.testing.assert_array_equal(
+            np.asarray(results_omitted.parameters["step_size"]),
+            np.asarray(results_explicit.parameters["step_size"]),
+        )
+        self.assertNotIn("start_state_probation", results_omitted.parameters)
+        self.assertNotIn("start_state_probation", results_explicit.parameters)
+        # Same leading (step) dim on both -- no extra steps folded in when disabled.
+        self.assertEqual(
+            jax.tree.leaves(info_omitted)[0].shape[0],
+            jax.tree.leaves(info_explicit)[0].shape[0],
+        )
+
+    def test_enabled_dict_position_smoke(self):
+        """Dict/PyTree position through the FULL vmapped probation scan
+        (amendment C) -- guards the blind spot fixed in PR #1013."""
+        n_chains = 8
+
+        def logdensity_fn(x):
+            return -0.5 * jnp.sum(x["a"] ** 2) - 0.5 * jnp.sum(x["b"] ** 2)
+
+        position = {
+            "a": jnp.zeros((n_chains, 3)),
+            "b": jnp.zeros((n_chains, 2)),
+        }
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="auto",
+            max_grad_budget=8000,
+            n_chains=n_chains,
+            start_state_probation=True,
+            probation_window=10,
+        )
+        key = jax.random.key(21)
+        results, info = warmup.run(key, position, num_steps=40)
+
+        self.assertEqual(set(results.state.position.keys()), {"a", "b"})
+        self.assertEqual(results.state.position["a"].shape, (n_chains, 3))
+        self.assertEqual(results.state.position["b"].shape, (n_chains, 2))
+        diag = results.parameters["start_state_probation"]
+        self.assertTrue(diag["enabled"])
+        self.assertEqual(diag["window"], 10)
+        self.assertEqual(
+            jax.tree.leaves(info)[0].shape[0],
+            40 + 10,
+            "info stream must be the main warmup steps plus the probation window",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Red-check: engineered bad post-warmup start state (ratified design note)
+# ---------------------------------------------------------------------------
+
+
+class TestApplyStartStateProbationRedCheck(BlackJAXTest):
+    """One chain is placed deep in a funnel's neck (tight local curvature)
+    while the other 7 sit near the mouth -- mirroring "a single chain handed
+    a bad post-warmup start state" from Issue#1064.  A step size fine for
+    the mouth is engineered to reliably diverge the neck chain.
+    """
+
+    _D = 6
+    _N_HEALTHY = 7
+    _STEP_SIZE = 0.5
+
+    def _funnel_logdensity(self, x):
+        x0 = x[0]
+        tail = x[1:]
+        return (
+            -0.5 * (x0 / 3.0) ** 2
+            - 0.5 * (self._D - 1) * x0
+            - 0.5 * jnp.sum(tail**2) * jnp.exp(-x0)
+        )
+
+    def _make_states(self):
+        key = jax.random.key(7)
+        healthy_key, bad_key = jax.random.split(key)
+        healthy_keys = jax.random.split(healthy_key, self._N_HEALTHY)
+
+        def _mk_healthy(k):
+            k0, k1 = jax.random.split(k)
+            return jnp.concatenate(
+                [
+                    jax.random.normal(k0, (1,)) * 0.3,
+                    jax.random.normal(k1, (self._D - 1,)),
+                ]
+            )
+
+        healthy_positions = jax.vmap(_mk_healthy)(healthy_keys)
+        # Deep in the neck (x0=-5: conditional std exp(-2.5)~=0.08) but with
+        # a MOUTH-scale tail -- both a logdensity outlier (stage 1 target)
+        # and a locally stiff / divergence-prone point under a
+        # mouth-calibrated step size (stage 2b target).
+        bad_position = jnp.concatenate(
+            [jnp.array([-5.0]), jax.random.normal(bad_key, (self._D - 1,))]
+        )
+        positions = jnp.concatenate([healthy_positions, bad_position[None]], axis=0)
+        states = jax.vmap(lambda pos: blackjax.nuts.init(pos, self._funnel_logdensity))(
+            positions
+        )
+        return states
+
+    def _divergence_rate(self, states, mcmc_kernel, metric, key, n_steps, M):
+        keys = jax.random.split(key, n_steps)
+
+        def _step(carry, k):
+            chain_keys = jax.random.split(k, M)
+            new_states, infos = jax.vmap(
+                lambda ck, s: mcmc_kernel(
+                    ck, s, self._funnel_logdensity, self._STEP_SIZE, metric
+                )
+            )(chain_keys, carry)
+            return new_states, infos.is_divergent
+
+        _, divergences = jax.lax.scan(_step, states, keys)
+        return jnp.mean(divergences, axis=0)
+
+    def test_disabled_transient_reproduces_in_miniature(self):
+        """Mechanism disabled: naively sampling from the raw post-warmup
+        state at the shared step size reproduces the divergence storm on the
+        engineered bad chain, while every healthy chain stays clean."""
+        states = self._make_states()
+        M = self._N_HEALTHY + 1
+        bad_idx = M - 1
+        mcmc_kernel = blackjax.nuts.build_kernel()
+        metric = _IDENTITY_METRIC(self._D)
+
+        naive_rate = self._divergence_rate(
+            states, mcmc_kernel, metric, jax.random.key(11), 80, M
+        )
+
+        self.assertGreater(
+            float(naive_rate[bad_idx]),
+            0.5,
+            "Engineered bad chain must show a high naive divergence rate "
+            "(mechanism disabled); got "
+            f"{float(naive_rate[bad_idx]):.2f}",  # noqa: E231
+        )
+        self.assertEqual(
+            float(jnp.max(naive_rate[:bad_idx])),
+            0.0,
+            "Healthy chains must stay clean at this step size (isolation check)",
+        )
+
+    def test_enabled_rehabilitates_bad_chain(self):
+        """Mechanism enabled: stage 1 flags the bad chain, stage 2a/2b
+        rehabilitate it, and re-sampling from the rehabilitated state at the
+        SAME shared step size no longer diverges."""
+        states = self._make_states()
+        M = self._N_HEALTHY + 1
+        bad_idx = M - 1
+        mcmc_kernel = blackjax.nuts.build_kernel()
+        metric = _IDENTITY_METRIC(self._D)
+        step_size = jnp.asarray(self._STEP_SIZE)
+
+        naive_rate = self._divergence_rate(
+            states, mcmc_kernel, metric, jax.random.key(11), 80, M
+        )
+
+        rehab_states, _probation_info, diagnostics = _apply_start_state_probation(
+            jax.random.key(12),
+            states,
+            mcmc_kernel,
+            blackjax.nuts.init,
+            self._funnel_logdensity,
+            step_size,
+            metric,
+            M,
+            _PROBATION_WINDOW_DEFAULT,
+            {},
+            return_all_adapt_info,
+            states,
+        )
+
+        self.assertIn(
+            bad_idx,
+            diagnostics["flagged_chain_idx"],
+            "Stage 1 must flag the engineered bad chain",
+        )
+        self.assertTrue(diagnostics["redraw_applied"])
+
+        post_rate = self._divergence_rate(
+            rehab_states, mcmc_kernel, metric, jax.random.key(13), 80, M
+        )
+
+        self.assertLess(
+            float(post_rate[bad_idx]),
+            float(naive_rate[bad_idx]),
+            "Probation must reduce the previously-bad chain's divergence rate",
+        )
+        self.assertLessEqual(
+            float(post_rate[bad_idx]),
+            0.1,
+            "Rehabilitated chain should sample cleanly at the shared step size",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Verdict fold-in (no silent interventions)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMultiChainVerdictProbationResult(BlackJAXTest):
+    def test_probation_result_none_is_backward_compatible(self):
+        """Omitting probation_result leaves flags exactly as before (no new keys)."""
+        from blackjax.adaptation.meta.builders import build_multi_chain_meta_core
+
+        core = build_multi_chain_meta_core(max_grad_budget=40000, n_chains=8)
+        state = core.init(10)
+        verdict = extract_multi_chain_verdict(
+            state, max_grad_budget=40000, num_warmup_steps=100
+        )
+        self.assertFalse(
+            any(k.startswith("start_state_probation_") for k in verdict.flags)
+        )
+
+    def test_probation_result_folded_into_flags(self):
+        from blackjax.adaptation.meta.builders import build_multi_chain_meta_core
+
+        core = build_multi_chain_meta_core(max_grad_budget=40000, n_chains=8)
+        state = core.init(10)
+        probation_result = {
+            "enabled": True,
+            "n_chains_flagged_by_state_gate": 1,
+            "n_chains_unresolved": 0,
+        }
+        verdict = extract_multi_chain_verdict(
+            state,
+            max_grad_budget=40000,
+            num_warmup_steps=100,
+            probation_result=probation_result,
+        )
+        self.assertEqual(verdict.flags["start_state_probation_enabled"], True)
+        self.assertEqual(
+            verdict.flags["start_state_probation_n_chains_flagged_by_state_gate"], 1
+        )
+        self.assertEqual(verdict.flags["start_state_probation_n_chains_unresolved"], 0)

--- a/tests/adaptation/test_start_state_probation.py
+++ b/tests/adaptation/test_start_state_probation.py
@@ -272,6 +272,68 @@ class TestStagedAdaptationProbationWiring(BlackJAXTest):
             "info stream must be the main warmup steps plus the probation window",
         )
 
+    def test_dict_position_engineered_outlier_through_stage1_2a_2b(self):
+        """Amendment C (v2): a dict/PyTree position with an ENGINEERED outlier
+        chain driven through stage 1 + 2a + 2b end-to-end via
+        _apply_start_state_probation directly -- confirms stage 2a's jitter
+        and redraw are pytree-correct PER KEY (not just structurally
+        non-crashing, which test_enabled_dict_position_smoke above already
+        covers for the identical-start case where nothing gets flagged)."""
+        M = 8
+
+        def logdensity_fn(x):
+            return -0.5 * jnp.sum(x["a"] ** 2) - 0.5 * jnp.sum(x["b"] ** 2)
+
+        position = {
+            "a": jnp.zeros((M, 3)).at[7].set(30.0),
+            "b": jnp.zeros((M, 2)).at[7].set(-30.0),
+        }
+        states = jax.vmap(lambda pos: blackjax.nuts.init(pos, logdensity_fn))(position)
+        mcmc_kernel = blackjax.nuts.build_kernel()
+        step_size = jnp.asarray(0.5)
+        metric = _IDENTITY_METRIC(5)
+
+        rehab_states, _probation_info, diagnostics = _apply_start_state_probation(
+            jax.random.key(30),
+            states,
+            mcmc_kernel,
+            blackjax.nuts.init,
+            logdensity_fn,
+            step_size,
+            metric,
+            M,
+            _PROBATION_WINDOW_DEFAULT,
+            {},
+            return_all_adapt_info,
+            states,
+        )
+
+        self.assertIn(
+            7, diagnostics["flagged_chain_idx"], "Engineered outlier must be flagged"
+        )
+        self.assertTrue(diagnostics["redraw_applied"])
+        self.assertEqual(set(rehab_states.position.keys()), {"a", "b"})
+        self.assertEqual(rehab_states.position["a"].shape, (M, 3))
+        self.assertEqual(rehab_states.position["b"].shape, (M, 2))
+
+        # Amendment A': pre/post logdensity pair is auditable against stage
+        # 1's own decision -- the outlier chain's logdensity must move
+        # substantially toward the healthy ensemble's range in BOTH dict
+        # keys' worth of mass (a single flat number, but only reachable if
+        # both "a" and "b" were correctly redrawn -- a pytree bug that only
+        # fixed one key would leave the other contributing -450 alone).
+        pre_ld = diagnostics["pre_probation_logdensity"]
+        post_ld = diagnostics["post_probation_logdensity"]
+        self.assertLess(
+            pre_ld[7], -500.0, "sanity: engineered chain must be a clear outlier"
+        )
+        self.assertGreater(
+            post_ld[7],
+            pre_ld[7] + 400.0,
+            "Rehabilitated chain's logdensity must move substantially "
+            "toward the ensemble in both pytree keys",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Red-check: engineered bad post-warmup start state (ratified design note)

--- a/tests/adaptation/test_start_state_probation.py
+++ b/tests/adaptation/test_start_state_probation.py
@@ -45,7 +45,10 @@ from blackjax.adaptation.meta._start_state import (
     select_healthy_anchor,
 )
 from blackjax.adaptation.meta.verdict import extract_multi_chain_verdict
-from blackjax.adaptation.staged_adaptation import _apply_start_state_probation
+from blackjax.adaptation.staged_adaptation import (
+    StagedAdaptationInfo,
+    _apply_start_state_probation,
+)
 from blackjax.mcmc.metrics import LowRankInverseMassMatrix
 from tests.adaptation._meta_fixtures import _make_mc_isotropic
 from tests.fixtures import BlackJAXTest
@@ -263,13 +266,17 @@ class TestStagedAdaptationProbationWiring(BlackJAXTest):
         self.assertEqual(set(results.state.position.keys()), {"a", "b"})
         self.assertEqual(results.state.position["a"].shape, (n_chains, 3))
         self.assertEqual(results.state.position["b"].shape, (n_chains, 2))
-        diag = results.parameters["start_state_probation"]
+        # Issue#1090 fix 1: diagnostics never land in `parameters` -- it must
+        # stay a pure sampler-kwargs dict.
+        self.assertNotIn("start_state_probation", results.parameters)
+        self.assertIsInstance(info, StagedAdaptationInfo)
+        diag = info.diagnostics
         self.assertTrue(diag["enabled"])
         self.assertEqual(diag["window"], 10)
         self.assertEqual(
-            jax.tree.leaves(info)[0].shape[0],
+            jax.tree.leaves(info.trace)[0].shape[0],
             40 + 10,
-            "info stream must be the main warmup steps plus the probation window",
+            "info.trace must be the main warmup steps plus the probation window",
         )
 
     def test_dict_position_engineered_outlier_through_stage1_2a_2b(self):
@@ -332,6 +339,137 @@ class TestStagedAdaptationProbationWiring(BlackJAXTest):
             pre_ld[7] + 400.0,
             "Rehabilitated chain's logdensity must move substantially "
             "toward the ensemble in both pytree keys",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue#1090: PR #1015 integration defects found by the P1 corpus-rerun
+# consumer.  Each class below reproduces one of the two repro patterns +
+# the tuple-shaped info_fn regression named in the issue.
+# ---------------------------------------------------------------------------
+
+
+class TestIssue1090ParametersDeployPatternRegression(BlackJAXTest):
+    """Fix 1 red-check: PR #1015 injected a diagnostics dict under
+    ``parameters["start_state_probation"]``, so the standard sampler-deploy
+    pattern ``algorithm(logdensity_fn, **result.parameters)`` -- used
+    throughout BlackJAX's own docs and by Paper 1's fixed-suite harness --
+    raised ``TypeError: unexpected keyword argument 'start_state_probation'``
+    whenever ``start_state_probation=True``.  Reproduces exactly that call."""
+
+    def test_deploy_pattern_does_not_raise(self):
+        n_chains = 8
+
+        def logdensity_fn(x):
+            return -0.5 * jnp.sum(x**2)
+
+        position = jnp.zeros((n_chains, 4))
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="auto",
+            max_grad_budget=8000,
+            n_chains=n_chains,
+            start_state_probation=True,
+            probation_window=10,
+        )
+        results, info = warmup.run(jax.random.key(40), position, num_steps=40)
+
+        self.assertNotIn("start_state_probation", results.parameters)
+
+        # The documented deploy pattern -- must not raise TypeError.
+        sampler = blackjax.nuts(logdensity_fn, **results.parameters)
+        keys = jax.random.split(jax.random.key(41), n_chains)
+        new_state, sample_info = jax.vmap(sampler.step)(keys, results.state)
+
+        self.assertEqual(new_state.position.shape, (n_chains, 4))
+
+
+class TestIssue1090ScheduleBoundaryRegression(BlackJAXTest):
+    """Fix 2 red-check: the probation window's extra steps were
+    concatenated onto the info stream past the caller's declared
+    ``num_steps`` with no explicit boundary exposed, so a
+    prescribed-schedule-length consumer (e.g. Paper 1's
+    ``extract_schedule_events``, which asserts an exact-length trace against
+    ``num_warmup_steps``) broke.  Reproduces a boundary-aware trace
+    consumer against ``info.diagnostics["warmup_boundary_index"]``."""
+
+    def test_boundary_index_recovers_prescribed_length(self):
+        n_chains, num_steps, window = 8, 40, 10
+
+        def logdensity_fn(x):
+            return -0.5 * jnp.sum(x**2)
+
+        position = jnp.zeros((n_chains, 4))
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="auto",
+            max_grad_budget=8000,
+            n_chains=n_chains,
+            start_state_probation=True,
+            probation_window=window,
+        )
+        results, info = warmup.run(jax.random.key(42), position, num_steps=num_steps)
+
+        self.assertIsInstance(info, StagedAdaptationInfo)
+        boundary = info.diagnostics["warmup_boundary_index"]
+        self.assertEqual(boundary, num_steps)
+
+        full_trace_len = jax.tree.leaves(info.trace)[0].shape[0]
+        self.assertEqual(full_trace_len, num_steps + window)
+
+        # A prescribed-boundary trace consumer (mirrors Paper 1's
+        # extract_schedule_events) slices to the boundary and recovers
+        # exactly the caller's declared num_warmup_steps.
+        prescribed_trace = jax.tree.map(lambda x: x[:boundary], info.trace)
+        self.assertEqual(
+            jax.tree.leaves(prescribed_trace)[0].shape[0],
+            num_steps,
+            "trace sliced at warmup_boundary_index must equal num_warmup_steps",
+        )
+
+
+class TestIssue1090ExtraGradEvalsTupleInfoFnRegression(BlackJAXTest):
+    """Fix 3 red-check: ``extra_grad_evals`` fell back to a silent ``-1``
+    sentinel whenever the caller's ``adaptation_info_fn`` didn't shape its
+    record with a ``.info`` attribute -- e.g. a bare-tuple info_fn, which is
+    a valid ``adaptation_info_fn`` per the documented ``(state, info,
+    adaptation_state) -> Any`` signature (``return_all_adapt_info``'s
+    ``AdaptationInfo`` NamedTuple is only the default, not a requirement)."""
+
+    def test_tuple_shaped_info_fn_does_not_silently_zero_the_ledger(self):
+        n_chains = 8
+
+        def logdensity_fn(x):
+            return -0.5 * jnp.sum(x**2)
+
+        def tuple_info_fn(state, info, adaptation_state):
+            # A bare tuple has no `.info` attribute at all, unlike the
+            # default return_all_adapt_info's AdaptationInfo(state, info,
+            # adaptation_state) NamedTuple.
+            return (state, info)
+
+        position = jnp.zeros((n_chains, 4))
+        warmup = blackjax.staged_adaptation(
+            blackjax.nuts,
+            logdensity_fn,
+            metric="auto",
+            max_grad_budget=8000,
+            n_chains=n_chains,
+            adaptation_info_fn=tuple_info_fn,
+            start_state_probation=True,
+            probation_window=10,
+        )
+        results, info = warmup.run(jax.random.key(43), position, num_steps=40)
+
+        self.assertIsInstance(info, StagedAdaptationInfo)
+        extra_grad_evals = info.diagnostics["extra_grad_evals"]
+        self.assertGreater(
+            extra_grad_evals,
+            0,
+            "extra_grad_evals must be a real positive count, not the silent "
+            "-1 sentinel, regardless of adaptation_info_fn's return shape",
         )
 
 


### PR DESCRIPTION
# P1 per-chain post-warmup start-state safety

## Mechanism

Two-stage, opt-in (`staged_adaptation(..., start_state_probation=True)`, default `False`), multi-chain-only. Runs once after the shared `step_size` / `inverse_mass_matrix` are finalized.

**Stage 1 — ensemble-calibrated typical-region gate.** Each chain's cached post-warmup logdensity vs a leave-one-out region from the other `M−1` chains — the controller's route-level LOO principle applied one level down (route → parameter → state). Zero extra gradients.

**Stage 2a — redraw near a healthy anchor.** Flagged chains re-initialize at the healthiest non-flagged chain's *actual* position + small metric-consistent jitter.

**Stage 2b — per-chain probation (unconditional).** Every chain runs a `probation_window` (default 50) of real kernel steps at the frozen shared metric with divergence-triggered per-chain step back-off, recovering geometrically to the shared value.

Deployed `step_size` / `inverse_mass_matrix` never change — only per-chain start positions.

## Motivating incident + acceptance evidence

stoch_vol (d=503, M=8) seed-2: 471 sampling divergences, 375 in one chain, first-quarter concentrated — a single bad post-warmup start under shared products. **With this PR enabled: 471→61 divergences, max chain 375→14, ess/charged-grad 0.09×→1.32× of NUTS+window-adaptation; 3-seed acceptance passed** (worst seed 1.32× vs required 0.8×, all GT gates green).

## Cost model — corrected (fixed absolute window)

Probation info concatenates onto the caller's `info` stream, so summing ledgers charge it as warmup automatically. **The window is a fixed length, so its cost is absolute** (~115 extra kernel steps' gradients at defaults): **+1.6% of warmup at 400k-step budgets, ~5% at 160k, 13–20% at 50k.** State the % for your budget; the window length is a property of the rehabilitation dynamics, not the budget (deliberately not budget-scaled).

## Corpus-scale evidence (Paper-1 fixed suite, 77 cells, OFF/ON back-to-back, exact frozen env)

- **Disabled path: bit-identical to the frozen corpus on all 53 comparable cells** (same draws SHA-256, same routes, ess/grad ratio 1.0000) — the safety claim at corpus scale.
- Blast radius exactly scoped: 48/48 manual-plan cells bit-identical OFF vs ON.
- ON vs OFF (29 auto cells): **median −1.08%** ess/grad; per-cell swings on funnel-class geometry (−20%/+29%) are symmetric start-state re-roll variance, not systematic cost.
- Stage 1 fired on 12/29 cells (all redraws applied; one cell correctly tripped the loud `n_chains_unresolved` channel); one flagged cell improved 61→52 divergences.

## API (post-review revision)

- `result.parameters` stays a **pure sampler-kwargs dict** — the documented `algorithm(logdensity_fn, **result.parameters)` deploy pattern works with the flag on (regression-tested). Diagnostics live on the info side: `run()`'s second value is a `StagedAdaptationInfo(trace, diagnostics)` when the flag is enabled.
- `diagnostics["warmup_boundary_index"]` marks the schedule/probation boundary for prescribed-boundary consumers (concatenation kept for summing consumers; design argued in the docstring).
- `extra_grad_evals` computed robustly from raw kernel info, independent of the caller's `adaptation_info_fn` (tuple-shaped info_fn regression-tested; no silent −1).
- Flags surface: gate outcomes, `flagged_chain_idx`, `redraw_applied`, `n_chains_unresolved`, pre/post per-chain logdensity+energy observables, `extra_grad_evals` — folded into `verdict.flags` via `extract_multi_chain_verdict(..., probation_result=...)`. `n_chains_unresolved > 0` = do not trust that chain's early draws.

## Tests

15-test probation suite + 4 Issue#1090 red-checked regressions (deploy pattern, boundary consumer, tuple info_fn, x64 scan-carry dtype) + engineered-funnel red-check (100%→≤10% divergence) + bit-identical-when-disabled RNG test. Full suite: **1799 passed / 0 failed / 97% coverage.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
