### PR TITLE
Guard jaxtap optional dependency with pytest.importorskip

### DIFF
--- a/tests/test_progress_bar.py
+++ b/tests/test_progress_bar.py
@@ -22,7 +22,11 @@ import chex
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from absl.testing import absltest
+
+pytest.importorskip("jaxtap")
+pytest.importorskip("tqdm")
 
 import blackjax
 from blackjax.progress_bar import ProgressState


### PR DESCRIPTION
## Summary

Fixed recurring collection failures in `tests/test_progress_bar.py` by guarding the optional `jaxtap` dependency with `pytest.importorskip()`. On fresh worktrees without jaxtap installed, the file now skips cleanly instead of erroring, allowing the full test suite to run. This issue has occurred 3 times in 24 hours, blocking multiple agents.

## Changes

- Added `pytest.importorskip("jaxtap")` at module level before the `blackjax.progress_bar` and `blackjax.progress_reader` imports
- jaxtap remains optional by design (only imported lazily inside progress_bar's context manager)
- Tests skip cleanly when jaxtap is unavailable; run and pass when it is available

## Validation

- **Without jaxtap:** Collection succeeds, file skips cleanly (1 skipped)
- **With jaxtap:** All tests run and pass (22 passed)
- Pre-commit: PASS