### PR TITLE
Add a diagnostics-only divergence-concentration warning

### DIFF
--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -804,9 +804,12 @@ def divergence_concentration(
     module — and is intended to be read from a post-sampling
     routing/verdict layer (whatever code decides what to do with a
     finished run), not from a warmup/adaptation routine: warmup
-    algorithms return before any sampling divergence exists to diagnose.
-    Existing warmup-adaptation algorithms in this library (e.g.
-    :func:`window_adaptation`) are unaffected by this function.
+    algorithms return before any sampling divergence exists to diagnose,
+    so a warmup-time version of this check would have no data to act on.
+    Existing warmup-adaptation algorithms in this library — e.g.
+    :func:`window_adaptation` and ``staged_adaptation`` — are unaffected
+    by this function; it neither reads nor writes anything warmup
+    produces.
 
     **What the message reports.** For each flagged chain the report
     carries factual, non-causal fields: the chain's overall rate, its

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """MCMC diagnostics."""
+from typing import NamedTuple
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -27,6 +29,10 @@ __all__ = [
     "ess_tail",
     "pareto_khat",
     "psis_weights",
+    "DivergenceConcentrationReport",
+    "divergence_concentration",
+    "divergence_concentration_from_counts",
+    "format_divergence_warning",
 ]
 
 
@@ -691,3 +697,259 @@ def psis_weights(log_ratios: Array, r_eff: float = 1.0) -> tuple[Array, Array]:
     lw_orig = jnp.zeros_like(lw_smooth).at[sorted_idx].set(lw_smooth)
     log_w = lw_orig - jax.nn.logsumexp(lw_orig)
     return log_w, k
+
+
+class DivergenceConcentrationReport(NamedTuple):
+    """Per-run divergence-concentration diagnostic report.
+
+    All fields are plain JAX numerics — no strings — so the statistic
+    itself stays JIT-compilable.  Pass the report to
+    :func:`format_divergence_warning` to render a human-readable message
+    from concrete (non-traced) values.
+
+    Attributes
+    ----------
+    warn
+        Bool. Whether the run's worst chain crossed ``rate_threshold``.
+    concentrated
+        Bool. When ``warn`` is true, whether the divergences are
+        concentrated on one chain (``True``) or elevated across the
+        ensemble (``False``). Meaningless when ``warn`` is false.
+    chain
+        Index (0-based) of the chain with the most divergences.
+    num_chains_elevated
+        Number of chains whose own divergence rate is at or above
+        ``rate_threshold``.
+    total_divergences
+        Total divergence count ``D`` summed over all chains.
+    num_chains
+        Number of chains ``M``.
+    max_rate
+        Divergence rate of the worst chain, ``d_max / n_draws``.
+    mean_rate
+        Ensemble-mean per-chain divergence rate, ``D / (M * n_draws)``.
+    ratio
+        ``max_rate / mean_rate`` (0 when ``mean_rate`` is 0, i.e. ``D=0``).
+    multinomial_p_value
+        Bonferroni-corrected exchangeable-null tail probability
+        ``min(1, M * P(Binomial(D, 1/M) >= d_max))``. Reported as context
+        only — see the module-level notes on :func:`divergence_concentration`
+        for why this does not drive the warning. ``NaN`` when ``D=0``.
+    """
+
+    warn: Array
+    concentrated: Array
+    chain: Array
+    num_chains_elevated: Array
+    total_divergences: Array
+    num_chains: Array
+    max_rate: Array
+    mean_rate: Array
+    ratio: Array
+    multinomial_p_value: Array
+
+
+def divergence_concentration(
+    is_divergent: ArrayLike,
+    *,
+    rate_threshold: float = 0.02,
+    ratio_cutoff: float = 3.0,
+) -> DivergenceConcentrationReport:
+    """Flag a sampling run whose divergences concentrate on one or a few chains.
+
+    A multi-chain sampling run can end up with the same total divergence
+    count reached in very different ways: one chain landing on a bad
+    post-warmup start state and diverging heavily while the rest are clean,
+    versus every chain diverging moderately because the model geometry
+    itself is hard. The two call for different remedies, so this function
+    reports which pattern (if either) is present — it never intervenes.
+
+    Parameters
+    ----------
+    is_divergent
+        Per-draw divergence flags (bool or 0/1), shape ``(n_chains,
+        n_draws)``. Any leading batch dimensions are treated as extra chain
+        axes only if they are the true chain axis; this function assumes
+        the array is exactly 2-D, chains on axis 0.
+    rate_threshold
+        Minimum per-chain divergence rate (``d_max / n_draws``) that
+        triggers a warning. Default ``0.02`` (2%).
+    ratio_cutoff
+        Minimum ``max_rate / mean_rate`` ratio to classify a warning as
+        chain-concentrated (``report.concentrated=True``) rather than
+        ensemble-wide elevation. Default ``3.0``.
+
+    Returns
+    -------
+    :class:`DivergenceConcentrationReport`
+
+    Notes
+    -----
+    **Evidence basis.** Validated retrospectively (no gating, no
+    intervention — a pure read of existing per-chain divergence records)
+    across 120 (model, warmup arm, seed) cells spanning several models,
+    warmup strategies, and seeds. At the default 2% threshold, 7 of the 8
+    flagged non-degenerate cells were independently substantiated true
+    positives — textbook funnel-neck geometry, a near-storm single-chain
+    concentration at ~7x the ensemble mean, and ensembles with every chain
+    globally elevated; the most severe cell in the corpus (worst-chain rate
+    18.75%) was flagged with a roughly 9x margin over the threshold. The
+    ``max_rate / mean_rate`` ratio was found, after the fact rather than by
+    design, to separate the two failure signatures cleanly: single
+    bad-start chains cluster around 4-7x, ensemble-wide elevation around
+    1.6-1.8x — hence the ``ratio_cutoff`` default of 3.0, placed between
+    the two clusters.
+
+    **Why the multinomial tail is reported as context only, never as the
+    trigger.** An earlier design tried triggering on
+    ``report.multinomial_p_value`` — a Bonferroni-corrected tail
+    probability under the null that divergences are exchangeable across
+    chains (every chain equally likely to produce the next divergence).
+    That null does not hold for real NUTS/HMC ensembles: distinct chains
+    settle into distinct post-warmup local geometries, so divergence
+    propensity is not exchangeable even on a perfectly healthy run.
+    Empirically this produced a 13% false-positive rate on healthy cells in
+    the same validation corpus, so the p-value is computed and returned for
+    interested callers but never decides ``warn``.
+
+    **Coverage caveat.** This diagnostic needs per-chain divergence
+    records. Sampling setups that only retain a scalar divergence total
+    (a single witness chain, or draws pooled across chains before
+    counting) cannot be diagnosed here — feed per-chain ``is_divergent``
+    flags (or precomputed per-chain counts via
+    :func:`divergence_concentration_from_counts`) from a genuinely
+    multi-chain run.
+
+    **Non-goal.** This function observes and describes; it does not
+    extend warmup, redraw, back off the step size, or drop a chain. Any
+    remedy is left to the caller — see :func:`format_divergence_warning`
+    for the suggested-next-step text.
+    """
+    is_divergent = jnp.asarray(is_divergent)
+    n_draws = is_divergent.shape[-1]
+    counts = jnp.sum(is_divergent, axis=-1)
+    return divergence_concentration_from_counts(
+        counts, n_draws, rate_threshold=rate_threshold, ratio_cutoff=ratio_cutoff
+    )
+
+
+def divergence_concentration_from_counts(
+    chain_divergence_counts: ArrayLike,
+    n_draws: int,
+    *,
+    rate_threshold: float = 0.02,
+    ratio_cutoff: float = 3.0,
+) -> DivergenceConcentrationReport:
+    """Same as :func:`divergence_concentration`, from precomputed per-chain counts.
+
+    Use this entry point when per-draw flags are not retained but
+    per-chain divergence totals are (e.g. counted incrementally during
+    sampling rather than stored).
+
+    Parameters
+    ----------
+    chain_divergence_counts
+        Per-chain divergence counts, shape ``(n_chains,)``.
+    n_draws
+        Number of post-warmup draws per chain.
+    rate_threshold, ratio_cutoff
+        See :func:`divergence_concentration`.
+
+    Returns
+    -------
+    :class:`DivergenceConcentrationReport`
+    """
+    counts = jnp.asarray(chain_divergence_counts)
+    num_chains = counts.shape[-1]
+
+    total = jnp.sum(counts, axis=-1)
+    max_count = jnp.max(counts, axis=-1)
+    argmax_chain = jnp.argmax(counts, axis=-1)
+    mean_count = total / num_chains
+
+    rates = counts / n_draws
+    max_rate = max_count / n_draws
+    mean_rate = mean_count / n_draws
+    num_chains_elevated = jnp.sum(rates >= rate_threshold, axis=-1)
+
+    # Guard mean_count == 0 (only possible when D == 0, i.e. no
+    # divergences at all): report ratio=0 rather than 0/0.
+    safe_mean_count = jnp.where(mean_count > 0, mean_count, 1.0)
+    ratio = jnp.where(mean_count > 0, max_count / safe_mean_count, 0.0)
+
+    has_divergences = total > 0
+    warn = has_divergences & (max_rate >= rate_threshold)
+    concentrated = warn & (ratio >= ratio_cutoff)
+
+    # Multinomial exchangeable-null tail: min(1, M * P(Binomial(D, 1/M) >= d_max)),
+    # exact via the regularized incomplete beta function
+    # (P(X >= k) = betainc(k, n-k+1, p) for X ~ Binomial(n, p)). Guard
+    # D == 0 so betainc never sees a == 0.
+    safe_total = jnp.where(has_divergences, total, 1)
+    safe_max = jnp.where(has_divergences, max_count, 1)
+    tail = jax.scipy.special.betainc(
+        safe_max.astype(float),
+        (safe_total - safe_max + 1).astype(float),
+        1.0 / num_chains,
+    )
+    p_value = jnp.where(
+        has_divergences,
+        jnp.minimum(1.0, num_chains * tail),
+        jnp.asarray(jnp.nan),
+    )
+
+    return DivergenceConcentrationReport(
+        warn=warn,
+        concentrated=concentrated,
+        chain=argmax_chain,
+        num_chains_elevated=num_chains_elevated,
+        total_divergences=total,
+        num_chains=jnp.asarray(num_chains),
+        max_rate=max_rate,
+        mean_rate=mean_rate,
+        ratio=ratio,
+        multinomial_p_value=p_value,
+    )
+
+
+def format_divergence_warning(report: DivergenceConcentrationReport) -> str:
+    """Render a :class:`DivergenceConcentrationReport` as a human-readable message.
+
+    Returns ``""`` when ``report.warn`` is false. Not JIT-compatible by
+    design — call it on concrete report values (e.g. after a sampling run
+    has completed), not inside traced code.
+
+    Parameters
+    ----------
+    report
+        A report produced by :func:`divergence_concentration` or
+        :func:`divergence_concentration_from_counts`.
+
+    Returns
+    -------
+    ``str``, empty when there is nothing to warn about.
+    """
+    if not bool(report.warn):
+        return ""
+    if bool(report.concentrated):
+        # printf-style, not an f-string format spec: an f-string
+        # `{value:.1f}` is flagged by the linter as a missing-whitespace-
+        # after-colon error, indistinguishable from an actual dict/
+        # annotation colon, and pyupgrade rewrites `.format()` back into
+        # that same f-string form.
+        pct = "%.1f" % (float(report.max_rate) * 100.0)
+        multiple = "%.1f" % float(report.ratio)
+        chain = int(report.chain)
+        return (
+            f"chain {chain}: diverged on {pct}% of its draws "
+            f"({multiple}x the ensemble mean) — likely bad post-warmup "
+            "start state; consider extending warmup, re-running, or "
+            "excluding this chain when recomputing shared products"
+        )
+    n_elevated = int(report.num_chains_elevated)
+    num_chains = int(report.num_chains)
+    return (
+        f"elevated divergence rate across {n_elevated} of {num_chains} "
+        "chains — likely model geometry, not a single chain's start; "
+        "consider reparameterization or reviewing the warmup verdict"
+    )

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -710,42 +710,49 @@ class DivergenceConcentrationReport(NamedTuple):
     Attributes
     ----------
     warn
-        Bool. Whether the run's worst chain crossed ``rate_threshold``.
-    concentrated
-        Bool. When ``warn`` is true, whether the divergences are
-        concentrated on one chain (``True``) or elevated across the
-        ensemble (``False``). Meaningless when ``warn`` is false.
-    chain
-        Index (0-based) of the chain with the most divergences.
-    num_chains_elevated
-        Number of chains whose own divergence rate is at or above
-        ``rate_threshold``.
+        Bool. Whether a minority of chains (see the module notes on
+        :func:`divergence_concentration`) crossed ``rate_threshold``.
+    flagged
+        Bool array, shape ``(n_chains,)``. Which chains crossed
+        ``rate_threshold``, independent of whether ``warn`` ends up true.
+    num_flagged
+        Number of flagged chains, ``flagged.sum()``.
+    rates
+        Per-chain sampling-phase divergence rate, shape ``(n_chains,)``.
+    early_rate, late_rate
+        Per-chain divergence rate in the first and last quarter of the
+        sampling draws, shape ``(n_chains,)``. ``NaN`` when computed from
+        :func:`divergence_concentration_from_counts` (no per-draw
+        resolution available).
+    median_other_rate
+        For each chain, the median ``rates`` value across the *other*
+        ``n_chains - 1`` chains, shape ``(n_chains,)``. ``NaN`` when
+        ``n_chains <= 1``.
     total_divergences
         Total divergence count ``D`` summed over all chains.
     num_chains
         Number of chains ``M``.
-    max_rate
-        Divergence rate of the worst chain, ``d_max / n_draws``.
-    mean_rate
-        Ensemble-mean per-chain divergence rate, ``D / (M * n_draws)``.
-    ratio
-        ``max_rate / mean_rate`` (0 when ``mean_rate`` is 0, i.e. ``D=0``).
+    rate_threshold
+        The threshold that was applied (echoed back for the message /
+        for callers that only keep the report).
     multinomial_p_value
-        Bonferroni-corrected exchangeable-null tail probability
-        ``min(1, M * P(Binomial(D, 1/M) >= d_max))``. Reported as context
-        only — see the module-level notes on :func:`divergence_concentration`
-        for why this does not drive the warning. ``NaN`` when ``D=0``.
+        Bonferroni-corrected exchangeable-null tail probability for the
+        single worst chain, ``min(1, M * P(Binomial(D, 1/M) >= d_max))``.
+        Reported as context only — see the module-level notes on
+        :func:`divergence_concentration` for why this does not drive the
+        warning. ``NaN`` when ``D=0``.
     """
 
     warn: Array
-    concentrated: Array
-    chain: Array
-    num_chains_elevated: Array
+    flagged: Array
+    num_flagged: Array
+    rates: Array
+    early_rate: Array
+    late_rate: Array
+    median_other_rate: Array
     total_divergences: Array
     num_chains: Array
-    max_rate: Array
-    mean_rate: Array
-    ratio: Array
+    rate_threshold: Array
     multinomial_p_value: Array
 
 
@@ -753,31 +760,19 @@ def divergence_concentration(
     is_divergent: ArrayLike,
     *,
     rate_threshold: float = 0.02,
-    ratio_cutoff: float = 3.0,
 ) -> DivergenceConcentrationReport:
-    """Flag a sampling run whose divergences concentrate on one or a few chains.
-
-    A multi-chain sampling run can end up with the same total divergence
-    count reached in very different ways: one chain landing on a bad
-    post-warmup start state and diverging heavily while the rest are clean,
-    versus every chain diverging moderately because the model geometry
-    itself is hard. The two call for different remedies, so this function
-    reports which pattern (if either) is present — it never intervenes.
+    """Flag a run where sampling-phase divergences concentrate on a minority of chains.
 
     Parameters
     ----------
     is_divergent
-        Per-draw divergence flags (bool or 0/1), shape ``(n_chains,
-        n_draws)``. Any leading batch dimensions are treated as extra chain
-        axes only if they are the true chain axis; this function assumes
-        the array is exactly 2-D, chains on axis 0.
+        Per-draw divergence flags (bool or 0/1) for the **sampling
+        (post-warmup) phase only**, shape ``(n_chains, n_draws)``. Warmup
+        divergences must not be included — see the module notes below.
     rate_threshold
-        Minimum per-chain divergence rate (``d_max / n_draws``) that
-        triggers a warning. Default ``0.02`` (2%).
-    ratio_cutoff
-        Minimum ``max_rate / mean_rate`` ratio to classify a warning as
-        chain-concentrated (``report.concentrated=True``) rather than
-        ensemble-wide elevation. Default ``3.0``.
+        Minimum per-chain divergence rate (``d_k / n_draws``) for chain
+        ``k`` to count as flagged. Default ``0.02`` (2%), the validated
+        default (see Notes).
 
     Returns
     -------
@@ -785,20 +780,54 @@ def divergence_concentration(
 
     Notes
     -----
+    **Scope: a minority-outlier trigger, not a general divergence
+    monitor.** ``report.warn`` is true iff between 1 and
+    ``max(1, n_chains // 4)`` chains are flagged (e.g. 1-2 chains out of
+    8). This function targets exactly one validated pattern — one or a
+    couple of chains landing on a bad post-warmup start state while the
+    rest of the ensemble stays clean. It deliberately does **not** warn
+    when most or all chains are flagged together: that pattern is already
+    visible in the run's aggregate divergence count and whatever verdict
+    a routing/warmup layer already derives from it, and this function's
+    per-chain remedy language (see below) would misdescribe a
+    whole-ensemble issue as a single bad chain. ``report.flagged`` and
+    ``report.num_flagged`` are populated in that case too, so a caller
+    who wants the raw counts can still read them — only the message-worthy
+    ``warn`` flag is withheld.
+
+    **Counting is sampling-phase only.** Divergences that occur during
+    warmup are out of scope for this diagnostic; feed it post-warmup
+    draws only. This also determines where the function is meant to be
+    called from: it is a standalone, kernel-agnostic function that
+    operates purely on completed sampling output — the same shape as
+    :func:`rhat` or :func:`effective_sample_size` next to it in this
+    module — and is intended to be read from a post-sampling
+    routing/verdict layer (whatever code decides what to do with a
+    finished run), not from a warmup/adaptation routine: warmup
+    algorithms return before any sampling divergence exists to diagnose.
+    Existing warmup-adaptation algorithms in this library (e.g.
+    :func:`window_adaptation`) are unaffected by this function.
+
+    **What the message reports.** For each flagged chain the report
+    carries factual, non-causal fields: the chain's overall rate, its
+    divergence rate restricted to the first and last quarter of the
+    sampling draws (``early_rate`` / ``late_rate`` — a chain that
+    diverges heavily early and recovers looks different from one that
+    degrades throughout), and the median rate of the other chains for
+    comparison. :func:`format_divergence_warning` turns these into a
+    sentence per flagged chain with no causal or remedial claims baked
+    into the wording itself (see below for remedies as documentation).
+
     **Evidence basis.** Validated retrospectively (no gating, no
     intervention — a pure read of existing per-chain divergence records)
     across 120 (model, warmup arm, seed) cells spanning several models,
     warmup strategies, and seeds. At the default 2% threshold, 7 of the 8
     flagged non-degenerate cells were independently substantiated true
     positives — textbook funnel-neck geometry, a near-storm single-chain
-    concentration at ~7x the ensemble mean, and ensembles with every chain
-    globally elevated; the most severe cell in the corpus (worst-chain rate
-    18.75%) was flagged with a roughly 9x margin over the threshold. The
-    ``max_rate / mean_rate`` ratio was found, after the fact rather than by
-    design, to separate the two failure signatures cleanly: single
-    bad-start chains cluster around 4-7x, ensemble-wide elevation around
-    1.6-1.8x — hence the ``ratio_cutoff`` default of 3.0, placed between
-    the two clusters.
+    concentration, and ensembles with every chain globally elevated (the
+    case this function now declines to warn on, per the scope note
+    above); the most severe cell in the corpus (worst-chain rate 18.75%)
+    was flagged with a roughly 9x margin over the threshold.
 
     **Why the multinomial tail is reported as context only, never as the
     trigger.** An earlier design tried triggering on
@@ -812,24 +841,38 @@ def divergence_concentration(
     the same validation corpus, so the p-value is computed and returned for
     interested callers but never decides ``warn``.
 
+    **Remedies are documentation, not part of the message.** If
+    ``report.warn`` is true, this-run options include treating the
+    flagged chain's early draws as untrustworthy, or excluding the
+    flagged chain when recomputing shared summaries/expectations that
+    pool across chains. The message text itself asserts neither a cause
+    nor a fix — only the observed rates.
+
     **Coverage caveat.** This diagnostic needs per-chain divergence
-    records. Sampling setups that only retain a scalar divergence total
-    (a single witness chain, or draws pooled across chains before
-    counting) cannot be diagnosed here — feed per-chain ``is_divergent``
-    flags (or precomputed per-chain counts via
-    :func:`divergence_concentration_from_counts`) from a genuinely
-    multi-chain run.
+    records from a genuinely multi-chain run. Sampling setups that only
+    retain a scalar divergence total (a single witness chain, or draws
+    pooled across chains before counting) cannot be diagnosed here.
 
     **Non-goal.** This function observes and describes; it does not
     extend warmup, redraw, back off the step size, or drop a chain. Any
-    remedy is left to the caller — see :func:`format_divergence_warning`
-    for the suggested-next-step text.
+    remedy is left entirely to the caller.
     """
     is_divergent = jnp.asarray(is_divergent)
     n_draws = is_divergent.shape[-1]
+    num_chains = is_divergent.shape[-2]
     counts = jnp.sum(is_divergent, axis=-1)
-    return divergence_concentration_from_counts(
-        counts, n_draws, rate_threshold=rate_threshold, ratio_cutoff=ratio_cutoff
+
+    quarter = max(n_draws // 4, 1)
+    early_rate = jnp.sum(is_divergent[:, :quarter], axis=-1) / quarter
+    late_rate = jnp.sum(is_divergent[:, n_draws - quarter :], axis=-1) / quarter
+
+    return _divergence_concentration_core(
+        counts,
+        n_draws,
+        num_chains,
+        early_rate,
+        late_rate,
+        rate_threshold=rate_threshold,
     )
 
 
@@ -838,21 +881,25 @@ def divergence_concentration_from_counts(
     n_draws: int,
     *,
     rate_threshold: float = 0.02,
-    ratio_cutoff: float = 3.0,
 ) -> DivergenceConcentrationReport:
     """Same as :func:`divergence_concentration`, from precomputed per-chain counts.
 
     Use this entry point when per-draw flags are not retained but
     per-chain divergence totals are (e.g. counted incrementally during
-    sampling rather than stored).
+    sampling rather than stored). ``report.early_rate`` and
+    ``report.late_rate`` are ``NaN`` throughout — the temporal quarter
+    profile needs per-draw resolution that this entry point does not
+    have; :func:`format_divergence_warning` degrades gracefully and omits
+    that part of the message.
 
     Parameters
     ----------
     chain_divergence_counts
-        Per-chain divergence counts, shape ``(n_chains,)``.
+        Per-chain divergence counts for the sampling phase, shape
+        ``(n_chains,)``.
     n_draws
-        Number of post-warmup draws per chain.
-    rate_threshold, ratio_cutoff
+        Number of post-warmup (sampling) draws per chain.
+    rate_threshold
         See :func:`divergence_concentration`.
 
     Returns
@@ -861,30 +908,59 @@ def divergence_concentration_from_counts(
     """
     counts = jnp.asarray(chain_divergence_counts)
     num_chains = counts.shape[-1]
+    nan_quarters = jnp.full((num_chains,), jnp.nan)
+    return _divergence_concentration_core(
+        counts,
+        n_draws,
+        num_chains,
+        nan_quarters,
+        nan_quarters,
+        rate_threshold=rate_threshold,
+    )
 
+
+def _divergence_concentration_core(
+    counts: Array,
+    n_draws: int,
+    num_chains: int,
+    early_rate: Array,
+    late_rate: Array,
+    *,
+    rate_threshold: float,
+) -> DivergenceConcentrationReport:
     total = jnp.sum(counts, axis=-1)
     max_count = jnp.max(counts, axis=-1)
-    argmax_chain = jnp.argmax(counts, axis=-1)
-    mean_count = total / num_chains
 
     rates = counts / n_draws
-    max_rate = max_count / n_draws
-    mean_rate = mean_count / n_draws
-    num_chains_elevated = jnp.sum(rates >= rate_threshold, axis=-1)
+    flagged = rates >= rate_threshold
+    num_flagged = jnp.sum(flagged, axis=-1)
+    cap = jnp.maximum(1, num_chains // 4)
+    warn = (num_flagged >= 1) & (num_flagged <= cap)
 
-    # Guard mean_count == 0 (only possible when D == 0, i.e. no
-    # divergences at all): report ratio=0 rather than 0/0.
-    safe_mean_count = jnp.where(mean_count > 0, mean_count, 1.0)
-    ratio = jnp.where(mean_count > 0, max_count / safe_mean_count, 0.0)
-
-    has_divergences = total > 0
-    warn = has_divergences & (max_rate >= rate_threshold)
-    concentrated = warn & (ratio >= ratio_cutoff)
+    # Per-chain median of the *other* n_chains - 1 rates, via an explicit
+    # (static) index array per chain rather than boolean masking, so the
+    # gather shape stays static under jit. n_chains is a Python int here
+    # (it comes from a static array shape), so this loop unrolls at trace
+    # time. With a single chain there are no "others" to gather at all.
+    if num_chains > 1:
+        median_other_rate = jnp.stack(
+            [
+                jnp.median(
+                    rates[
+                        jnp.concatenate([jnp.arange(k), jnp.arange(k + 1, num_chains)])
+                    ]
+                )
+                for k in range(num_chains)
+            ]
+        )
+    else:
+        median_other_rate = jnp.full((num_chains,), jnp.nan)
 
     # Multinomial exchangeable-null tail: min(1, M * P(Binomial(D, 1/M) >= d_max)),
     # exact via the regularized incomplete beta function
     # (P(X >= k) = betainc(k, n-k+1, p) for X ~ Binomial(n, p)). Guard
     # D == 0 so betainc never sees a == 0.
+    has_divergences = total > 0
     safe_total = jnp.where(has_divergences, total, 1)
     safe_max = jnp.where(has_divergences, max_count, 1)
     tail = jax.scipy.special.betainc(
@@ -900,14 +976,15 @@ def divergence_concentration_from_counts(
 
     return DivergenceConcentrationReport(
         warn=warn,
-        concentrated=concentrated,
-        chain=argmax_chain,
-        num_chains_elevated=num_chains_elevated,
+        flagged=flagged,
+        num_flagged=num_flagged,
+        rates=rates,
+        early_rate=early_rate,
+        late_rate=late_rate,
+        median_other_rate=median_other_rate,
         total_divergences=total,
         num_chains=jnp.asarray(num_chains),
-        max_rate=max_rate,
-        mean_rate=mean_rate,
-        ratio=ratio,
+        rate_threshold=jnp.asarray(rate_threshold),
         multinomial_p_value=p_value,
     )
 
@@ -915,9 +992,11 @@ def divergence_concentration_from_counts(
 def format_divergence_warning(report: DivergenceConcentrationReport) -> str:
     """Render a :class:`DivergenceConcentrationReport` as a human-readable message.
 
-    Returns ``""`` when ``report.warn`` is false. Not JIT-compatible by
-    design — call it on concrete report values (e.g. after a sampling run
-    has completed), not inside traced code.
+    Returns ``""`` when ``report.warn`` is false. Otherwise returns one
+    sentence per flagged chain (newline-separated when more than one
+    chain is flagged). Not JIT-compatible by design — call it on concrete
+    report values (e.g. after a sampling run has completed), not inside
+    traced code.
 
     Parameters
     ----------
@@ -931,25 +1010,28 @@ def format_divergence_warning(report: DivergenceConcentrationReport) -> str:
     """
     if not bool(report.warn):
         return ""
-    if bool(report.concentrated):
-        # printf-style, not an f-string format spec: an f-string
-        # `{value:.1f}` is flagged by the linter as a missing-whitespace-
-        # after-colon error, indistinguishable from an actual dict/
-        # annotation colon, and pyupgrade rewrites `.format()` back into
-        # that same f-string form.
-        pct = "%.1f" % (float(report.max_rate) * 100.0)
-        multiple = "%.1f" % float(report.ratio)
-        chain = int(report.chain)
-        return (
-            f"chain {chain}: diverged on {pct}% of its draws "
-            f"({multiple}x the ensemble mean) — likely bad post-warmup "
-            "start state; consider extending warmup, re-running, or "
-            "excluding this chain when recomputing shared products"
+
+    lines = []
+    flagged = np.asarray(report.flagged)
+    for k in np.flatnonzero(flagged):
+        k = int(k)
+        pct = "%.1f" % (float(report.rates[k]) * 100.0)
+        median = "%.1f" % (float(report.median_other_rate[k]) * 100.0)
+        early = float(report.early_rate[k])
+        late = float(report.late_rate[k])
+        if np.isfinite(early) and np.isfinite(late):
+            early_str = "%.1f" % (early * 100.0)
+            late_str = "%.1f" % (late * 100.0)
+            quarters = " ({}% in the first quarter, {}% in the last)".format(
+                early_str,
+                late_str,
+            )
+        else:
+            quarters = ""
+        lines.append(
+            f"chain {k}: {pct}% of its sampling draws diverged{quarters} — "
+            f"significantly more than the other chains ({median}% median)"
+            "; draws from this chain, especially early ones, may be "
+            "untrustworthy."
         )
-    n_elevated = int(report.num_chains_elevated)
-    num_chains = int(report.num_chains)
-    return (
-        f"elevated divergence rate across {n_elevated} of {num_chains} "
-        "chains — likely model geometry, not a single chain's start; "
-        "consider reparameterization or reviewing the warmup verdict"
-    )
+    return "\n".join(lines)

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -738,9 +738,7 @@ class DivergenceConcentrationReport(NamedTuple):
     multinomial_p_value
         Bonferroni-corrected exchangeable-null tail probability for the
         single worst chain, ``min(1, M * P(Binomial(D, 1/M) >= d_max))``.
-        Reported as context only — see the module-level notes on
-        :func:`divergence_concentration` for why this does not drive the
-        warning. ``NaN`` when ``D=0``.
+        Context only; never drives ``warn``. ``NaN`` when ``D=0``.
     """
 
     warn: Array
@@ -766,129 +764,28 @@ def divergence_concentration(
     Parameters
     ----------
     is_divergent
-        Per-draw divergence flags (bool or 0/1) for the **sampling
-        (post-warmup) phase only**, shape ``(n_chains, n_draws)``. Warmup
-        divergences must not be included — see the module notes below.
+        Per-draw divergence flags (bool or 0/1) for the sampling
+        (post-warmup) phase only, shape ``(n_chains, n_draws)``.
     rate_threshold
-        Minimum per-chain divergence rate (``d_k / n_draws``) for chain
-        ``k`` to count as flagged. Default ``0.02`` (2%), the validated
-        default (see Notes).
+        Minimum per-chain divergence rate for chain ``k`` to count as
+        flagged. Default ``0.02`` (2%).
 
     Returns
     -------
-    :class:`DivergenceConcentrationReport`
+    :class:`DivergenceConcentrationReport`. ``warn`` is true iff between
+    1 and ``max(1, n_chains // 4)`` chains are flagged -- a
+    minority-outlier trigger; an ensemble where most/all chains cross the
+    threshold returns populated fields but no warning.
 
     Notes
     -----
-    **Scope: a minority-outlier trigger, not a general divergence
-    monitor.** ``report.warn`` is true iff between 1 and
-    ``max(1, n_chains // 4)`` chains are flagged (e.g. 1-2 chains out of
-    8). This function targets exactly one validated pattern — one or a
-    couple of chains landing on a bad post-warmup start state while the
-    rest of the ensemble stays clean. It deliberately does **not** warn
-    when most or all chains are flagged together: that pattern is already
-    visible in the run's aggregate divergence count and whatever verdict
-    a routing/warmup layer already derives from it, and this function's
-    per-chain remedy language (see below) would misdescribe a
-    whole-ensemble issue as a single bad chain. ``report.flagged`` and
-    ``report.num_flagged`` are populated in that case too, so a caller
-    who wants the raw counts can still read them — only the message-worthy
-    ``warn`` flag is withheld.
-
-    **Counting is sampling-phase only.** Divergences that occur during
-    warmup are out of scope for this diagnostic; feed it post-warmup
-    draws only. This also determines where the function is meant to be
-    called from: it is a standalone, kernel-agnostic function that
-    operates purely on completed sampling output — the same shape as
-    :func:`rhat` or :func:`effective_sample_size` next to it in this
-    module — and is intended to be read from a post-sampling
-    routing/verdict layer (whatever code decides what to do with a
-    finished run), not from a warmup/adaptation routine: warmup
-    algorithms return before any sampling divergence exists to diagnose,
-    so a warmup-time version of this check would have no data to act on.
-    Existing warmup-adaptation algorithms in this library — e.g.
-    :func:`window_adaptation` and ``staged_adaptation`` — are unaffected
-    by this function; it neither reads nor writes anything warmup
-    produces.
-
-    There is no way for this function to detect a caller accidentally
-    passing warmup-inclusive divergence flags — a boolean array carries no
-    phase label — so getting this wrong fails silently, and in the
-    dangerous direction: mixing in warmup draws dilutes a genuine chain's
-    rate downward rather than raising a false alarm, because the extra
-    draws lengthen the denominator without (typically) contributing at
-    the same rate. Concretely: a chain diverging on 25 of 1000 sampling
-    draws (2.5%, above the default threshold) reads as the same 25
-    divergences over a doubled, 2000-draw denominator — 1.25%, below
-    threshold, no warning at all — once an equal-length, divergence-free
-    warmup segment is concatenated in front of it. Slice to sampling
-    draws only before calling this function.
-
-    **What the message reports.** For each flagged chain the report
-    carries factual, non-causal fields: the chain's overall rate, its
-    divergence rate restricted to the first and last quarter of the
-    sampling draws (``early_rate`` / ``late_rate`` — a chain that
-    diverges heavily early and recovers looks different from one that
-    degrades throughout), and the median rate of the other chains for
-    comparison. :func:`format_divergence_warning` turns these into a
-    sentence per flagged chain with no causal or remedial claims baked
-    into the wording itself (see below for remedies as documentation).
-
-    **Evidence basis.** Validated retrospectively (no gating, no
-    intervention — a pure read of existing per-chain divergence records)
-    across 120 (model, warmup arm, seed) cells spanning several models,
-    warmup strategies, and seeds. At the default 2% threshold, 7 of the 8
-    flagged non-degenerate cells were independently substantiated true
-    positives — textbook funnel-neck geometry, a near-storm single-chain
-    concentration, and ensembles with every chain globally elevated (the
-    case this function now declines to warn on, per the scope note
-    above); the most severe cell in the corpus (worst-chain rate 18.75%)
-    was flagged with a roughly 9x margin over the threshold.
-
-    **Why the multinomial tail is reported as context only, never as the
-    trigger.** An earlier design tried triggering on
-    ``report.multinomial_p_value`` — a Bonferroni-corrected tail
-    probability under the null that divergences are exchangeable across
-    chains (every chain equally likely to produce the next divergence).
-    That null does not hold for real NUTS/HMC ensembles: distinct chains
-    settle into distinct post-warmup local geometries, so divergence
-    propensity is not exchangeable even on a perfectly healthy run.
-    Empirically this produced a 13% false-positive rate on healthy cells in
-    the same validation corpus, so the p-value is computed and returned for
-    interested callers but never decides ``warn``.
-
-    **Remedies are documentation, not part of the message.** If
-    ``report.warn`` is true, this-run options include treating the
-    flagged chain's early draws as untrustworthy, or excluding the
-    flagged chain when recomputing shared summaries/expectations that
-    pool across chains. The message text itself asserts neither a cause
-    nor a fix — only the observed rates.
-
-    **Coverage caveat.** This diagnostic needs per-chain divergence
-    records from a genuinely multi-chain run. Sampling setups that only
-    retain a scalar divergence total (a single witness chain, or draws
-    pooled across chains before counting) cannot be diagnosed here.
-
-    **Corrupted input fails loud, not silent.** ``is_divergent`` is cast
-    to bool: any non-finite value (e.g. a stray ``NaN`` from upstream
-    float arithmetic) becomes a flagged draw rather than silently
-    dropping out of a rate computation and comparing false against
-    ``rate_threshold`` — a numeric comparison against ``NaN`` is always
-    false, which would otherwise report a corrupted chain as clean.
-    :func:`divergence_concentration_from_counts` applies the same
-    principle to its counts: ``NaN`` becomes ``n_draws`` (worst case) and
-    out-of-range values are clipped into ``[0, n_draws]``.
-
-    **Non-goal.** This function observes and describes; it does not
-    extend warmup, redraw, back off the step size, or drop a chain. Any
-    remedy is left entirely to the caller.
+    - Counting is sampling-phase only; warmup divergences are out of scope.
+    - Concatenating warmup draws in front of sampling draws dilutes a real
+      signal below threshold rather than raising a false alarm -- slice to
+      sampling draws only before calling this.
+    - ``multinomial_p_value`` is context only; it never decides ``warn``.
     """
-    # Cast to bool rather than trust the caller's dtype: any non-finite or
-    # non-zero value (including NaN, which is neither True nor False under
-    # a numeric comparison) becomes a flagged draw. This fails loud
-    # (over-counts) rather than silent (NaN would otherwise propagate into
-    # `rates` and compare False against `rate_threshold`, silently hiding
-    # a corrupted chain behind a clean-looking report).
+    # NaN must flag, not silently pass.
     is_divergent = jnp.asarray(is_divergent).astype(bool)
     n_draws = is_divergent.shape[-1]
     num_chains = is_divergent.shape[-2]
@@ -916,13 +813,10 @@ def divergence_concentration_from_counts(
 ) -> DivergenceConcentrationReport:
     """Same as :func:`divergence_concentration`, from precomputed per-chain counts.
 
-    Use this entry point when per-draw flags are not retained but
-    per-chain divergence totals are (e.g. counted incrementally during
-    sampling rather than stored). ``report.early_rate`` and
-    ``report.late_rate`` are ``NaN`` throughout — the temporal quarter
-    profile needs per-draw resolution that this entry point does not
-    have; :func:`format_divergence_warning` degrades gracefully and omits
-    that part of the message.
+    Use when per-draw flags are not retained but per-chain totals are.
+    ``early_rate`` / ``late_rate`` are ``NaN`` (no per-draw resolution for
+    a quarter profile); :func:`format_divergence_warning` omits that part
+    of the message rather than printing "nan%".
 
     Parameters
     ----------
@@ -930,7 +824,7 @@ def divergence_concentration_from_counts(
         Per-chain divergence counts for the sampling phase, shape
         ``(n_chains,)``.
     n_draws
-        Number of post-warmup (sampling) draws per chain.
+        Number of sampling draws per chain.
     rate_threshold
         See :func:`divergence_concentration`.
 
@@ -938,13 +832,7 @@ def divergence_concentration_from_counts(
     -------
     :class:`DivergenceConcentrationReport`
     """
-    # Sanitize rather than trust the caller's values: NaN becomes n_draws
-    # (worst case, fully divergent) and out-of-range values are clipped
-    # into [0, n_draws]. Fails loud -- an implausibly high reported rate
-    # is visible -- rather than silent, since an un-sanitized NaN would
-    # otherwise propagate into `rates` and compare False against
-    # `rate_threshold`, hiding a corrupted chain behind a clean-looking
-    # report (mirrors the boolean-cast guard in divergence_concentration).
+    # NaN must flag (as fully divergent), not silently pass.
     counts = jnp.asarray(chain_divergence_counts).astype(float)
     counts = jnp.clip(jnp.nan_to_num(counts, nan=float(n_draws)), 0.0, float(n_draws))
     num_chains = counts.shape[-1]
@@ -977,11 +865,8 @@ def _divergence_concentration_core(
     cap = jnp.maximum(1, num_chains // 4)
     warn = (num_flagged >= 1) & (num_flagged <= cap)
 
-    # Per-chain median of the *other* n_chains - 1 rates, via an explicit
-    # (static) index array per chain rather than boolean masking, so the
-    # gather shape stays static under jit. n_chains is a Python int here
-    # (it comes from a static array shape), so this loop unrolls at trace
-    # time. With a single chain there are no "others" to gather at all.
+    # Static per-chain index gather keeps this jit-safe (num_chains is a
+    # Python int); no "others" exist when num_chains == 1.
     if num_chains > 1:
         median_other_rate = jnp.stack(
             [
@@ -996,10 +881,8 @@ def _divergence_concentration_core(
     else:
         median_other_rate = jnp.full((num_chains,), jnp.nan)
 
-    # Multinomial exchangeable-null tail: min(1, M * P(Binomial(D, 1/M) >= d_max)),
-    # exact via the regularized incomplete beta function
-    # (P(X >= k) = betainc(k, n-k+1, p) for X ~ Binomial(n, p)). Guard
-    # D == 0 so betainc never sees a == 0.
+    # Exact binomial tail via the regularized incomplete beta function;
+    # D == 0 is guarded so betainc never sees a == 0.
     has_divergences = total > 0
     safe_total = jnp.where(has_divergences, total, 1)
     safe_max = jnp.where(has_divergences, max_count, 1)

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -811,6 +811,19 @@ def divergence_concentration(
     by this function; it neither reads nor writes anything warmup
     produces.
 
+    There is no way for this function to detect a caller accidentally
+    passing warmup-inclusive divergence flags — a boolean array carries no
+    phase label — so getting this wrong fails silently, and in the
+    dangerous direction: mixing in warmup draws dilutes a genuine chain's
+    rate downward rather than raising a false alarm, because the extra
+    draws lengthen the denominator without (typically) contributing at
+    the same rate. Concretely: a chain diverging on 25 of 1000 sampling
+    draws (2.5%, above the default threshold) reads as the same 25
+    divergences over a doubled, 2000-draw denominator — 1.25%, below
+    threshold, no warning at all — once an equal-length, divergence-free
+    warmup segment is concatenated in front of it. Slice to sampling
+    draws only before calling this function.
+
     **What the message reports.** For each flagged chain the report
     carries factual, non-causal fields: the chain's overall rate, its
     divergence rate restricted to the first and last quarter of the
@@ -856,11 +869,27 @@ def divergence_concentration(
     retain a scalar divergence total (a single witness chain, or draws
     pooled across chains before counting) cannot be diagnosed here.
 
+    **Corrupted input fails loud, not silent.** ``is_divergent`` is cast
+    to bool: any non-finite value (e.g. a stray ``NaN`` from upstream
+    float arithmetic) becomes a flagged draw rather than silently
+    dropping out of a rate computation and comparing false against
+    ``rate_threshold`` — a numeric comparison against ``NaN`` is always
+    false, which would otherwise report a corrupted chain as clean.
+    :func:`divergence_concentration_from_counts` applies the same
+    principle to its counts: ``NaN`` becomes ``n_draws`` (worst case) and
+    out-of-range values are clipped into ``[0, n_draws]``.
+
     **Non-goal.** This function observes and describes; it does not
     extend warmup, redraw, back off the step size, or drop a chain. Any
     remedy is left entirely to the caller.
     """
-    is_divergent = jnp.asarray(is_divergent)
+    # Cast to bool rather than trust the caller's dtype: any non-finite or
+    # non-zero value (including NaN, which is neither True nor False under
+    # a numeric comparison) becomes a flagged draw. This fails loud
+    # (over-counts) rather than silent (NaN would otherwise propagate into
+    # `rates` and compare False against `rate_threshold`, silently hiding
+    # a corrupted chain behind a clean-looking report).
+    is_divergent = jnp.asarray(is_divergent).astype(bool)
     n_draws = is_divergent.shape[-1]
     num_chains = is_divergent.shape[-2]
     counts = jnp.sum(is_divergent, axis=-1)
@@ -909,7 +938,15 @@ def divergence_concentration_from_counts(
     -------
     :class:`DivergenceConcentrationReport`
     """
-    counts = jnp.asarray(chain_divergence_counts)
+    # Sanitize rather than trust the caller's values: NaN becomes n_draws
+    # (worst case, fully divergent) and out-of-range values are clipped
+    # into [0, n_draws]. Fails loud -- an implausibly high reported rate
+    # is visible -- rather than silent, since an un-sanitized NaN would
+    # otherwise propagate into `rates` and compare False against
+    # `rate_threshold`, hiding a corrupted chain behind a clean-looking
+    # report (mirrors the boolean-cast guard in divergence_concentration).
+    counts = jnp.asarray(chain_divergence_counts).astype(float)
+    counts = jnp.clip(jnp.nan_to_num(counts, nan=float(n_draws)), 0.0, float(n_draws))
     num_chains = counts.shape[-1]
     nan_quarters = jnp.full((num_chains,), jnp.nan)
     return _divergence_concentration_core(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -511,93 +511,173 @@ class ParetoKhatTest(chex.TestCase):
         ), f"pareto_khat for Cauchy heavy tail expected >0.3 got {got_k}"
 
 
-class DivergenceConcentrationTest(chex.TestCase):
-    """Tests for the divergence-concentration warning.
+def _build_is_divergent(chain_specs, n_draws):
+    """Build a synthetic ``(n_chains, n_draws)`` boolean array from
+    ``(total, first_quarter_count, last_quarter_count)`` triples.
 
-    Fixtures are real per-chain divergence counts (not synthetic), pulled
-    from a retrospective 120-cell validation corpus of BlackJAX/tuningfork
-    benchmark runs — the same corpus the default ``rate_threshold=0.02``
-    and ``ratio_cutoff=3.0`` were calibrated against.
+    Reproduces exact real per-chain totals *and* first-/last-quarter
+    counts (the rest of a chain's divergences are placed in the middle
+    half, where placement is irrelevant to what these tests check) so the
+    quarter-profile fields can be tested against real validation-corpus
+    numbers without depending on any external file path.
+    """
+    quarter = n_draws // 4
+    rows = []
+    for total, first_q, last_q in chain_specs:
+        mid = total - first_q - last_q
+        assert 0 <= first_q <= quarter and 0 <= last_q <= quarter and mid >= 0
+        row = np.zeros(n_draws, dtype=bool)
+        row[:first_q] = True
+        if last_q:
+            row[n_draws - last_q :] = True
+        row[quarter : quarter + mid] = True
+        rows.append(row)
+    return jnp.asarray(np.stack(rows))
+
+
+class DivergenceConcentrationTest(chex.TestCase):
+    """Tests for the sampling-phase divergence-concentration warning.
+
+    Fixtures reproduce real per-chain divergence counts and (for the
+    flagged-chain quarter-profile tests) real first-/last-quarter counts,
+    pulled from a retrospective 120-cell validation corpus of
+    BlackJAX/tuningfork benchmark runs — the same corpus the default
+    ``rate_threshold=0.02`` and the ``num_chains // 4`` minority cap were
+    calibrated against.
     """
 
-    # A single chain (index 6 of 8) landing on a bad post-warmup start
-    # state and diverging heavily while the rest stay clean: rate 18.75%,
-    # ratio ~6.4x the ensemble mean. The most severe cell in the
-    # validation corpus.
-    _CONCENTRATED_COUNTS = [7, 6, 9, 44, 6, 9, 375, 15]
+    _N_DRAWS = 2000
+
+    # A minority-of-two case: one dominant chain (index 6) landing on a
+    # bad post-warmup start state (18.75% overall, 72.2% in just the
+    # first quarter, recovering to 0.2% in the last), plus one chain
+    # (index 3) barely over the 2% threshold. Both cross rate_threshold;
+    # num_flagged=2 == max(1, 8 // 4), the boundary of the minority cap.
+    # (total, first_quarter_count, last_quarter_count) per chain, quarter=500.
+    _STORM_SPECS = [
+        (7, 0, 1),
+        (6, 1, 2),
+        (9, 2, 4),
+        (44, 1, 0),
+        (6, 3, 1),
+        (9, 3, 4),
+        (375, 361, 1),
+        (15, 9, 1),
+    ]
+    _STORM_FLAGGED = (3, 6)
+
+    # A single-chain minority case at a much smaller D: chain 7 at 2.9%,
+    # right at the edge of the default 2% threshold, degrading rather
+    # than recovering (0% first quarter, 11.4% last quarter).
+    _SINGLE_FLAGGED_SPECS = [
+        (1, 0, 0),
+        (1, 0, 0),
+        (0, 0, 0),
+        (3, 0, 0),
+        (0, 0, 0),
+        (4, 0, 0),
+        (0, 0, 0),
+        (58, 0, 57),
+    ]
+    _SINGLE_FLAGGED_CHAIN = 7
 
     # Every chain in the ensemble globally elevated (12.85%-26.70% each):
-    # model-geometry signature, not a single bad chain. Ratio ~1.6x.
+    # a model-geometry signature, not a minority bad-start chain — all 8
+    # of 8 chains flagged, over the max(1, 8 // 4) = 2 minority cap, so
+    # this must NOT warn even though the fields are all populated.
     _ENSEMBLE_COUNTS = [316, 261, 257, 534, 272, 384, 302, 271]
-
-    # Same single-bad-chain signature as _CONCENTRATED_COUNTS but at much
-    # smaller D: chain 7 at 2.9% (ratio ~6.9x) — right at the edge of the
-    # default 2% threshold, independently substantiated as a genuine
-    # near-storm concentration rather than noise.
-    _NEAR_STORM_COUNTS = [1, 1, 0, 3, 0, 4, 0, 58]
 
     # Ordinary scattered divergences well below any threshold: healthy.
     _HEALTHY_COUNTS = [2, 6, 3, 4, 7, 3, 4, 7]
 
-    _N_DRAWS = 2000
-
     @chex.all_variants(with_pmap=False)
-    def test_concentrated_storm_warns(self):
-        core = self.variant(
-            functools.partial(
-                diagnostics.divergence_concentration_from_counts,
-                n_draws=self._N_DRAWS,
-            )
-        )
-        report = core(jnp.array(self._CONCENTRATED_COUNTS))
+    def test_storm_warns_minority_of_two(self):
+        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
+        report = self.variant(diagnostics.divergence_concentration)(is_divergent)
         assert bool(report.warn) is True
-        assert bool(report.concentrated) is True
-        assert int(report.chain) == 6
+        assert int(report.num_flagged) == 2
+        np.testing.assert_array_equal(
+            np.asarray(report.flagged),
+            [False, False, False, True, False, False, True, False],
+        )
         assert int(report.total_divergences) == 471
-        np.testing.assert_allclose(float(report.max_rate), 375 / 2000, rtol=1e-6)
+        np.testing.assert_allclose(float(report.rates[6]), 375 / 2000, rtol=1e-6)
 
-    def test_concentrated_storm_message(self):
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._CONCENTRATED_COUNTS), self._N_DRAWS
+    def test_storm_quarter_profile_dominant_chain(self):
+        # Real evidence: chain 6 diverges heavily early and recovers.
+        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
+        report = diagnostics.divergence_concentration(is_divergent)
+        np.testing.assert_allclose(float(report.early_rate[6]), 361 / 500, rtol=1e-6)
+        np.testing.assert_allclose(float(report.late_rate[6]), 1 / 500, rtol=1e-6)
+        assert float(report.early_rate[6]) > float(report.late_rate[6])
+
+    def test_storm_message_lists_both_flagged_chains_no_causal_claims(self):
+        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
+        report = diagnostics.divergence_concentration(is_divergent)
+        msg = diagnostics.format_divergence_warning(report)
+        assert "chain 6:" in msg, msg
+        assert "chain 3:" in msg, msg
+        assert "first quarter" in msg and "in the last" in msg
+        assert "median" in msg
+        # Factual observation only -- no causal/remedy language in the
+        # message text itself (that stays in the docstring as documentation).
+        for banned in ("geometry", "post-warmup start", "reparameterization"):
+            assert banned not in msg, msg
+
+    def test_single_flagged_chain_warns(self):
+        is_divergent = _build_is_divergent(self._SINGLE_FLAGGED_SPECS, self._N_DRAWS)
+        report = diagnostics.divergence_concentration(is_divergent)
+        assert bool(report.warn) is True
+        assert int(report.num_flagged) == 1
+        assert bool(report.flagged[self._SINGLE_FLAGGED_CHAIN])
+        np.testing.assert_allclose(
+            float(report.rates[self._SINGLE_FLAGGED_CHAIN]), 58 / 2000, rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            float(report.late_rate[self._SINGLE_FLAGGED_CHAIN]), 57 / 500, rtol=1e-6
         )
         msg = diagnostics.format_divergence_warning(report)
-        assert msg.startswith("chain 6:"), msg
-        assert "post-warmup start" in msg
-        assert "%" in msg and "x the ensemble mean" in msg
+        assert msg.startswith(f"chain {self._SINGLE_FLAGGED_CHAIN}" ":"), msg
 
-    def test_ensemble_elevated_warns(self):
+    def test_ensemble_wide_elevation_does_not_warn(self):
+        # 8 of 8 chains flagged > max(1, 8 // 4) = 2: fields are populated
+        # but this is out of scope for the minority-outlier trigger.
         report = diagnostics.divergence_concentration_from_counts(
             jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
         )
-        assert bool(report.warn) is True
-        assert bool(report.concentrated) is False
-        assert int(report.num_chains_elevated) == 8
+        assert bool(report.warn) is False
+        assert int(report.num_flagged) == 8
+        np.testing.assert_array_equal(np.asarray(report.flagged), [True] * 8)
+        assert int(report.total_divergences) == sum(self._ENSEMBLE_COUNTS)
+        assert diagnostics.format_divergence_warning(report) == ""
 
-    def test_ensemble_elevated_message(self):
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
-        )
-        msg = diagnostics.format_divergence_warning(report)
-        assert "elevated divergence rate across 8 of 8 chains" in msg
-        assert "geometry" in msg
-        assert "chain 3:" not in msg  # not the single-chain phrasing
+    def test_minority_cap_boundary(self):
+        # num_chains=8 -> cap=2. Exactly 3 flagged chains must NOT warn,
+        # even though each individually clears rate_threshold.
+        counts = jnp.array([50, 50, 50, 0, 0, 0, 0, 0])  # 3 chains at 2.5%
+        report = diagnostics.divergence_concentration_from_counts(counts, self._N_DRAWS)
+        assert int(report.num_flagged) == 3
+        assert bool(report.warn) is False
 
-    def test_near_storm_warns_concentrated_at_default_threshold(self):
-        # rate = 58/2000 = 2.9% >= default 2% threshold -> warns.
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._NEAR_STORM_COUNTS), self._N_DRAWS
+    def test_minority_cap_at_small_num_chains(self):
+        # num_chains=4 -> cap=max(1, 1)=1. One flagged chain warns; two does not.
+        one_flagged = jnp.array([50, 0, 0, 0])
+        two_flagged = jnp.array([50, 50, 0, 0])
+        report_one = diagnostics.divergence_concentration_from_counts(
+            one_flagged, self._N_DRAWS
         )
-        assert bool(report.warn) is True
-        assert bool(report.concentrated) is True
-        assert int(report.chain) == 7
-        np.testing.assert_allclose(float(report.max_rate), 58 / 2000, rtol=1e-6)
-        assert float(report.ratio) > 3.0
+        report_two = diagnostics.divergence_concentration_from_counts(
+            two_flagged, self._N_DRAWS
+        )
+        assert bool(report_one.warn) is True
+        assert bool(report_two.warn) is False
 
     def test_healthy_scatter_no_warning(self):
         report = diagnostics.divergence_concentration_from_counts(
             jnp.array(self._HEALTHY_COUNTS), self._N_DRAWS
         )
         assert bool(report.warn) is False
+        assert int(report.num_flagged) == 0
         assert diagnostics.format_divergence_warning(report) == ""
 
     def test_zero_divergences_no_warning(self):
@@ -605,63 +685,66 @@ class DivergenceConcentrationTest(chex.TestCase):
             jnp.zeros(8, dtype=int), self._N_DRAWS
         )
         assert bool(report.warn) is False
+        assert int(report.num_flagged) == 0
         assert diagnostics.format_divergence_warning(report) == ""
 
-    def test_ratio_guard_at_zero_mean(self):
-        # D=0 -> mean_count=0; ratio must not be nan/inf, and no warning.
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.zeros(4, dtype=int), self._N_DRAWS
-        )
-        ratio = float(report.ratio)
-        assert np.isfinite(ratio), f"ratio must be finite at mean=0, got {ratio}"
-        assert ratio == 0.0
-        assert bool(report.warn) is False
+    def test_from_counts_quarters_are_nan_and_degrade_gracefully(self):
+        # The counts-only entry point has no per-draw resolution: quarter
+        # fields are NaN, and the message omits the quarter parenthetical
+        # rather than printing "nan%".
+        counts = jnp.array([1, 1, 0, 3, 0, 4, 0, 58])  # matches the single-flagged case
+        report = diagnostics.divergence_concentration_from_counts(counts, self._N_DRAWS)
+        assert bool(report.warn) is True
+        assert np.isnan(float(report.early_rate[7]))
+        assert np.isnan(float(report.late_rate[7]))
+        msg = diagnostics.format_divergence_warning(report)
+        assert "nan" not in msg.lower(), msg
+        assert "first quarter" not in msg, msg
+        assert msg.startswith("chain 7:"), msg
 
-    def test_from_is_divergent_matches_from_counts(self):
-        # Build a (chains, draws) boolean array with the same per-chain
-        # counts as the concentrated fixture and check both entry points agree.
-        counts = self._CONCENTRATED_COUNTS
-        is_divergent = jnp.zeros((len(counts), self._N_DRAWS), dtype=bool)
-        for k, c in enumerate(counts):
-            is_divergent = is_divergent.at[k, :c].set(True)
+    def test_from_is_divergent_matches_from_counts_trigger(self):
+        # Trigger-level fields (warn, flagged, rates, D) must agree between
+        # the two entry points for the same underlying counts; only the
+        # quarter fields differ (real vs NaN).
+        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
         report_flags = diagnostics.divergence_concentration(is_divergent)
+        counts = [total for total, _, _ in self._STORM_SPECS]
         report_counts = diagnostics.divergence_concentration_from_counts(
             jnp.array(counts), self._N_DRAWS
         )
         assert bool(report_flags.warn) == bool(report_counts.warn)
-        assert bool(report_flags.concentrated) == bool(report_counts.concentrated)
-        assert int(report_flags.chain) == int(report_counts.chain)
+        assert int(report_flags.num_flagged) == int(report_counts.num_flagged)
         np.testing.assert_allclose(
-            float(report_flags.max_rate), float(report_counts.max_rate), rtol=1e-6
+            np.asarray(report_flags.rates), np.asarray(report_counts.rates), rtol=1e-6
+        )
+        assert int(report_flags.total_divergences) == int(
+            report_counts.total_divergences
         )
 
     def test_rate_threshold_override(self):
-        # Raising the threshold above the near-storm cell's rate silences it.
+        # Raising the threshold above the single-flagged cell's rate silences it.
+        counts = jnp.array([1, 1, 0, 3, 0, 4, 0, 58])
         report_default = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._NEAR_STORM_COUNTS), self._N_DRAWS
+            counts, self._N_DRAWS
         )
         report_high_threshold = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._NEAR_STORM_COUNTS), self._N_DRAWS, rate_threshold=0.05
+            counts, self._N_DRAWS, rate_threshold=0.05
         )
         assert bool(report_default.warn) is True
         assert bool(report_high_threshold.warn) is False
 
-    def test_ratio_cutoff_override(self):
-        # Lowering ratio_cutoff below the ensemble cell's ratio (~1.64x)
-        # reclassifies it from ensemble-wide to concentrated.
-        report_default = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
+    def test_median_other_rate_single_chain_guard(self):
+        # num_chains=1: there are no "other" chains -- must not crash, and
+        # median_other_rate must be NaN rather than raising.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array([5]), self._N_DRAWS
         )
-        report_low_cutoff = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS, ratio_cutoff=1.5
-        )
-        assert bool(report_default.concentrated) is False
-        assert bool(report_low_cutoff.concentrated) is True
+        assert np.isnan(float(report.median_other_rate[0]))
 
     def test_multinomial_p_value_is_context_not_trigger(self):
-        # The healthy-scatter cell can still have a tiny multinomial
+        # The healthy-scatter cell can still have a small multinomial
         # p-value (real chains are not exchangeable) yet must not warn --
-        # the rate threshold, not the p-value, decides `warn`.
+        # the per-chain rate threshold, not the p-value, decides `warn`.
         report = diagnostics.divergence_concentration_from_counts(
             jnp.array(self._HEALTHY_COUNTS), self._N_DRAWS
         )

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -638,6 +638,14 @@ class DivergenceConcentrationTest(chex.TestCase):
         assert bool(report_default.warn) is True
         assert bool(report_high.warn) is False
 
+    def test_single_chain_input_is_handled_gracefully(self):
+        # num_chains=1 has no "other" chains to compare against -- must
+        # not crash, just report cleanly.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array([5]), self._N_DRAWS
+        )
+        assert bool(report.warn) is False
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -512,20 +512,14 @@ class ParetoKhatTest(chex.TestCase):
 
 
 def _build_is_divergent(chain_specs, n_draws):
-    """Build a synthetic ``(n_chains, n_draws)`` boolean array from
-    ``(total, first_quarter_count, last_quarter_count)`` triples.
-
-    Reproduces exact real per-chain totals *and* first-/last-quarter
-    counts (the rest of a chain's divergences are placed in the middle
-    half, where placement is irrelevant to what these tests check) so the
-    quarter-profile fields can be tested against real validation-corpus
-    numbers without depending on any external file path.
+    """Build a ``(n_chains, n_draws)`` bool array from ``(total,
+    first_quarter_count, last_quarter_count)`` triples, reproducing real
+    validation-corpus per-chain and quarter counts without an external file.
     """
     quarter = n_draws // 4
     rows = []
     for total, first_q, last_q in chain_specs:
         mid = total - first_q - last_q
-        assert 0 <= first_q <= quarter and 0 <= last_q <= quarter and mid >= 0
         row = np.zeros(n_draws, dtype=bool)
         row[:first_q] = True
         if last_q:
@@ -536,24 +530,13 @@ def _build_is_divergent(chain_specs, n_draws):
 
 
 class DivergenceConcentrationTest(chex.TestCase):
-    """Tests for the sampling-phase divergence-concentration warning.
-
-    Fixtures reproduce real per-chain divergence counts and (for the
-    flagged-chain quarter-profile tests) real first-/last-quarter counts,
-    pulled from a retrospective 120-cell validation corpus of
-    BlackJAX/tuningfork benchmark runs — the same corpus the default
-    ``rate_threshold=0.02`` and the ``num_chains // 4`` minority cap were
-    calibrated against.
-    """
+    """Tests for the sampling-phase divergence-concentration warning."""
 
     _N_DRAWS = 2000
 
-    # A minority-of-two case: one dominant chain (index 6) landing on a
-    # bad post-warmup start state (18.75% overall, 72.2% in just the
-    # first quarter, recovering to 0.2% in the last), plus one chain
-    # (index 3) barely over the 2% threshold. Both cross rate_threshold;
-    # num_flagged=2 == max(1, 8 // 4), the boundary of the minority cap.
-    # (total, first_quarter_count, last_quarter_count) per chain, quarter=500.
+    # Real validation-corpus counts: chain 6 dominant (18.75%, early-
+    # concentrated then recovers), chain 3 marginal (2.2%) -- num_flagged=2
+    # at the max(1, 8 // 4) minority-cap boundary.
     _STORM_SPECS = [
         (7, 0, 1),
         (6, 1, 2),
@@ -564,120 +547,45 @@ class DivergenceConcentrationTest(chex.TestCase):
         (375, 361, 1),
         (15, 9, 1),
     ]
-    _STORM_FLAGGED = (3, 6)
 
-    # A single-chain minority case at a much smaller D: chain 7 at 2.9%,
-    # right at the edge of the default 2% threshold, degrading rather
-    # than recovering (0% first quarter, 11.4% last quarter).
-    _SINGLE_FLAGGED_SPECS = [
-        (1, 0, 0),
-        (1, 0, 0),
-        (0, 0, 0),
-        (3, 0, 0),
-        (0, 0, 0),
-        (4, 0, 0),
-        (0, 0, 0),
-        (58, 0, 57),
-    ]
-    _SINGLE_FLAGGED_CHAIN = 7
-
-    # Every chain in the ensemble globally elevated (12.85%-26.70% each):
-    # a model-geometry signature, not a minority bad-start chain — all 8
-    # of 8 chains flagged, over the max(1, 8 // 4) = 2 minority cap, so
-    # this must NOT warn even though the fields are all populated.
+    # Every chain elevated (12.85%-26.70%): 8 of 8 flagged, over the
+    # minority cap -- must NOT warn.
     _ENSEMBLE_COUNTS = [316, 261, 257, 534, 272, 384, 302, 271]
 
-    # Ordinary scattered divergences well below any threshold: healthy.
     _HEALTHY_COUNTS = [2, 6, 3, 4, 7, 3, 4, 7]
+    _SINGLE_CHAIN_COUNTS = jnp.array([1, 1, 0, 3, 0, 4, 0, 58])
 
-    @chex.all_variants(with_pmap=False)
-    def test_storm_warns_minority_of_two(self):
+    def test_storm_minority_of_two(self):
         is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
-        report = self.variant(diagnostics.divergence_concentration)(is_divergent)
+        report = diagnostics.divergence_concentration(is_divergent)
         assert bool(report.warn) is True
         assert int(report.num_flagged) == 2
         np.testing.assert_array_equal(
             np.asarray(report.flagged),
             [False, False, False, True, False, False, True, False],
         )
-        assert int(report.total_divergences) == 471
-        np.testing.assert_allclose(float(report.rates[6]), 375 / 2000, rtol=1e-6)
-
-    def test_storm_quarter_profile_dominant_chain(self):
-        # Real evidence: chain 6 diverges heavily early and recovers.
-        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
-        report = diagnostics.divergence_concentration(is_divergent)
         np.testing.assert_allclose(float(report.early_rate[6]), 361 / 500, rtol=1e-6)
         np.testing.assert_allclose(float(report.late_rate[6]), 1 / 500, rtol=1e-6)
-        assert float(report.early_rate[6]) > float(report.late_rate[6])
 
-    def test_storm_message_lists_both_flagged_chains_no_causal_claims(self):
-        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
-        report = diagnostics.divergence_concentration(is_divergent)
         msg = diagnostics.format_divergence_warning(report)
-        assert "chain 6:" in msg, msg
-        assert "chain 3:" in msg, msg
-        assert "first quarter" in msg and "in the last" in msg
-        assert "median" in msg
-        # Factual observation only -- no causal/remedy language in the
-        # message text itself (that stays in the docstring as documentation).
+        assert "chain 3:" in msg and "chain 6:" in msg, msg
+        assert "first quarter" in msg and "median" in msg
         for banned in ("geometry", "post-warmup start", "reparameterization"):
             assert banned not in msg, msg
 
-    def test_single_flagged_chain_warns(self):
-        is_divergent = _build_is_divergent(self._SINGLE_FLAGGED_SPECS, self._N_DRAWS)
-        report = diagnostics.divergence_concentration(is_divergent)
-        assert bool(report.warn) is True
-        assert int(report.num_flagged) == 1
-        assert bool(report.flagged[self._SINGLE_FLAGGED_CHAIN])
-        np.testing.assert_allclose(
-            float(report.rates[self._SINGLE_FLAGGED_CHAIN]), 58 / 2000, rtol=1e-6
-        )
-        np.testing.assert_allclose(
-            float(report.late_rate[self._SINGLE_FLAGGED_CHAIN]), 57 / 500, rtol=1e-6
-        )
-        msg = diagnostics.format_divergence_warning(report)
-        assert msg.startswith(f"chain {self._SINGLE_FLAGGED_CHAIN}" ":"), msg
-
     def test_ensemble_wide_elevation_does_not_warn(self):
-        # 8 of 8 chains flagged > max(1, 8 // 4) = 2: fields are populated
-        # but this is out of scope for the minority-outlier trigger.
         report = diagnostics.divergence_concentration_from_counts(
             jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
         )
         assert bool(report.warn) is False
         assert int(report.num_flagged) == 8
-        np.testing.assert_array_equal(np.asarray(report.flagged), [True] * 8)
-        assert int(report.total_divergences) == sum(self._ENSEMBLE_COUNTS)
         assert diagnostics.format_divergence_warning(report) == ""
-
-    def test_minority_cap_boundary(self):
-        # num_chains=8 -> cap=2. Exactly 3 flagged chains must NOT warn,
-        # even though each individually clears rate_threshold.
-        counts = jnp.array([50, 50, 50, 0, 0, 0, 0, 0])  # 3 chains at 2.5%
-        report = diagnostics.divergence_concentration_from_counts(counts, self._N_DRAWS)
-        assert int(report.num_flagged) == 3
-        assert bool(report.warn) is False
-
-    def test_minority_cap_at_small_num_chains(self):
-        # num_chains=4 -> cap=max(1, 1)=1. One flagged chain warns; two does not.
-        one_flagged = jnp.array([50, 0, 0, 0])
-        two_flagged = jnp.array([50, 50, 0, 0])
-        report_one = diagnostics.divergence_concentration_from_counts(
-            one_flagged, self._N_DRAWS
-        )
-        report_two = diagnostics.divergence_concentration_from_counts(
-            two_flagged, self._N_DRAWS
-        )
-        assert bool(report_one.warn) is True
-        assert bool(report_two.warn) is False
 
     def test_healthy_scatter_no_warning(self):
         report = diagnostics.divergence_concentration_from_counts(
             jnp.array(self._HEALTHY_COUNTS), self._N_DRAWS
         )
         assert bool(report.warn) is False
-        assert int(report.num_flagged) == 0
         assert diagnostics.format_divergence_warning(report) == ""
 
     def test_zero_divergences_no_warning(self):
@@ -685,123 +593,50 @@ class DivergenceConcentrationTest(chex.TestCase):
             jnp.zeros(8, dtype=int), self._N_DRAWS
         )
         assert bool(report.warn) is False
-        assert int(report.num_flagged) == 0
-        assert diagnostics.format_divergence_warning(report) == ""
-
-    def test_from_counts_quarters_are_nan_and_degrade_gracefully(self):
-        # The counts-only entry point has no per-draw resolution: quarter
-        # fields are NaN, and the message omits the quarter parenthetical
-        # rather than printing "nan%".
-        counts = jnp.array([1, 1, 0, 3, 0, 4, 0, 58])  # matches the single-flagged case
-        report = diagnostics.divergence_concentration_from_counts(counts, self._N_DRAWS)
-        assert bool(report.warn) is True
-        assert np.isnan(float(report.early_rate[7]))
-        assert np.isnan(float(report.late_rate[7]))
-        msg = diagnostics.format_divergence_warning(report)
-        assert "nan" not in msg.lower(), msg
-        assert "first quarter" not in msg, msg
-        assert msg.startswith("chain 7:"), msg
-
-    def test_from_is_divergent_matches_from_counts_trigger(self):
-        # Trigger-level fields (warn, flagged, rates, D) must agree between
-        # the two entry points for the same underlying counts; only the
-        # quarter fields differ (real vs NaN).
-        is_divergent = _build_is_divergent(self._STORM_SPECS, self._N_DRAWS)
-        report_flags = diagnostics.divergence_concentration(is_divergent)
-        counts = [total for total, _, _ in self._STORM_SPECS]
-        report_counts = diagnostics.divergence_concentration_from_counts(
-            jnp.array(counts), self._N_DRAWS
-        )
-        assert bool(report_flags.warn) == bool(report_counts.warn)
-        assert int(report_flags.num_flagged) == int(report_counts.num_flagged)
-        np.testing.assert_allclose(
-            np.asarray(report_flags.rates), np.asarray(report_counts.rates), rtol=1e-6
-        )
-        assert int(report_flags.total_divergences) == int(
-            report_counts.total_divergences
-        )
-
-    def test_rate_threshold_override(self):
-        # Raising the threshold above the single-flagged cell's rate silences it.
-        counts = jnp.array([1, 1, 0, 3, 0, 4, 0, 58])
-        report_default = diagnostics.divergence_concentration_from_counts(
-            counts, self._N_DRAWS
-        )
-        report_high_threshold = diagnostics.divergence_concentration_from_counts(
-            counts, self._N_DRAWS, rate_threshold=0.05
-        )
-        assert bool(report_default.warn) is True
-        assert bool(report_high_threshold.warn) is False
-
-    def test_median_other_rate_single_chain_guard(self):
-        # num_chains=1: there are no "other" chains -- must not crash, and
-        # median_other_rate must be NaN rather than raising.
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.array([5]), self._N_DRAWS
-        )
-        assert np.isnan(float(report.median_other_rate[0]))
-
-    def test_multinomial_p_value_is_context_not_trigger(self):
-        # The healthy-scatter cell can still have a small multinomial
-        # p-value (real chains are not exchangeable) yet must not warn --
-        # the per-chain rate threshold, not the p-value, decides `warn`.
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.array(self._HEALTHY_COUNTS), self._N_DRAWS
-        )
-        assert bool(report.warn) is False  # regardless of what p_value says
-        assert np.isfinite(float(report.multinomial_p_value))
-
-    def test_p_value_nan_when_no_divergences(self):
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.zeros(6, dtype=int), self._N_DRAWS
-        )
         assert np.isnan(float(report.multinomial_p_value))
 
-    def test_nan_in_is_divergent_flags_loud_not_silent(self):
-        # A stray NaN (e.g. from upstream float arithmetic) in a
-        # supposedly-boolean array must not silently vanish into a
-        # NaN rate that then compares False against rate_threshold --
-        # it must become a flagged (True) draw instead.
-        is_divergent = jnp.array([[0.0, 1.0, float("nan"), 0.0]] * 4, dtype=jnp.float32)
+    def test_from_counts_quarters_are_nan_and_degrade_gracefully(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            self._SINGLE_CHAIN_COUNTS, self._N_DRAWS
+        )
+        assert bool(report.warn) is True
+        assert np.isnan(float(report.early_rate[7]))
+        msg = diagnostics.format_divergence_warning(report)
+        assert "nan" not in msg.lower() and "first quarter" not in msg, msg
+
+    def test_nan_input_flags_loud_not_silent(self):
+        # NaN must flag, not silently pass -- in both entry points.
+        is_divergent = jnp.array([[0.0, 1.0, float("nan"), 0.0]] * 4)
         report = diagnostics.divergence_concentration(is_divergent)
-        assert not np.any(np.isnan(np.asarray(report.rates))), "NaN must not survive"
-        np.testing.assert_allclose(np.asarray(report.rates), 0.5)
+        assert not np.any(np.isnan(np.asarray(report.rates)))
         assert bool(np.all(np.asarray(report.flagged)))
 
-    def test_nan_count_sanitized_to_n_draws(self):
-        # Same fail-loud principle for the counts-only entry point: a NaN
-        # count becomes n_draws (worst case), not a silently-dropped 0.
-        report = diagnostics.divergence_concentration_from_counts(
+        counts_report = diagnostics.divergence_concentration_from_counts(
             jnp.array([1.0, 2.0, float("nan"), 0.0]), self._N_DRAWS
         )
-        assert not np.isnan(float(report.rates[2]))
-        np.testing.assert_allclose(float(report.rates[2]), 1.0)
-        assert bool(report.flagged[2])
+        assert not np.isnan(float(counts_report.rates[2]))
+        assert bool(counts_report.flagged[2])
 
-    def test_out_of_range_counts_are_clipped(self):
-        # Negative and over-n_draws counts are clamped into [0, n_draws]
-        # rather than producing a nonsensical negative or >100% rate.
-        report = diagnostics.divergence_concentration_from_counts(
-            jnp.array([-5.0, 9999.0, 0.0, 0.0]), self._N_DRAWS
+    @chex.all_variants(with_pmap=False)
+    def test_jit_compilability(self):
+        core = self.variant(
+            functools.partial(
+                diagnostics.divergence_concentration_from_counts,
+                n_draws=self._N_DRAWS,
+            )
         )
-        np.testing.assert_allclose(float(report.rates[0]), 0.0)
-        np.testing.assert_allclose(float(report.rates[1]), 1.0)
+        report = core(jnp.array([7, 6, 9, 44, 6, 9, 375, 15]))
+        assert bool(report.warn) is True
 
-    def test_warmup_dilution_hides_a_genuine_signal(self):
-        # Documents (as a regression test, not just prose) the one risk
-        # this function cannot detect in code: concatenating a clean
-        # warmup segment in front of sampling draws dilutes a real signal
-        # below threshold.
-        n = 1000
-        sampling = np.zeros((8, n), dtype=bool)
-        sampling[3, :25] = True  # 2.5% >= default threshold
-        warmup_clean = np.zeros((8, n), dtype=bool)
-        correct = diagnostics.divergence_concentration(jnp.asarray(sampling))
-        diluted = diagnostics.divergence_concentration(
-            jnp.asarray(np.concatenate([warmup_clean, sampling], axis=1))
+    def test_rate_threshold_override(self):
+        report_default = diagnostics.divergence_concentration_from_counts(
+            self._SINGLE_CHAIN_COUNTS, self._N_DRAWS
         )
-        assert bool(correct.warn) is True
-        assert bool(diluted.warn) is False
+        report_high = diagnostics.divergence_concentration_from_counts(
+            self._SINGLE_CHAIN_COUNTS, self._N_DRAWS, rate_threshold=0.05
+        )
+        assert bool(report_default.warn) is True
+        assert bool(report_high.warn) is False
 
 
 if __name__ == "__main__":

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -757,6 +757,52 @@ class DivergenceConcentrationTest(chex.TestCase):
         )
         assert np.isnan(float(report.multinomial_p_value))
 
+    def test_nan_in_is_divergent_flags_loud_not_silent(self):
+        # A stray NaN (e.g. from upstream float arithmetic) in a
+        # supposedly-boolean array must not silently vanish into a
+        # NaN rate that then compares False against rate_threshold --
+        # it must become a flagged (True) draw instead.
+        is_divergent = jnp.array([[0.0, 1.0, float("nan"), 0.0]] * 4, dtype=jnp.float32)
+        report = diagnostics.divergence_concentration(is_divergent)
+        assert not np.any(np.isnan(np.asarray(report.rates))), "NaN must not survive"
+        np.testing.assert_allclose(np.asarray(report.rates), 0.5)
+        assert bool(np.all(np.asarray(report.flagged)))
+
+    def test_nan_count_sanitized_to_n_draws(self):
+        # Same fail-loud principle for the counts-only entry point: a NaN
+        # count becomes n_draws (worst case), not a silently-dropped 0.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array([1.0, 2.0, float("nan"), 0.0]), self._N_DRAWS
+        )
+        assert not np.isnan(float(report.rates[2]))
+        np.testing.assert_allclose(float(report.rates[2]), 1.0)
+        assert bool(report.flagged[2])
+
+    def test_out_of_range_counts_are_clipped(self):
+        # Negative and over-n_draws counts are clamped into [0, n_draws]
+        # rather than producing a nonsensical negative or >100% rate.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array([-5.0, 9999.0, 0.0, 0.0]), self._N_DRAWS
+        )
+        np.testing.assert_allclose(float(report.rates[0]), 0.0)
+        np.testing.assert_allclose(float(report.rates[1]), 1.0)
+
+    def test_warmup_dilution_hides_a_genuine_signal(self):
+        # Documents (as a regression test, not just prose) the one risk
+        # this function cannot detect in code: concatenating a clean
+        # warmup segment in front of sampling draws dilutes a real signal
+        # below threshold.
+        n = 1000
+        sampling = np.zeros((8, n), dtype=bool)
+        sampling[3, :25] = True  # 2.5% >= default threshold
+        warmup_clean = np.zeros((8, n), dtype=bool)
+        correct = diagnostics.divergence_concentration(jnp.asarray(sampling))
+        diluted = diagnostics.divergence_concentration(
+            jnp.asarray(np.concatenate([warmup_clean, sampling], axis=1))
+        )
+        assert bool(correct.warn) is True
+        assert bool(diluted.warn) is False
+
 
 if __name__ == "__main__":
     absltest.main()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -511,5 +511,169 @@ class ParetoKhatTest(chex.TestCase):
         ), f"pareto_khat for Cauchy heavy tail expected >0.3 got {got_k}"
 
 
+class DivergenceConcentrationTest(chex.TestCase):
+    """Tests for the divergence-concentration warning.
+
+    Fixtures are real per-chain divergence counts (not synthetic), pulled
+    from a retrospective 120-cell validation corpus of BlackJAX/tuningfork
+    benchmark runs — the same corpus the default ``rate_threshold=0.02``
+    and ``ratio_cutoff=3.0`` were calibrated against.
+    """
+
+    # A single chain (index 6 of 8) landing on a bad post-warmup start
+    # state and diverging heavily while the rest stay clean: rate 18.75%,
+    # ratio ~6.4x the ensemble mean. The most severe cell in the
+    # validation corpus.
+    _CONCENTRATED_COUNTS = [7, 6, 9, 44, 6, 9, 375, 15]
+
+    # Every chain in the ensemble globally elevated (12.85%-26.70% each):
+    # model-geometry signature, not a single bad chain. Ratio ~1.6x.
+    _ENSEMBLE_COUNTS = [316, 261, 257, 534, 272, 384, 302, 271]
+
+    # Same single-bad-chain signature as _CONCENTRATED_COUNTS but at much
+    # smaller D: chain 7 at 2.9% (ratio ~6.9x) — right at the edge of the
+    # default 2% threshold, independently substantiated as a genuine
+    # near-storm concentration rather than noise.
+    _NEAR_STORM_COUNTS = [1, 1, 0, 3, 0, 4, 0, 58]
+
+    # Ordinary scattered divergences well below any threshold: healthy.
+    _HEALTHY_COUNTS = [2, 6, 3, 4, 7, 3, 4, 7]
+
+    _N_DRAWS = 2000
+
+    @chex.all_variants(with_pmap=False)
+    def test_concentrated_storm_warns(self):
+        core = self.variant(
+            functools.partial(
+                diagnostics.divergence_concentration_from_counts,
+                n_draws=self._N_DRAWS,
+            )
+        )
+        report = core(jnp.array(self._CONCENTRATED_COUNTS))
+        assert bool(report.warn) is True
+        assert bool(report.concentrated) is True
+        assert int(report.chain) == 6
+        assert int(report.total_divergences) == 471
+        np.testing.assert_allclose(float(report.max_rate), 375 / 2000, rtol=1e-6)
+
+    def test_concentrated_storm_message(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._CONCENTRATED_COUNTS), self._N_DRAWS
+        )
+        msg = diagnostics.format_divergence_warning(report)
+        assert msg.startswith("chain 6:"), msg
+        assert "post-warmup start" in msg
+        assert "%" in msg and "x the ensemble mean" in msg
+
+    def test_ensemble_elevated_warns(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
+        )
+        assert bool(report.warn) is True
+        assert bool(report.concentrated) is False
+        assert int(report.num_chains_elevated) == 8
+
+    def test_ensemble_elevated_message(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
+        )
+        msg = diagnostics.format_divergence_warning(report)
+        assert "elevated divergence rate across 8 of 8 chains" in msg
+        assert "geometry" in msg
+        assert "chain 3:" not in msg  # not the single-chain phrasing
+
+    def test_near_storm_warns_concentrated_at_default_threshold(self):
+        # rate = 58/2000 = 2.9% >= default 2% threshold -> warns.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._NEAR_STORM_COUNTS), self._N_DRAWS
+        )
+        assert bool(report.warn) is True
+        assert bool(report.concentrated) is True
+        assert int(report.chain) == 7
+        np.testing.assert_allclose(float(report.max_rate), 58 / 2000, rtol=1e-6)
+        assert float(report.ratio) > 3.0
+
+    def test_healthy_scatter_no_warning(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._HEALTHY_COUNTS), self._N_DRAWS
+        )
+        assert bool(report.warn) is False
+        assert diagnostics.format_divergence_warning(report) == ""
+
+    def test_zero_divergences_no_warning(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.zeros(8, dtype=int), self._N_DRAWS
+        )
+        assert bool(report.warn) is False
+        assert diagnostics.format_divergence_warning(report) == ""
+
+    def test_ratio_guard_at_zero_mean(self):
+        # D=0 -> mean_count=0; ratio must not be nan/inf, and no warning.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.zeros(4, dtype=int), self._N_DRAWS
+        )
+        ratio = float(report.ratio)
+        assert np.isfinite(ratio), f"ratio must be finite at mean=0, got {ratio}"
+        assert ratio == 0.0
+        assert bool(report.warn) is False
+
+    def test_from_is_divergent_matches_from_counts(self):
+        # Build a (chains, draws) boolean array with the same per-chain
+        # counts as the concentrated fixture and check both entry points agree.
+        counts = self._CONCENTRATED_COUNTS
+        is_divergent = jnp.zeros((len(counts), self._N_DRAWS), dtype=bool)
+        for k, c in enumerate(counts):
+            is_divergent = is_divergent.at[k, :c].set(True)
+        report_flags = diagnostics.divergence_concentration(is_divergent)
+        report_counts = diagnostics.divergence_concentration_from_counts(
+            jnp.array(counts), self._N_DRAWS
+        )
+        assert bool(report_flags.warn) == bool(report_counts.warn)
+        assert bool(report_flags.concentrated) == bool(report_counts.concentrated)
+        assert int(report_flags.chain) == int(report_counts.chain)
+        np.testing.assert_allclose(
+            float(report_flags.max_rate), float(report_counts.max_rate), rtol=1e-6
+        )
+
+    def test_rate_threshold_override(self):
+        # Raising the threshold above the near-storm cell's rate silences it.
+        report_default = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._NEAR_STORM_COUNTS), self._N_DRAWS
+        )
+        report_high_threshold = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._NEAR_STORM_COUNTS), self._N_DRAWS, rate_threshold=0.05
+        )
+        assert bool(report_default.warn) is True
+        assert bool(report_high_threshold.warn) is False
+
+    def test_ratio_cutoff_override(self):
+        # Lowering ratio_cutoff below the ensemble cell's ratio (~1.64x)
+        # reclassifies it from ensemble-wide to concentrated.
+        report_default = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS
+        )
+        report_low_cutoff = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._ENSEMBLE_COUNTS), self._N_DRAWS, ratio_cutoff=1.5
+        )
+        assert bool(report_default.concentrated) is False
+        assert bool(report_low_cutoff.concentrated) is True
+
+    def test_multinomial_p_value_is_context_not_trigger(self):
+        # The healthy-scatter cell can still have a tiny multinomial
+        # p-value (real chains are not exchangeable) yet must not warn --
+        # the rate threshold, not the p-value, decides `warn`.
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.array(self._HEALTHY_COUNTS), self._N_DRAWS
+        )
+        assert bool(report.warn) is False  # regardless of what p_value says
+        assert np.isfinite(float(report.multinomial_p_value))
+
+    def test_p_value_nan_when_no_divergences(self):
+        report = diagnostics.divergence_concentration_from_counts(
+            jnp.zeros(6, dtype=int), self._N_DRAWS
+        )
+        assert np.isnan(float(report.multinomial_p_value))
+
+
 if __name__ == "__main__":
     absltest.main()


### PR DESCRIPTION
## Summary
- New pure-observation diagnostic in `blackjax/diagnostics.py`: `divergence_concentration()` (per-draw flags) / `divergence_concentration_from_counts()` (totals) + `format_divergence_warning()`.
- Flags a run where a **minority** of chains (1 up to `max(1, num_chains // 4)`) cross a per-chain sampling-phase divergence-rate threshold (default 2%) while the rest stay clean. Deliberately does **not** warn when most/all chains cross together — that pattern is already visible in the aggregate count.
- Per flagged chain, factual non-causal context: overall rate, first/last-quarter rates, median rate of the other chains. No remedy or cause asserted in the message.
- Supersedes #1015 (closed unmerged): the earlier design attempted automatic warmup intervention; adversarial review surfaced correctness defects (translation-invariance failure, inverted redraw metric, unverified causal claim) and a placebo-controlled test found the intervention machinery indistinguishable from plain settling steps. The shipped decision: warn and describe, never intervene.

## Spec
- Trigger: `r_k = d_k / n_draws >= 0.02` marks chain k flagged; `warn` iff `1 <= num_flagged <= max(1, num_chains // 4)`.
- Per flagged chain: `rate`, `early_rate`/`late_rate` (first/last quarter, sampling phase only), `median_other_rate`.
- A Bonferroni-corrected exchangeable-null multinomial tail is returned as **context only** — real multi-chain runs are not exchangeable in divergence propensity (validated: 13% healthy-cell false-positive rate at nominal alpha), so it never decides `warn`.
- `D=0` never warns; numeric core JIT-compilable; corrupted input fails loud (NaN flags become True; counts sanitized to worst-case visible, never silent zeros).

## Evidence basis
Retrospective validation over 120 cells of real per-chain divergence records: at the 2% default, 7 of 8 flagged non-degenerate cells were independently substantiated pathologies; the most severe cell (18.75% worst-chain rate) flags with ~9x margin. The validation corpus's own most severe cell contains a real minority-of-two (a dominant recovering chain: 72.2% first-quarter/0.2% last; plus a marginal one), and a separate single-flagged case shows the opposite, degrading profile (0% early/11.4% late) — the message reports both shapes as numbers and interprets neither.

## Message
> chain {k}: {X}% of its sampling draws diverged ({early}% in the first quarter, {late}% in the last) — significantly more than the other chains ({median}% median); draws from this chain, especially early ones, may be untrustworthy.

## Placement & non-goal
Standalone, kernel-agnostic, same shape as `rhat`/`effective_sample_size`; designed to be called from a post-sampling routing/verdict layer. `window_adaptation` and `staged_adaptation` are unaffected. Pure observation: no automatic extension, redraw, backoff, or exclusion — remedies are the caller's.

## Testing
9 lean tests (post review-trim), fixtures reconstructed from real corpus data (not synthetic); red-checked (including the single-chain guard, verified to catch a real crash when the guard is removed). Docstrings trimmed to house style per review — the evidence narrative lives in this PR body and the project record, not the source. Full suite: **1806 passed, 11 skipped, 0 failed** (pre-trim; trim was subtractive/doc-only + one guarded micro-test, targeted file 185/10 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

