### PR TITLE
Test against actual JAX nightly builds

### DIFF
--- a/.github/workflows/test_jax_nightly.yml
+++ b/.github/workflows/test_jax_nightly.yml
@@ -19,7 +19,18 @@ jobs:
       run: uv sync --group dev --extra progress
     - name: Install JAX nightly
       run: |
-        uv pip install --prerelease=allow --force-reinstall jax jaxlib \
-          -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
+        uv pip install --prerelease=allow --upgrade --force-reinstall jax jaxlib \
+          --index https://us-python.pkg.dev/ml-oss-artifacts-published/jax-public-nightly-artifacts-registry/simple/
+    - name: Verify JAX nightly versions
+      run: |
+        uv run --no-sync python - <<'PY'
+        import jax
+        import jaxlib
+
+        versions = {"jax": jax.__version__, "jaxlib": jaxlib.__version__}
+        print(" ".join(f"{package}={version}" for package, version in versions.items()))
+        if not all(".dev" in version for version in versions.values()):
+            raise RuntimeError(f"Expected nightly JAX builds, got {versions}")
+        PY
     - name: Run tests
-      run: uv run pytest -n 2 -vv --benchmark-disable tests
+      run: uv run --no-sync pytest -n 2 -vv --benchmark-disable tests


### PR DESCRIPTION
## Summary

- Install `jax` and `jaxlib` from JAX's nightly-only Artifact Registry instead of the retired GCS find-links page.
- Use `uv run --no-sync` so the test command cannot restore the lockfile's release versions.
- Fail fast unless both installed packages report development versions.

## Why

The legacy package page now resolves release builds, and the subsequent `uv run` re-synchronized the environment to the lockfile before pytest. The scheduled job therefore passed or failed without exercising JAX HEAD.

## Validation

- The exact install command resolved `jax==jaxlib==0.11.2.dev20260823` in an isolated Python 3.12 environment.
- The extracted workflow verification step passed for that nightly pair and rejected the lockfile's `0.10.0` release pair.
- The workflow parsed successfully as YAML, and the changed-file pre-commit hooks passed.
- All repository pre-commit hooks passed; the pinned Black hook was applied serially to all 198 tracked Python files because its multi-file process pool stalls in the local sandbox.

The full pytest suite was not run locally because this change is confined to GitHub Actions configuration.
