### PR TITLE
Remove leaked internal worklog IDs from public docstrings

### DIFF
--- a/blackjax/mcmc/composed/_seam.py
+++ b/blackjax/mcmc/composed/_seam.py
@@ -259,9 +259,9 @@ def build_kernel(divergence_threshold: float = 1000) -> Callable:
     this seam could bring it down to two, at the cost of a more complex seam
     contract. ``gist_trajectory_length`` takes exactly this route for its
     own accepted-move build: it caches the forward rollout's leapfrog states
-    in a buffer (see its module docstring, "Forward-rollout caching",
-    Issue#1058) so the proposal for the selected ``alpha`` is a gather, not
-    a re-integration, dropping it to two per kernel call -- the forward
+    in a buffer (see its module docstring, "Forward-rollout caching") so the
+    proposal for the selected ``alpha`` is a gather, not a re-integration,
+    dropping it to two per kernel call -- the forward
     search plus the still-necessary reverse-direction re-check (there is
     nothing to gather for the reverse rollout; only its count is used). See
     ``gist_step_size``'s own ``chex.assert_max_traces(n=4)`` test (1 at

--- a/blackjax/mcmc/composed/trajectory_length.py
+++ b/blackjax/mcmc/composed/trajectory_length.py
@@ -38,7 +38,7 @@ to :func:`_apply_fn` as GIST's ``aux``, so building the proposal is an
 ``O(1)`` gather rather than an ``O(L)`` re-integration. Per transition this
 drops the cost from roughly ``U + L + U_rev`` leapfrog/gradient evaluations
 (``~2.75 U`` empirically, averaging over ``L``'s distribution) to roughly
-``U + U_rev`` (``~1.25 U``) -- see Issue#1058. The reverse rollout
+``U + U_rev`` (``~1.25 U``). The reverse rollout
 ``U_rev(theta', rho')`` (section 2.2.4) has nothing to gather from (its own
 states are never selected as the proposal) and is left as an ordinary,
 unbuffered :func:`num_steps_to_uturn` call.
@@ -207,7 +207,7 @@ def num_steps_to_uturn(
 
 class _ForwardRollout(NamedTuple):
     """Cached forward rollout, threaded from :func:`_tuning_parameter_fn` to
-    :func:`_apply_fn` as GIST's ``aux`` (Issue#1058).
+    :func:`_apply_fn` as GIST's ``aux``.
 
     num_steps_to_uturn
         ``U(theta, rho)`` -- the same value :func:`num_steps_to_uturn` would
@@ -235,8 +235,8 @@ def _num_steps_to_uturn_with_rollout(
     max_num_steps: int,
 ) -> Callable:
     """Forward-only variant of :func:`num_steps_to_uturn` that additionally
-    buffers every rolled-out state (Issue#1058), so :func:`_apply_fn` can
-    gather the selected-``L`` proposal instead of re-integrating it.
+    buffers every rolled-out state, so :func:`_apply_fn` can gather the
+    selected-``L`` proposal instead of re-integrating it.
 
     Only used for the forward rollout, in :func:`_tuning_parameter_fn`: the
     reverse rollout in :func:`_apply_fn` has no selected state to gather
@@ -326,7 +326,7 @@ def _apply_fn(
         rollout: _ForwardRollout = aux
         forward = rollout.num_steps_to_uturn
 
-        # GATHER, not a re-integration (Issue#1058): `num_steps` (`alpha`) is
+        # GATHER, not a re-integration: `num_steps` (`alpha`) is
         # always <= `forward` by construction of `_tuning_parameter_fn`'s
         # draw, so `rollout.states[num_steps - 1]` was written by the
         # forward rollout above and is bit-identical to what


### PR DESCRIPTION
## Summary

Removed internal trackinizer worklog IDs that accidentally shipped into public BlackJAX docstrings. The ID `Issue#1058` appears 5 times across 2 files and reads as a GitHub issue number to external readers, creating unresolvable and misleading cross-references.

## Changes

- **trajectory_length.py** (lines 41, 210, 238, 329): Removed `Issue#1058` references from docstrings and code comments. The surrounding prose already explains the forward-rollout caching concept and its performance implications (~2.75U → ~1.25U cost reduction).
- **_seam.py** (line 263): Removed `Issue#1058` reference from the module docstring's discussion of caching trade-offs.

Confirmed with `grep -r '(Issue|Belief|Experiment|CodeChange)#[0-9]+'` that zero remaining internal IDs exist in the blackjax/ package.

## Validation

- Pre-commit: PASS
- Tests: All 42 tests pass (test_gist_trajectory_length.py + test_gist_step_size.py)