### PR TITLE
Expose update_strategy on the NS kernel

### DIFF
--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -169,6 +169,7 @@ def build_kernel(
     update_inner_kernel_params_fn: Callable,
     num_delete: int = 1,
     delete_fn: Callable = default_delete_fn,
+    update_strategy: Callable = update_with_mcmc_take_last,
 ) -> Callable:
     """Build a Nested Sampling kernel from a constrained inner step.
 
@@ -191,14 +192,15 @@ def build_kernel(
         Number of particles replaced per NS iteration.
     delete_fn
         Selects which particles to delete (default: the lowest-likelihood ones).
+    update_strategy
+        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
+        num_delete) -> update_fn`` (default: :func:`update_with_mcmc_take_last`)
 
     Returns
     -------
     A Nested Sampling kernel ``kernel(rng_key, state) -> (new_state, info)``.
     """
-    inner_kernel = update_with_mcmc_take_last(
-        constrained_step_fn, num_inner_steps, num_delete
-    )
+    inner_kernel = update_strategy(constrained_step_fn, num_inner_steps, num_delete)
     delete_fn = partial(delete_fn, num_delete=num_delete)
     return build_adaptive_kernel(
         delete_fn,

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -194,7 +194,22 @@ def build_kernel(
         Selects which particles to delete (default: the lowest-likelihood ones).
     update_strategy
         Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
-        num_delete) -> update_fn`` (default: :func:`update_with_mcmc_take_last`)
+        num_delete) -> update_fn`` (default:
+        :func:`update_with_mcmc_take_last`). The returned ``update_fn`` is
+        called once per NS iteration as::
+
+            update_fn(rng_key, state, loglikelihood_0, **step_parameters)
+                -> (new_particles, update_info)
+
+        where ``loglikelihood_0`` is the likelihood contour being replaced and
+        ``step_parameters`` is the current ``state.inner_kernel_params``. It
+        must return exactly ``num_delete`` particle states whose pytree
+        structure and dtypes match ``state.particles``, since they are written
+        back by index, and each must satisfy ``loglikelihood >
+        loglikelihood_0`` with ``loglikelihood_birth`` set to
+        ``loglikelihood_0``. Driving the particles with ``constrained_step_fn``
+        gives the last two properties for free. ``update_info`` is passed
+        through to ``NSInfo.update_info`` unchanged and may be any pytree.
 
     Returns
     -------

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -357,9 +357,9 @@ def build_kernel(
         :func:`live_covariance` with a custom proposal, preserving the existing
         covariance-based extension seam.
     update_strategy
-        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
-        num_delete) -> update_fn``
-        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
+        Inner-kernel factory
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`).
+        See :func:`~blackjax.ns.from_mcmc.build_kernel` for the contract.
 
     Returns
     -------
@@ -482,9 +482,9 @@ def build_swig_kernel(
         ``(rng_key, state, info, params) -> params`` (:func:`live_widths` by
         default, the per-axis live-point spread).
     update_strategy
-        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
-        num_delete) -> update_fn``
-        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
+        Inner-kernel factory
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`).
+        See :func:`~blackjax.ns.from_mcmc.build_kernel` for the contract.
 
     Returns
     -------
@@ -557,9 +557,9 @@ def as_top_level_api(
         :func:`live_covariance` with a custom proposal. Used both to seed
         ``init`` and to update each step.
     update_strategy
-        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
-        num_delete) -> update_fn``
-        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
+        Inner-kernel factory
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`).
+        See :func:`~blackjax.ns.from_mcmc.build_kernel` for the contract.
 
     Returns
     -------
@@ -661,9 +661,9 @@ def swig_as_top_level_api(
         ``(rng_key, state, info, params) -> params`` (:func:`live_widths` by
         default). Used both to seed ``init`` and to update each step.
     update_strategy
-        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
-        num_delete) -> update_fn``
-        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
+        Inner-kernel factory
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`).
+        See :func:`~blackjax.ns.from_mcmc.build_kernel` for the contract.
 
     Returns
     -------

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -33,6 +33,7 @@ from blackjax.mcmc.slice import random_order, stepping_out
 from blackjax.ns.adaptive import init
 from blackjax.ns.base import NSInfo, NSState, init_state_strategy
 from blackjax.ns.from_mcmc import build_kernel as build_from_mcmc_kernel
+from blackjax.ns.from_mcmc import update_with_mcmc_take_last
 from blackjax.smc.tuning.from_particles import (
     particles_covariance_matrix,
     particles_stds,
@@ -326,6 +327,7 @@ def build_kernel(
     max_shrinkage: int = 100,
     proposal: Callable = covariance_proposal,
     inner_kernel_params: Callable | None = None,
+    update_strategy: Callable = update_with_mcmc_take_last,
 ) -> Callable:
     """Build the Nested Slice Sampling kernel.
 
@@ -354,6 +356,10 @@ def build_kernel(
         :func:`live_covariance_factor` with the default proposal and
         :func:`live_covariance` with a custom proposal, preserving the existing
         covariance-based extension seam.
+    update_strategy
+        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
+        num_delete) -> update_fn``
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
 
     Returns
     -------
@@ -371,6 +377,7 @@ def build_kernel(
         num_inner_steps,
         inner_kernel_params,
         num_delete,
+        update_strategy=update_strategy,
     )
 
 
@@ -435,6 +442,7 @@ def build_swig_kernel(
     proposal: Callable = coordinate_proposal,
     coordinate_order: Callable = random_order,
     inner_kernel_params: Callable = live_widths,
+    update_strategy: Callable = update_with_mcmc_take_last,
 ) -> Callable:
     """Build the Nested Slice-within-Gibbs (SwiG) kernel.
 
@@ -473,6 +481,10 @@ def build_swig_kernel(
         Computes the inner-kernel parameters from the live points each step,
         ``(rng_key, state, info, params) -> params`` (:func:`live_widths` by
         default, the per-axis live-point spread).
+    update_strategy
+        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
+        num_delete) -> update_fn``
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
 
     Returns
     -------
@@ -494,6 +506,7 @@ def build_swig_kernel(
         num_inner_steps,
         inner_kernel_params,
         num_delete,
+        update_strategy=update_strategy,
     )
 
 
@@ -506,6 +519,7 @@ def as_top_level_api(
     max_shrinkage: int = 100,
     proposal: Callable = covariance_proposal,
     inner_kernel_params: Callable | None = None,
+    update_strategy: Callable = update_with_mcmc_take_last,
 ) -> SamplingAlgorithm:
     """Creates a Nested Slice Sampling (NSS) algorithm, ``blackjax.nss``.
 
@@ -542,6 +556,10 @@ def as_top_level_api(
         :func:`live_covariance_factor` with the default proposal and
         :func:`live_covariance` with a custom proposal. Used both to seed
         ``init`` and to update each step.
+    update_strategy
+        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
+        num_delete) -> update_fn``
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
 
     Returns
     -------
@@ -576,6 +594,7 @@ def as_top_level_api(
         max_shrinkage=max_shrinkage,
         proposal=proposal,
         inner_kernel_params=inner_kernel_params,
+        update_strategy=update_strategy,
     )
 
     def init_fn(position, rng_key=None):
@@ -602,6 +621,7 @@ def swig_as_top_level_api(
     proposal: Callable = coordinate_proposal,
     coordinate_order: Callable = random_order,
     inner_kernel_params: Callable = live_widths,
+    update_strategy: Callable = update_with_mcmc_take_last,
 ) -> SamplingAlgorithm:
     """Creates a Nested Slice-within-Gibbs (SwiG) sampling algorithm, ``blackjax.nsswig``.
 
@@ -640,6 +660,10 @@ def swig_as_top_level_api(
         Computes the inner-kernel parameters from the live points,
         ``(rng_key, state, info, params) -> params`` (:func:`live_widths` by
         default). Used both to seed ``init`` and to update each step.
+    update_strategy
+        Inner-kernel factory ``(constrained_step_fn, num_inner_steps,
+        num_delete) -> update_fn``
+        (default: :func:`~blackjax.ns.from_mcmc.update_with_mcmc_take_last`)
 
     Returns
     -------
@@ -673,6 +697,7 @@ def swig_as_top_level_api(
         proposal=proposal,
         coordinate_order=coordinate_order,
         inner_kernel_params=inner_kernel_params,
+        update_strategy=update_strategy,
     )
 
     def init_fn(position, rng_key=None):

--- a/tests/ns/test_nested_sampling.py
+++ b/tests/ns/test_nested_sampling.py
@@ -396,14 +396,29 @@ class NestedSliceSamplingTest(chex.TestCase):
     @parameterized.parameters(nss.as_top_level_api, nss.swig_as_top_level_api)
     def test_update_strategy_seam(self, api):
         """update_strategy reaches the engine on both top-level APIs, built once
-        with the caller's num_inner_steps / num_delete."""
+        with the caller's num_inner_steps / num_delete, and the updater it
+        returns is the one the kernel actually runs."""
         calls = []
+        sentinel = 1234.0
 
         def recording_strategy(step_fn, num_inner_steps, num_delete):
             calls.append((num_inner_steps, num_delete))
-            return from_mcmc.update_with_mcmc_take_last(
+            inner_update_fn = from_mcmc.update_with_mcmc_take_last(
                 step_fn, num_inner_steps, num_delete
             )
+
+            def update_fn(rng_key, state, loglikelihood_0, **step_parameters):
+                particles, update_info = inner_update_fn(
+                    rng_key, state, loglikelihood_0, **step_parameters
+                )
+                # tagging the info distinguishes "this updater ran" from
+                # "the factory was called and its result discarded"
+                return particles, {
+                    "sentinel": jnp.full((num_delete,), sentinel),
+                    "inner": update_info,
+                }
+
+            return update_fn
 
         algo = api(
             gaussian_logprior,
@@ -415,8 +430,12 @@ class NestedSliceSamplingTest(chex.TestCase):
         # the strategy is a build-time seam: consulted once, with what we passed
         self.assertEqual(calls, [(4, 2)])
         state = algo.init(jnp.zeros((20, 2)))
-        new_state, _ = jax.jit(algo.step)(self.key, state)
+        new_state, info = jax.jit(algo.step)(self.key, state)
         chex.assert_shape(new_state.particles.position, (20, 2))
+        # the returned updater is installed, not merely constructed
+        chex.assert_trees_all_close(
+            info.update_info["sentinel"], jnp.full((2,), sentinel)
+        )
 
 
 class NestedSamplingStatisticalTest(chex.TestCase):

--- a/tests/ns/test_nested_sampling.py
+++ b/tests/ns/test_nested_sampling.py
@@ -393,6 +393,31 @@ class NestedSliceSamplingTest(chex.TestCase):
         new_state, _ = jax.jit(algo.step)(self.key, state)
         chex.assert_shape(new_state.particles.position, (20, 2))
 
+    @parameterized.parameters(nss.as_top_level_api, nss.swig_as_top_level_api)
+    def test_update_strategy_seam(self, api):
+        """update_strategy reaches the engine on both top-level APIs, built once
+        with the caller's num_inner_steps / num_delete."""
+        calls = []
+
+        def recording_strategy(step_fn, num_inner_steps, num_delete):
+            calls.append((num_inner_steps, num_delete))
+            return from_mcmc.update_with_mcmc_take_last(
+                step_fn, num_inner_steps, num_delete
+            )
+
+        algo = api(
+            gaussian_logprior,
+            gaussian_loglikelihood,
+            num_inner_steps=4,
+            num_delete=2,
+            update_strategy=recording_strategy,
+        )
+        # the strategy is a build-time seam: consulted once, with what we passed
+        self.assertEqual(calls, [(4, 2)])
+        state = algo.init(jnp.zeros((20, 2)))
+        new_state, _ = jax.jit(algo.step)(self.key, state)
+        chex.assert_shape(new_state.particles.position, (20, 2))
+
 
 class NestedSamplingStatisticalTest(chex.TestCase):
     """Statistical correctness tests for nested sampling algorithms."""


### PR DESCRIPTION
## Description

`ns/from_mcmc.build_kernel` hardwires `update_with_mcmc_take_last` as the way replacement particles are seeded. This makes it a keyword argument with that function as the default, and threads it through the four `nss` entry points. Nothing changes unless you pass something.

This isn't new; it existed in the handley-lab NS fork, and was lost when nested sampling came upstream in #947. Nothing is impossible without it, and I'm managing to extend stock blackjax≥1.6 today with a multimodal update. However, in its current form, I have to rebuild `blackjax.nss` out of parts, using eight imports which are all internal, and re-declare `num_delete`, `max_steps` and `max_shrinkage` now that `**kwargs` is gone.

The strategy we want draws each replacement from a cluster in proportion to its prior volume, rather than uniformly from the survivors, similar to how PolyChordLite works. This is what keeps separated modes alive when one of them is losing points. It is a decision about seeding rather than about the inner kernel, which is why `proposal` is not the right place for it. None of the clustering code is in this PR; this is just an example I think is important which is much easier with this change.

Cluster bookkeeping which has to persist between steps already has a route. `adaptive.build_kernel` applies the inner kernel as `partial(inner_kernel, **state.inner_kernel_params)`, so whatever the `inner_kernel_params` seam returns reaches the strategy as `step_parameters`.

There is precedent in `smc.from_mcmc.build_kernel`, which already takes an `update_strategy`, and is how `waste_free_smc` plugs in. The contracts are not identical, since SMC consults its strategy every step while NS only does so at construction.

I've already run these changes past @yallup (from #946 and #947) who was happy with my suggestions.

`test_update_strategy_seam` runs against both top-level APIs, and asserts the strategy is consulted exactly once with the caller's `(num_inner_steps, num_delete)`, and that a full step still runs. That first assertion is the important one, since a regression which dropped the keyword would fall back to the default and still pass everything else in the suite. I broke the seam deliberately to check the test notices. `tests/ns/` passes, 28 tests.

Just one question: a parameter threaded through `build_kernel`, `build_swig_kernel` and the two top-level APIs ends up documented four times, and the existing ones are not consistent about how. `coordinate_order` is terse everywhere, `proposal` cross-references its non-SwiG counterpart, and `inner_kernel_params` is written out in full each time. I have given `update_strategy` identical wording at every site, but is there a house rule?

## Related issues / discussions

Related to #947 (which superseded #911 and rebuilt on the slice primitives from #946).

## Checklist

**General**
- [x] The branch is rebased on the latest `main`
- [x] Commit messages are clear and descriptive
- [x] `pre-commit run --all-files` passes (black, isort, flake8, mypy)
- [x] Tests cover the changes (`mamba run -n blackjax python -m pytest tests/`)

**Code quality**
- [x] Public functions have docstrings following the [NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Naming follows existing conventions (`logdensity`, `jax.tree.map`, `jax.random.key()`, `jnp.clip(min=, max=)`)
- [x] All new code is JIT-compatible
