### PR TITLE
Return zero ESS for numerically degenerate chains

### DIFF
--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -172,6 +172,8 @@ def effective_sample_size(
     Returns
     -------
     NDArray of the resulting statistics (ess), with the chain and sample dimensions squeezed.
+    Variables whose within-chain variance is numerically zero have an effective
+    sample size of zero.
 
     Notes
     -----
@@ -198,6 +200,13 @@ def effective_sample_size(
         num_samples > 1
     ), f"The input array must have at least 2 samples, got only {num_samples}."
 
+    first_sample = jnp.take(input_array, jnp.array([0]), axis=sample_axis)
+    has_within_chain_variation = jnp.any(
+        input_array != first_sample,
+        axis=(chain_axis, sample_axis),
+        keepdims=True,
+    )
+
     mean_across_chain = input_array.mean(axis=sample_axis, keepdims=True)
     # Compute autocovariance estimates for every lag for the input array using FFT.
     centered_array = input_array - mean_across_chain
@@ -214,6 +223,9 @@ def effective_sample_size(
         * num_samples
         / (num_samples - 1.0)
     )
+    is_numerically_degenerate = jnp.isfinite(mean_var0) & (
+        ~has_within_chain_variation | (mean_var0 <= 0.0)
+    )
     weighted_var = mean_var0 * (num_samples - 1.0) / num_samples
     weighted_var = jax.lax.cond(
         num_chains > 1,
@@ -221,6 +233,9 @@ def effective_sample_size(
         + mean_across_chain.var(axis=chain_axis, ddof=1, keepdims=True),
         lambda _: weighted_var,
         operand=mean_across_chain,
+    )
+    weighted_var = jnp.where(
+        is_numerically_degenerate, jnp.ones_like(weighted_var), weighted_var
     )
 
     # Geyer's initial positive sequence
@@ -284,8 +299,9 @@ def effective_sample_size(
 
     tau_hat = jnp.maximum(tau_hat, 1 / np.log10(ess_raw))
     ess = ess_raw / tau_hat
+    ess = jnp.where(is_numerically_degenerate.squeeze(), 0.0, ess.squeeze())
 
-    return ess.squeeze()
+    return ess
 
 
 def splitR(position, num_chains, superchain_size, func_for_splitR=jnp.square):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -86,6 +86,43 @@ class DiagnosticsTest(chex.TestCase):
         np.testing.assert_array_equal(ess_val.shape, event_shape)
         np.testing.assert_allclose(ess_val, num_chains * self.num_samples, rtol=10)
 
+    @chex.all_variants(with_pmap=False)
+    @parameterized.parameters(1, 2)
+    def test_ess_returns_zero_for_numerically_degenerate_chains(self, num_chains):
+        num_samples = 2000
+        samples_shape = (num_chains, num_samples)
+        random_samples = jax.random.normal(
+            jax.random.key(self.test_seed), shape=samples_shape
+        )
+        constant_samples = jnp.zeros(samples_shape)
+        constant_with_different_chain_means = jnp.broadcast_to(
+            jnp.arange(num_chains)[:, None], samples_shape
+        )
+        near_constant_samples = 1e-30 * random_samples
+        samples = jnp.stack(
+            [
+                constant_samples,
+                constant_with_different_chain_means,
+                near_constant_samples,
+                random_samples,
+            ],
+            axis=-1,
+        )
+
+        effective_sample_size = self.variant(diagnostics.effective_sample_size)
+        ess = effective_sample_size(samples)
+
+        np.testing.assert_array_equal(ess[:3], jnp.zeros(3))
+        assert ess[3] > 0
+
+    def test_ess_can_exceed_draw_count_for_antithetic_chain(self):
+        num_samples = 2000
+        samples = jnp.tile(jnp.array([-1.0, 1.0]), num_samples // 2)[None, :]
+
+        ess = diagnostics.effective_sample_size(samples)
+
+        assert ess > num_samples
+
 
 # ---------------------------------------------------------------------------
 # Tests for ess_bulk, ess_tail, and pareto_khat


### PR DESCRIPTION
## Description

`effective_sample_size` currently lets zero within-chain variance reach the autocorrelation ratio. The resulting zero denominator is then hidden by the lower bound on `tau_hat`, causing frozen chains to report very large ESS values.

This change returns zero ESS per finite, numerically degenerate variable while preserving valid estimates for nondegenerate variables in the same array. It covers exact constants, chains constant at different means, and float32 variance underflow. It does not cap ESS globally because antithetic chains can legitimately exceed the nominal draw count.

## Related issues / discussions

Closes #1019

## Validation

- `JAX_PLATFORM_NAME=cpu uv run --extra progress pytest -n 4 -q --benchmark-disable tests/` — 1,805 passed, 11 skipped, 36 subtests passed
- `JAX_PLATFORM_NAME=cpu uv run pre-commit run --all-files` — passed

## Checklist

**General**
- [x] The branch is based on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes
- [x] Tests cover the changes

**Code quality**
- [x] Public functions have NumPy-style docstrings
- [x] Naming follows existing conventions
- [x] All new code is JIT-compatible
