### PR TITLE
Fix JIT compatibility of ChEES mass-matrix adaptation

### DIFF
--- a/blackjax/adaptation/chees_adaptation.py
+++ b/blackjax/adaptation/chees_adaptation.py
@@ -195,7 +195,7 @@ def _apply_length_floor(
     engaged: Array,
     enable: bool,
     max_leapfrog_steps: int = 1000,
-    step_size: float = 0.1,
+    step_size: float | Array = 0.1,
 ) -> tuple[Array, Array]:
     """Floor ``trajectory_length`` at
     ``CHEES_LENGTH_FLOOR_FACTOR * sqrt(lambda_max)`` -- the slow-direction
@@ -986,7 +986,7 @@ def chees_adaptation(
                 final_engaged,
                 _length_floor,
                 max_leapfrog_steps,
-                float(step_size_ma),
+                step_size_ma,
             )
             num_leapfrog_steps = consumed_trajectory_length_ma / step_size_ma
         else:

--- a/tests/adaptation/test_adaptation.py
+++ b/tests/adaptation/test_adaptation.py
@@ -212,6 +212,32 @@ def test_chees_mass_matrix_estimation_none_matches_omitted_bit_for_bit():
     assert params_none["step_size"] == params_none_no_floor["step_size"]
 
 
+def test_chees_mass_matrix_estimation_runs_under_jit():
+    """The diagonal mass-matrix path must keep its adapted step size traced."""
+    num_chains, num_dim = 8, 3
+    warmup = blackjax.chees_adaptation(
+        _chees_gaussian_logdensity(jnp.ones(num_dim)),
+        num_chains=num_chains,
+        mass_matrix_estimation="diagonal",
+    )
+    positions = jnp.zeros((num_chains, num_dim))
+    optim = optax.adam(0.1)
+
+    @jax.jit
+    def run(rng_key, initial_positions):
+        (state, _), _ = warmup.run(
+            rng_key,
+            initial_positions,
+            step_size=0.1,
+            optim=optim,
+            num_steps=40,
+        )
+        return state.position
+
+    final_positions = run(jax.random.key(0), positions)
+    assert jnp.all(jnp.isfinite(final_positions))
+
+
 def test_chees_mass_matrix_estimation_invalid_value_raises():
     with pytest.raises(ValueError, match="mass_matrix_estimation"):
         blackjax.chees_adaptation(


### PR DESCRIPTION
Fixes #1029.\n\nPass the adapted step size through the trajectory-length floor as a JAX value, avoiding Python scalar conversion while warmup is traced.\n\nAdds a regression test covering a jitted ChEES warmup with diagonal mass-matrix estimation.