### PR TITLE
Average tied ranks in the rank-normalized diagnostics

### DIFF
--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -653,11 +653,9 @@ def mclmc_lrd_warmup(
             "mclmc_lrd_warmup: pilot diagnostics are invalid — the effective "
             f"sample size of the pilot draws is {n_eff}, so the rank-safety "
             "bound k_safe = floor(n_eff / 2) cannot be computed and low-rank "
-            "selection cannot proceed. This means the pilot draws contain "
-            "non-finite values; inspect the pilot chain rather than the rank "
-            "bound. Usual causes are a diverging pilot trajectory, a pilot "
-            "step size that is too large, or a log-density that returns NaN "
-            "somewhere in the pilot region."
+            "selection cannot proceed. Inspect the pilot chain, its step size "
+            "and the log-density over the pilot region rather than the rank "
+            "bound."
         )
 
     k_safe = int(n_eff / 2)  # floor(n_eff / 2)

--- a/blackjax/adaptation/mclmc_lrd_adaptation.py
+++ b/blackjax/adaptation/mclmc_lrd_adaptation.py
@@ -115,6 +115,7 @@ Limitations
   The unadjusted default remains the stable, broadly validated path.
 """
 
+import math
 import warnings
 from typing import Any, NamedTuple
 
@@ -641,6 +642,23 @@ def mclmc_lrd_warmup(
         n_eff = float(jnp.min(ess_per_dim))  # conservative: use min over dims
     else:
         n_eff = 0.0  # degenerate: force k_safe=0 → k_used=1
+
+    # A non-finite n_eff means the pilot diagnostics are invalid, not that the
+    # rank bound is small: effective_sample_size reports NaN for any dimension
+    # holding a non-finite draw.  Refuse explicitly here, before the int()
+    # conversion and before the Phase-2 SVD, rather than crashing in int() or
+    # letting a fabricated rank through.
+    if not math.isfinite(n_eff):
+        raise ValueError(
+            "mclmc_lrd_warmup: pilot diagnostics are invalid — the effective "
+            f"sample size of the pilot draws is {n_eff}, so the rank-safety "
+            "bound k_safe = floor(n_eff / 2) cannot be computed and low-rank "
+            "selection cannot proceed. This means the pilot draws contain "
+            "non-finite values; inspect the pilot chain rather than the rank "
+            "bound. Usual causes are a diverging pilot trajectory, a pilot "
+            "step size that is too large, or a log-density that returns NaN "
+            "somewhere in the pilot region."
+        )
 
     k_safe = int(n_eff / 2)  # floor(n_eff / 2)
     k_used = min(k, max(k_safe, 1))  # clamp; always use at least rank 1

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -360,6 +360,67 @@ def _split_chains(x: Array) -> Array:
     return jnp.concatenate([first, second], axis=0)
 
 
+def _average_ranks(x_flat: Array) -> Array:
+    """One-indexed ranks along axis 0, averaging the ranks of tied values.
+
+    Equal values form a *tie group* and all receive the mean of the ordinal
+    ranks that the group spans.  This makes the ranking invariant to the
+    permutation of the pooled draws, which ordinal (``argsort``-of-``argsort``)
+    ranking is not.
+
+    Parameters
+    ----------
+    x_flat
+        Array of shape ``(n, …)``; ranks are computed along axis 0
+        independently for each element of the trailing dimensions.
+
+    Returns
+    -------
+    Array of the same shape holding 1-indexed average ranks.
+
+    Notes
+    -----
+    The implementation is written with sort and cumulative-reduction
+    primitives only, so it is ``jit``/``vmap``-compatible and has no
+    data-dependent shapes.  ``NaN`` values sort last and are treated as tied
+    with one another: they are mutually indistinguishable, so ranking them by
+    position would reintroduce the very asymmetry this function removes.  As before, non-finite entries are ranked rather than
+    propagated — no ``NaN`` is silently replaced, but none is silently
+    introduced either.
+    """
+    n = x_flat.shape[0]
+    extra_shape = x_flat.shape[1:]
+
+    order = jnp.argsort(x_flat, axis=0)
+    x_sorted = jnp.take_along_axis(x_flat, order, axis=0)
+
+    # Adjacent sorted entries share a tie group when they are equal.  ``nan
+    # != nan``, so NaNs are grouped explicitly.
+    same_as_prev = (x_sorted[1:] == x_sorted[:-1]) | (
+        jnp.isnan(x_sorted[1:]) & jnp.isnan(x_sorted[:-1])
+    )
+    true_row = jnp.ones((1, *extra_shape), dtype=bool)
+    is_first = jnp.concatenate([true_row, ~same_as_prev], axis=0)
+    is_last = jnp.concatenate([~same_as_prev, true_row], axis=0)
+
+    positions = jnp.broadcast_to(
+        jnp.arange(n).reshape((n, *(1,) * len(extra_shape))), x_flat.shape
+    )
+    # Running max/min of the group boundary markers gives, for every sorted
+    # position, the first and last 0-indexed position of its tie group.
+    group_start = jax.lax.cummax(jnp.where(is_first, positions, 0), axis=0)
+    group_end = jax.lax.cummin(
+        jnp.where(is_last, positions, n - 1), axis=0, reverse=True
+    )
+
+    # Mean of the 1-indexed ordinal ranks spanned by the group.
+    avg_rank_sorted = (group_start + group_end) / 2.0 + 1.0
+
+    # Scatter back to the original positions.
+    inverse = jnp.argsort(order, axis=0)
+    return jnp.take_along_axis(avg_rank_sorted, inverse, axis=0)
+
+
 def _rank_normalize(x: Array) -> Array:
     """Rank-normalize draws using the Blom plotting position.
 
@@ -384,6 +445,16 @@ def _rank_normalize(x: Array) -> Array:
 
     where :math:`r` is the 1-indexed rank and :math:`n = \\text{nchains}
     \\times \\text{nsamples}`.
+
+    Tied draws receive the *average* of the ordinal ranks their tie group
+    spans (see :func:`_average_ranks`), matching Vehtari et al. (2021) and
+    ``scipy.stats.rankdata(method="average")``.  Ordinal ranking would give
+    equal values different scores depending on where they sit in the pooled
+    array, manufacturing chain/time structure out of ties — a constant input
+    would acquire a spurious spread, and repeated states (rejections,
+    indicator observables) would inflate R̂ and deflate bulk ESS.  A constant
+    input now maps to a constant field of zeros, leaving R̂ undefined (0/0)
+    and the ESS degeneracy guard free to report 0.
     """
     nchains, nsamples = x.shape[0], x.shape[1]
     extra_shape = x.shape[2:]
@@ -392,8 +463,8 @@ def _rank_normalize(x: Array) -> Array:
     # Pool chains and draws into the leading axis: (n, …extra).
     x_flat = x.reshape(n, *extra_shape)
 
-    # Double argsort gives 0-indexed ranks; +1 for 1-indexed.
-    ranks = jnp.argsort(jnp.argsort(x_flat, axis=0), axis=0).astype(float) + 1
+    # Average ranks, so that tied draws receive identical scores.
+    ranks = _average_ranks(x_flat)
 
     # Blom plotting position.
     z = jax.scipy.special.ndtri((ranks - 3.0 / 8) / (n + 1.0 / 4))

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -128,6 +128,18 @@ def rhat(input_array: ArrayLike, chain_axis: int = 0, sample_axis: int = 1) -> A
        them, and compute split-R̂ again (**tail**).
     5. Return :math:`\\max(\\hat{R}_{\\text{bulk}}, \\hat{R}_{\\text{tail}})`.
 
+    .. warning::
+
+       ``NaN`` from this function does **not** uniquely mean "the draws
+       contained a missing observation".  The folded component subtracts the
+       pooled median, so when at least half of a component's pooled draws are
+       ``+inf`` (or ``-inf``) the median is infinite and the fold evaluates
+       ``inf - inf``, which is ``NaN``.  Such a component returns ``NaN`` from
+       :func:`rhat` while containing no ``NaN`` at all — and while
+       :func:`ess_bulk` and :func:`ess_tail` still return finite values for it.
+       Infinity handling is a separate open question from the missing-data
+       contract; this is documented, not yet decided.
+
     References
     ----------
     .. cite:p:`vehtari2021rank`
@@ -173,7 +185,10 @@ def effective_sample_size(
     -------
     NDArray of the resulting statistics (ess), with the chain and sample dimensions squeezed.
     Variables whose within-chain variance is numerically zero have an effective
-    sample size of zero.
+    sample size of zero.  Variables containing a ``NaN`` draw are undefined and
+    report ``NaN``; the reduction is per variable, so an independent finite
+    variable is unaffected.  Infinities are ordered values and are not treated
+    as missing.
 
     Notes
     -----
@@ -301,6 +316,17 @@ def effective_sample_size(
     ess = ess_raw / tau_hat
     ess = jnp.where(is_numerically_degenerate.squeeze(), 0.0, ess.squeeze())
 
+    # A NaN draw is a missing observation, not a value the estimator can use.
+    # Geyer's truncation above gates on partial sums being > 0, and every such
+    # comparison is False for NaN, so the truncation collapses and tau_hat
+    # falls back to its 1 / log10(MN) floor — manufacturing a large, entirely
+    # fictitious sample size.  Report the component as undefined instead.  The
+    # reduction runs over the chain and draw axes only, so a contaminated
+    # component never poisons an independent finite one, and ``.squeeze()``
+    # mirrors the squeeze applied to ``ess`` just above.
+    has_nan = jnp.any(jnp.isnan(input_array), axis=(chain_axis, sample_axis))
+    ess = jnp.where(jnp.squeeze(has_nan), jnp.nan, ess)
+
     return ess
 
 
@@ -388,7 +414,11 @@ def _average_ranks(x_flat: Array) -> Array:
     could be tied with anything, so a component containing one cannot be
     ranked: the whole component returns ``NaN``.  The reduction runs over
     axis 0 alone, so an invalid component never poisons an independent finite
-    sibling.  Infinities are ordered and are ranked normally.
+    sibling.
+
+    Infinities are ordered values and are ranked normally *by this function*.
+    That does not make the whole diagnostic pipeline infinity-safe: see the
+    note on folding in :func:`rhat`.
     """
     n = x_flat.shape[0]
     extra_shape = x_flat.shape[1:]
@@ -443,6 +473,12 @@ def _propagate_nan_components(value: Array, x: Array) -> Array:
     The reduction runs over the chain and draw axes only, so a component
     holding a missing observation never poisons an independent finite one.
 
+    ``x`` here is the *split* array, so with an odd number of draws the last
+    draw has already been trimmed by :func:`_split_chains` and a ``NaN``
+    sitting only in that draw is not seen.  The contract is therefore "a
+    ``NaN`` among the draws the diagnostic actually uses", which is narrower
+    than "a ``NaN`` anywhere in the input".
+
     The guard is needed because the estimators downstream do not propagate
     ``NaN`` on their own.  Geyer's initial-positive-sequence truncation in
     :func:`effective_sample_size` compares partial autocorrelation sums
@@ -452,7 +488,11 @@ def _propagate_nan_components(value: Array, x: Array) -> Array:
     entirely fictitious sample size instead of ``NaN``.
     """
     contaminated = jnp.any(jnp.isnan(x), axis=(0, 1))
-    return jnp.where(contaminated, jnp.nan, value)
+    # ``effective_sample_size`` ends with a bare ``.squeeze()``, which drops
+    # genuine size-1 event axes as well as the chain/draw axes.  Squeeze the
+    # mask the same way, or ``jnp.where`` broadcasts a (…, 1) mask against a
+    # squeezed value and silently changes both the shape and the numbers.
+    return jnp.where(jnp.squeeze(contaminated), jnp.nan, value)
 
 
 def _rank_normalize(x: Array) -> Array:
@@ -485,10 +525,13 @@ def _rank_normalize(x: Array) -> Array:
     ``scipy.stats.rankdata(method="average")``.  Ordinal ranking would give
     equal values different scores depending on where they sit in the pooled
     array, manufacturing chain/time structure out of ties — a constant input
-    would acquire a spurious spread, and repeated states (rejections,
-    indicator observables) would inflate R̂ and deflate bulk ESS.  A constant
-    input now maps to a constant field of zeros, leaving R̂ undefined (0/0)
-    and the ESS degeneracy guard free to report 0.
+    would acquire a spurious spread, and repeated states would inflate R̂ and
+    deflate bulk ESS.  The damage scales with how large and how scattered the
+    tie groups are: it is severe for indicator and discrete observables, and
+    mild for rejection repeats in a continuous chain, where the repeats form
+    short contiguous runs.  A constant input now maps to a constant field of
+    zeros, leaving R̂ undefined (0/0) and the ESS degeneracy guard free to
+    report 0.
     """
     nchains, nsamples = x.shape[0], x.shape[1]
     extra_shape = x.shape[2:]
@@ -545,7 +588,9 @@ def ess_bulk(
     x = _to_standard_axes(jnp.asarray(input_array), chain_axis, sample_axis)
     x_split = _split_chains(x)
     x_rn = _rank_normalize(x_split)
-    return _propagate_nan_components(effective_sample_size(x_rn), x_split)
+    # A contaminated component is already all-NaN after _rank_normalize, and
+    # effective_sample_size propagates that on its own.
+    return effective_sample_size(x_rn)
 
 
 def ess_tail(
@@ -563,8 +608,22 @@ def ess_tail(
     The tail quantiles are determined by ``prob``: the lower tail uses the
     ``(1 - prob) / 2`` quantile and the upper tail uses the
     ``(1 + prob) / 2`` quantile.  The default ``prob=0.90`` corresponds to
-    the 5th/95th percentiles, which matches ``az.ess(method="tail")`` in
-    ArviZ (the ArviZ default is also ``prob=(0.05, 0.95)``).
+    the 5th/95th percentiles, matching ArviZ's default ``prob=(0.05, 0.95)``.
+
+    .. warning::
+
+       The agreement with ``az.ess(method="tail")`` holds for **continuous**
+       draws only.  The upper-tail indicator here is
+       :math:`\\mathbf{1}(x \\ge q_{\\text{high}})`, whereas Vehtari et al.
+       and ArviZ use :math:`\\mathbf{1}(x \\le q)` for both tails.  On
+       continuous draws the two are exact complements and the ESS is
+       identical, but on tied draws they are not: for iid Bernoulli(0.1),
+       :math:`P(x \\ge q_{95})` is 0.097 rather than 0.05, and for a 5-level
+       grid it is 0.21.  This is a separate known defect in the tail
+       estimator's tie handling, tracked independently of the
+       rank-normalization fix; note that simply switching to ``<=`` does not
+       resolve it, since that indicator is identically 1 on such draws and
+       would be reported as degenerate.
 
     Parameters
     ----------

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -382,11 +382,13 @@ def _average_ranks(x_flat: Array) -> Array:
     -----
     The implementation is written with sort and cumulative-reduction
     primitives only, so it is ``jit``/``vmap``-compatible and has no
-    data-dependent shapes.  ``NaN`` values sort last and are treated as tied
-    with one another: they are mutually indistinguishable, so ranking them by
-    position would reintroduce the very asymmetry this function removes.  As before, non-finite entries are ranked rather than
-    propagated — no ``NaN`` is silently replaced, but none is silently
-    introduced either.
+    data-dependent shapes.
+
+    A ``NaN`` is a missing or invalid observation, not an ordered value that
+    could be tied with anything, so a component containing one cannot be
+    ranked: the whole component returns ``NaN``.  The reduction runs over
+    axis 0 alone, so an invalid component never poisons an independent finite
+    sibling.  Infinities are ordered and are ranked normally.
     """
     n = x_flat.shape[0]
     extra_shape = x_flat.shape[1:]
@@ -394,11 +396,8 @@ def _average_ranks(x_flat: Array) -> Array:
     order = jnp.argsort(x_flat, axis=0)
     x_sorted = jnp.take_along_axis(x_flat, order, axis=0)
 
-    # Adjacent sorted entries share a tie group when they are equal.  ``nan
-    # != nan``, so NaNs are grouped explicitly.
-    same_as_prev = (x_sorted[1:] == x_sorted[:-1]) | (
-        jnp.isnan(x_sorted[1:]) & jnp.isnan(x_sorted[:-1])
-    )
+    # Adjacent sorted entries share a tie group when they are equal.
+    same_as_prev = x_sorted[1:] == x_sorted[:-1]
     true_row = jnp.ones((1, *extra_shape), dtype=bool)
     is_first = jnp.concatenate([true_row, ~same_as_prev], axis=0)
     is_last = jnp.concatenate([~same_as_prev, true_row], axis=0)
@@ -418,7 +417,42 @@ def _average_ranks(x_flat: Array) -> Array:
 
     # Scatter back to the original positions.
     inverse = jnp.argsort(order, axis=0)
-    return jnp.take_along_axis(avg_rank_sorted, inverse, axis=0)
+    ranks = jnp.take_along_axis(avg_rank_sorted, inverse, axis=0)
+
+    # A component holding a missing observation has no valid ranking.
+    contaminated = jnp.any(jnp.isnan(x_flat), axis=0, keepdims=True)
+    return jnp.where(contaminated, jnp.nan, ranks)
+
+
+def _propagate_nan_components(value: Array, x: Array) -> Array:
+    """Set the entries of ``value`` whose draws contain a ``NaN`` to ``NaN``.
+
+    Parameters
+    ----------
+    value
+        Diagnostic values of shape ``x.shape[2:]``.
+    x
+        Draws of shape ``(nchains, nsamples, …)``.
+
+    Returns
+    -------
+    ``value`` with every contaminated component replaced by ``NaN``.
+
+    Notes
+    -----
+    The reduction runs over the chain and draw axes only, so a component
+    holding a missing observation never poisons an independent finite one.
+
+    The guard is needed because the estimators downstream do not propagate
+    ``NaN`` on their own.  Geyer's initial-positive-sequence truncation in
+    :func:`effective_sample_size` compares partial autocorrelation sums
+    against zero; every such comparison is ``False`` for ``NaN``, so the
+    truncation collapses and :math:`\\hat{\\tau}` falls back to its
+    ``1 / log10(MN)`` floor — turning an all-``NaN`` input into a large and
+    entirely fictitious sample size instead of ``NaN``.
+    """
+    contaminated = jnp.any(jnp.isnan(x), axis=(0, 1))
+    return jnp.where(contaminated, jnp.nan, value)
 
 
 def _rank_normalize(x: Array) -> Array:
@@ -511,7 +545,7 @@ def ess_bulk(
     x = _to_standard_axes(jnp.asarray(input_array), chain_axis, sample_axis)
     x_split = _split_chains(x)
     x_rn = _rank_normalize(x_split)
-    return effective_sample_size(x_rn)
+    return _propagate_nan_components(effective_sample_size(x_rn), x_split)
 
 
 def ess_tail(
@@ -589,6 +623,12 @@ def ess_tail(
 
     ess_lower = effective_sample_size(I_lower)
     ess_upper = effective_sample_size(I_upper)
+
+    # A NaN draw makes the pooled quantiles NaN, every indicator comparison
+    # False, and the resulting all-zero series degenerate — which would report
+    # 0 rather than "undefined".  Propagate instead.
+    ess_lower = _propagate_nan_components(ess_lower, x_split)
+    ess_upper = _propagate_nan_components(ess_upper, x_split)
 
     return jnp.minimum(ess_lower, ess_upper)
 

--- a/blackjax/diagnostics.py
+++ b/blackjax/diagnostics.py
@@ -685,11 +685,10 @@ def ess_tail(
 
     # A NaN draw makes the pooled quantiles NaN, every indicator comparison
     # False, and the resulting all-zero series degenerate — which would report
-    # 0 rather than "undefined".  Propagate instead.
-    ess_lower = _propagate_nan_components(ess_lower, x_split)
-    ess_upper = _propagate_nan_components(ess_upper, x_split)
-
-    return jnp.minimum(ess_lower, ess_upper)
+    # 0 rather than "undefined".  Guard once on the reduced value: the
+    # indicators themselves are never NaN, so the estimator cannot propagate
+    # this on its own the way it does for ess_bulk.
+    return _propagate_nan_components(jnp.minimum(ess_lower, ess_upper), x_split)
 
 
 def pareto_khat(x: ArrayLike, tail: str = "both", tail_frac: float = 0.10) -> Array:

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -136,13 +136,36 @@ class TestRankGuard:
         ), "Expected a UserWarning about rank clamping but none was emitted"
 
     def test_non_finite_pilot_ess_is_refused_before_rank_selection(self):
-        """An invalid pilot must fail loudly, before int() and before the SVD.
+        """An invalid pilot must fail with a descriptive error, not a bare one.
 
         `effective_sample_size` reports NaN for any dimension holding a
         non-finite draw. Previously that NaN reached `int(n_eff / 2)` and
         raised a bare `ValueError: cannot convert float NaN to integer`; before
         that it was worse, because the estimator fabricated a finite ESS and
         the contaminated dimension was reported as the best-mixing one.
+
+        What each assertion actually covers, since the two are often
+        conflated: the ``match=`` carries the discriminating claim, because
+        the bare `int(nan)` also raised ValueError at the pre-guard tree.  The
+        `_extract_lrd_from_samples` tripwire covers only non-execution — the
+        old `int(nan)` was itself upstream of the SVD, so the tripwire would
+        have passed there too.  It earns its place as the assertion that fails
+        if someone later moves the guard *below* the SVD, not as evidence
+        about the previous behaviour.
+
+        Falling back instead of raising would not degrade gracefully: the SVD
+        consumes the same contaminated `flat_pilot`, and on a (32, 3) pilot
+        with one NaN draw it returns sigma 33% NaN and U, lam_k, lam_all 100%
+        NaN — an all-NaN preconditioner out of a public warmup.  `n_eff = 0.0`
+        means "not measured"; NaN means "measured, and the draws are corrupt".
+
+        Monkeypatching the ESS is deterministic and independent of sampler
+        behaviour, but it does not exercise the real NaN-draws -> NaN-ESS
+        link, so on its own it would keep passing if
+        `effective_sample_size` ever stopped propagating and this guard went
+        dead.  `test_raw_ess_does_not_invent_a_sample_size_for_nan` in
+        `tests/test_diagnostics.py` covers that half; the two are complete as
+        a pair, not individually.
         """
         import blackjax.adaptation.mclmc_lrd_adaptation as lrd_mod
 

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -135,6 +135,77 @@ class TestRankGuard:
             issubclass(w.category, UserWarning) for w in caught
         ), "Expected a UserWarning about rank clamping but none was emitted"
 
+    def test_non_finite_pilot_ess_is_refused_before_rank_selection(self):
+        """An invalid pilot must fail loudly, before int() and before the SVD.
+
+        `effective_sample_size` reports NaN for any dimension holding a
+        non-finite draw. Previously that NaN reached `int(n_eff / 2)` and
+        raised a bare `ValueError: cannot convert float NaN to integer`; before
+        that it was worse, because the estimator fabricated a finite ESS and
+        the contaminated dimension was reported as the best-mixing one.
+        """
+        import blackjax.adaptation.mclmc_lrd_adaptation as lrd_mod
+
+        called = []
+
+        def _contaminated_ess(x, *args, **kwargs):
+            # Controlled contamination: stand in for a pilot whose draws
+            # contain non-finite values, without relying on a diverging chain.
+            return jnp.full((x.shape[-1],), jnp.nan)
+
+        def _tripwire(*args, **kwargs):
+            called.append("svd")
+            raise AssertionError("SVD ran despite invalid pilot diagnostics")
+
+        monkey = pytest.MonkeyPatch()
+        try:
+            monkey.setattr(lrd_mod, "effective_sample_size", _contaminated_ess)
+            monkey.setattr(lrd_mod, "_extract_lrd_from_samples", _tripwire)
+            with pytest.raises(ValueError, match="pilot diagnostics are invalid"):
+                mclmc_lrd_warmup(
+                    logdensity_fn,
+                    jnp.zeros(D),
+                    jax.random.key(11),
+                    k=K,
+                    pilot_num_warmup=50,
+                    pilot_num_samples=32,
+                    lrd_num_steps=50,
+                    num_chains=2,
+                )
+        finally:
+            monkey.undo()
+
+        assert not called, "the guard must fire before the Phase-2 SVD"
+
+    def test_finite_pilot_ess_path_is_unchanged(self):
+        """The finite path, including a zero-ESS pilot, must be untouched."""
+        import blackjax.adaptation.mclmc_lrd_adaptation as lrd_mod
+
+        def _zero_ess(x, *args, **kwargs):
+            return jnp.zeros((x.shape[-1],))
+
+        monkey = pytest.MonkeyPatch()
+        try:
+            monkey.setattr(lrd_mod, "effective_sample_size", _zero_ess)
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                result = mclmc_lrd_warmup(
+                    logdensity_fn,
+                    jnp.zeros(D),
+                    jax.random.key(12),
+                    k=K,
+                    pilot_num_warmup=50,
+                    pilot_num_samples=32,
+                    lrd_num_steps=50,
+                    num_chains=2,
+                )
+        finally:
+            monkey.undo()
+
+        # n_eff = 0.0 is finite: k_safe = 0, clamped to k_used = 1, no raise.
+        assert isinstance(result, MCLMCLRDAdaptationState)
+        assert result.diagnostics["k_used"] == 1
+
     def test_no_warning_when_k_within_bound(self):
         """When k ≤ n_eff/2, no clamping warning should be emitted."""
         rng = jax.random.key(6)

--- a/tests/adaptation/test_mclmc_lrd_adaptation.py
+++ b/tests/adaptation/test_mclmc_lrd_adaptation.py
@@ -135,99 +135,38 @@ class TestRankGuard:
             issubclass(w.category, UserWarning) for w in caught
         ), "Expected a UserWarning about rank clamping but none was emitted"
 
-    def test_non_finite_pilot_ess_is_refused_before_rank_selection(self):
-        """An invalid pilot must fail with a descriptive error, not a bare one.
+    def test_non_finite_pilot_ess_is_refused_before_rank_selection(self, monkeypatch):
+        """An invalid pilot fails with a descriptive error, before the SVD.
 
-        `effective_sample_size` reports NaN for any dimension holding a
-        non-finite draw. Previously that NaN reached `int(n_eff / 2)` and
-        raised a bare `ValueError: cannot convert float NaN to integer`; before
-        that it was worse, because the estimator fabricated a finite ESS and
-        the contaminated dimension was reported as the best-mixing one.
-
-        What each assertion actually covers, since the two are often
-        conflated: the ``match=`` carries the discriminating claim, because
-        the bare `int(nan)` also raised ValueError at the pre-guard tree.  The
-        `_extract_lrd_from_samples` tripwire covers only non-execution — the
-        old `int(nan)` was itself upstream of the SVD, so the tripwire would
-        have passed there too.  It earns its place as the assertion that fails
-        if someone later moves the guard *below* the SVD, not as evidence
-        about the previous behaviour.
-
-        Falling back instead of raising would not degrade gracefully: the SVD
-        consumes the same contaminated `flat_pilot`, and on a (32, 3) pilot
-        with one NaN draw it returns sigma 33% NaN and U, lam_k, lam_all 100%
-        NaN — an all-NaN preconditioner out of a public warmup.  `n_eff = 0.0`
-        means "not measured"; NaN means "measured, and the draws are corrupt".
-
-        Monkeypatching the ESS is deterministic and independent of sampler
-        behaviour, but it does not exercise the real NaN-draws -> NaN-ESS
-        link, so on its own it would keep passing if
-        `effective_sample_size` ever stopped propagating and this guard went
-        dead.  `test_raw_ess_does_not_invent_a_sample_size_for_nan` in
-        `tests/test_diagnostics.py` covers that half; the two are complete as
-        a pair, not individually.
+        The discriminating assertion is the message match: the pre-guard tree
+        also raised, but as a bare "cannot convert float NaN to integer". The
+        tripwire adds that the guard has not drifted below the SVD, which
+        matters because `_extract_lrd_from_samples` consumes the same
+        contaminated draws and returns an all-NaN preconditioner from them.
         """
         import blackjax.adaptation.mclmc_lrd_adaptation as lrd_mod
 
-        called = []
-
-        def _contaminated_ess(x, *args, **kwargs):
-            # Controlled contamination: stand in for a pilot whose draws
-            # contain non-finite values, without relying on a diverging chain.
-            return jnp.full((x.shape[-1],), jnp.nan)
-
         def _tripwire(*args, **kwargs):
-            called.append("svd")
             raise AssertionError("SVD ran despite invalid pilot diagnostics")
 
-        monkey = pytest.MonkeyPatch()
-        try:
-            monkey.setattr(lrd_mod, "effective_sample_size", _contaminated_ess)
-            monkey.setattr(lrd_mod, "_extract_lrd_from_samples", _tripwire)
-            with pytest.raises(ValueError, match="pilot diagnostics are invalid"):
-                mclmc_lrd_warmup(
-                    logdensity_fn,
-                    jnp.zeros(D),
-                    jax.random.key(11),
-                    k=K,
-                    pilot_num_warmup=50,
-                    pilot_num_samples=32,
-                    lrd_num_steps=50,
-                    num_chains=2,
-                )
-        finally:
-            monkey.undo()
+        monkeypatch.setattr(
+            lrd_mod,
+            "effective_sample_size",
+            lambda x, *a, **k: jnp.full(x.shape[-1], jnp.nan),
+        )
+        monkeypatch.setattr(lrd_mod, "_extract_lrd_from_samples", _tripwire)
 
-        assert not called, "the guard must fire before the Phase-2 SVD"
-
-    def test_finite_pilot_ess_path_is_unchanged(self):
-        """The finite path, including a zero-ESS pilot, must be untouched."""
-        import blackjax.adaptation.mclmc_lrd_adaptation as lrd_mod
-
-        def _zero_ess(x, *args, **kwargs):
-            return jnp.zeros((x.shape[-1],))
-
-        monkey = pytest.MonkeyPatch()
-        try:
-            monkey.setattr(lrd_mod, "effective_sample_size", _zero_ess)
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                result = mclmc_lrd_warmup(
-                    logdensity_fn,
-                    jnp.zeros(D),
-                    jax.random.key(12),
-                    k=K,
-                    pilot_num_warmup=50,
-                    pilot_num_samples=32,
-                    lrd_num_steps=50,
-                    num_chains=2,
-                )
-        finally:
-            monkey.undo()
-
-        # n_eff = 0.0 is finite: k_safe = 0, clamped to k_used = 1, no raise.
-        assert isinstance(result, MCLMCLRDAdaptationState)
-        assert result.diagnostics["k_used"] == 1
+        with pytest.raises(ValueError, match="pilot diagnostics are invalid"):
+            mclmc_lrd_warmup(
+                logdensity_fn,
+                jnp.zeros(D),
+                jax.random.key(11),
+                k=K,
+                pilot_num_warmup=50,
+                pilot_num_samples=32,
+                lrd_num_steps=50,
+                num_chains=2,
+            )
 
     def test_no_warning_when_k_within_bound(self):
         """When k ≤ n_eff/2, no clamping warning should be emitted."""

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -717,7 +717,7 @@ class RankNormalizeTiesTest(chex.TestCase):
         unguarded = float(diagnostics.effective_sample_size(all_nan))
         assert np.isfinite(unguarded) and unguarded > 0, (
             "premise no longer holds: effective_sample_size now propagates NaN"
-            f" on its own (got {unguarded}); the boundary guard may be"
+            f" on its own (got {unguarded}) — the boundary guard may be"
             " redundant and should be re-reviewed"
         )
         assert np.isnan(float(diagnostics.ess_bulk(all_nan)))

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -8,6 +8,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from absl.testing import absltest, parameterized
+from scipy.stats import norm, rankdata
 
 import blackjax.diagnostics as diagnostics
 
@@ -467,6 +468,320 @@ class EssTailTest(chex.TestCase):
         x = jax.random.normal(k2, shape=(_NCHAINS, _NSAMPLES)) * jnp.exp(v / 2.0)
         result = float(diagnostics.ess_tail(x))
         assert result > 0, f"ess_tail for funnel draws must be positive, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Regressions for tied-draw handling in the rank-normalized diagnostics
+# ---------------------------------------------------------------------------
+
+
+def _pairwise_average_ranks(x):
+    """1-indexed average ranks along axis 0, by direct pairwise counting.
+
+    Uses ``rank(v) = (1 + #{x < v} + #{x <= v}) / 2`` — the definition of the
+    mean of the ordinal ranks a tie group spans.  This shares no code path
+    with the sort/cumulative-reduction implementation under test, so it is an
+    independent oracle rather than a restatement of it.
+    """
+    a = np.asarray(x)
+    flat = a.reshape(a.shape[0], -1)
+    out = np.empty(flat.shape, dtype=np.float64)
+    for j in range(flat.shape[1]):
+        col = flat[:, j]
+        n_lt = (col[None, :] < col[:, None]).sum(axis=1)
+        n_le = (col[None, :] <= col[:, None]).sum(axis=1)
+        out[:, j] = (1.0 + n_lt + n_le) / 2.0
+    return out.reshape(a.shape)
+
+
+def _reference_rank_normalize(x):
+    """Blom rank-normalization of ``(nchains, nsamples, ...)`` draws, in NumPy."""
+    n = x.shape[0] * x.shape[1]
+    flat = np.asarray(x).reshape(n, *x.shape[2:])
+    ranks = _pairwise_average_ranks(flat)
+    return norm.ppf((ranks - 3.0 / 8) / (n + 1.0 / 4)).reshape(x.shape)
+
+
+def _reference_split(x):
+    """Split each chain of a ``(nchains, nsamples, ...)`` array in half."""
+    half = x.shape[1] // 2
+    x = x[:, : 2 * half]
+    return np.concatenate([x[:, :half], x[:, half:]], axis=0)
+
+
+def _reference_split_rhat(x):
+    """Plain split-R-hat on already-split, already-normalized draws."""
+    num_samples = x.shape[1]
+    between = num_samples * x.mean(axis=1).var(axis=0, ddof=1)
+    within = x.var(axis=1, ddof=1).mean(axis=0)
+    return np.sqrt((between / within + num_samples - 1) / num_samples)
+
+
+def _reference_rhat(x):
+    """Independent NumPy implementation of rank-normalized split-R-hat."""
+    x_split = _reference_split(np.asarray(x))
+    r_bulk = _reference_split_rhat(_reference_rank_normalize(x_split))
+    pooled = x_split.reshape(x_split.shape[0] * x_split.shape[1], *x_split.shape[2:])
+    folded = np.abs(x_split - np.median(pooled, axis=0))
+    r_tail = _reference_split_rhat(_reference_rank_normalize(folded))
+    return np.maximum(r_bulk, r_tail)
+
+
+class RankNormalizeTiesTest(chex.TestCase):
+    """Tied draws must receive equal, permutation-invariant rank scores.
+
+    Ordinal (double-``argsort``) ranking hands equal values different ranks
+    according to where they sit in the pooled array, which manufactures
+    chain/time structure out of ties and corrupts :func:`rhat` and
+    :func:`ess_bulk` for repeated states, indicator observables and
+    rejection-heavy chains.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.rng = jax.random.key(20260906)
+
+    def _tied_draws(self, nchains=4, nsamples=48, num_levels=5, shape=()):
+        """Draws from a small discrete grid, so most values are tied."""
+        levels = jax.random.randint(
+            self.rng, shape=(nchains, nsamples, *shape), minval=0, maxval=num_levels
+        )
+        return levels.astype(jnp.float32)
+
+    # -- the ranking primitive ------------------------------------------
+
+    def test_average_ranks_match_pairwise_reference(self):
+        pooled = np.asarray(self._tied_draws()).reshape(4 * 48)
+        ranks = np.asarray(diagnostics._average_ranks(jnp.asarray(pooled)))
+        np.testing.assert_array_equal(ranks, _pairwise_average_ranks(pooled))
+
+    def test_average_ranks_match_scipy_rankdata(self):
+        pooled = np.asarray(self._tied_draws(num_levels=3)).reshape(-1)
+        ranks = np.asarray(diagnostics._average_ranks(jnp.asarray(pooled)))
+        np.testing.assert_array_equal(ranks, rankdata(pooled, method="average"))
+
+    def test_average_ranks_are_independent_per_event(self):
+        # Trailing dimensions must be ranked independently of one another.
+        draws = self._tied_draws(shape=(3,))
+        pooled = np.asarray(draws).reshape(4 * 48, 3)
+        ranks = np.asarray(diagnostics._average_ranks(jnp.asarray(pooled)))
+        np.testing.assert_array_equal(ranks, _pairwise_average_ranks(pooled))
+        for event in range(3):
+            column = np.asarray(
+                diagnostics._average_ranks(jnp.asarray(pooled[:, event]))
+            )
+            np.testing.assert_array_equal(ranks[:, event], column)
+
+    def test_distinct_values_keep_ordinal_ranks(self):
+        # With no ties the average rank reduces to the ordinal rank, so the
+        # pre-existing behaviour on continuous draws is untouched.
+        # A shuffled arange, so the values are distinct by construction —
+        # float32 normal draws do collide occasionally at this size.
+        draws = jax.random.permutation(self.rng, jnp.arange(4 * 48)).astype(jnp.float32)
+        ranks = np.asarray(diagnostics._average_ranks(draws))
+        ordinal = np.asarray(jnp.argsort(jnp.argsort(draws)) + 1, dtype=np.float64)
+        np.testing.assert_array_equal(ranks, ordinal)
+
+    # -- permutation symmetry -------------------------------------------
+
+    def test_tied_draws_receive_identical_scores(self):
+        draws = self._tied_draws()
+        z = np.asarray(diagnostics._rank_normalize(draws))
+        values = np.asarray(draws).reshape(-1)
+        scores = z.reshape(-1)
+        for level in np.unique(values):
+            group = scores[values == level]
+            np.testing.assert_array_equal(
+                group,
+                np.full_like(group, group[0]),
+                err_msg=f"tied value {level} received unequal scores",
+            )
+
+    def test_rank_normalize_is_permutation_invariant(self):
+        draws = self._tied_draws()
+        z = np.asarray(diagnostics._rank_normalize(draws))
+
+        rng = np.random.default_rng(0)
+        pooled = np.asarray(draws).reshape(-1)
+        permutation = rng.permutation(pooled.size)
+        shuffled = pooled[permutation].reshape(draws.shape)
+        z_shuffled = np.asarray(diagnostics._rank_normalize(jnp.asarray(shuffled)))
+
+        inverse = np.empty_like(permutation)
+        inverse[permutation] = np.arange(permutation.size)
+        restored = z_shuffled.reshape(-1)[inverse].reshape(draws.shape)
+        np.testing.assert_array_equal(
+            z,
+            restored,
+            err_msg="rank normalization is not invariant to pooled permutation",
+        )
+
+    # -- degenerate inputs ----------------------------------------------
+
+    def test_constant_input_normalizes_to_zero(self):
+        # A constant input must not acquire artificial spread.
+        draws = jnp.full((4, 48), 2.5)
+        z = np.asarray(diagnostics._rank_normalize(draws))
+        np.testing.assert_allclose(z, np.zeros_like(z), atol=1e-6)
+
+    def test_constant_input_rhat_is_undefined(self):
+        # R-hat is 0/0 for a constant input: undefined, not a large number.
+        result = np.asarray(diagnostics.rhat(jnp.full((4, 64), 2.5)))
+        assert np.isnan(result), f"expected undefined R-hat, got {result}"
+
+    def test_constant_input_ess_bulk_reports_degeneracy(self):
+        # BlackJAX flags zero-variance variables with ESS 0; rank
+        # normalization must not turn the constant into a varying sequence
+        # first.  (This deliberately differs from ArviZ, which reports N.)
+        result = np.asarray(diagnostics.ess_bulk(jnp.full((4, 64), 2.5)))
+        np.testing.assert_array_equal(result, 0.0)
+
+    def test_mixed_constant_and_varying_events(self):
+        # Per-event degeneracy must be decided per event, not globally.
+        varying = jax.random.normal(self.rng, shape=(4, 64))
+        draws = jnp.stack([jnp.full((4, 64), 1.0), varying], axis=-1)
+        ess = np.asarray(diagnostics.ess_bulk(draws))
+        assert ess[0] == 0.0, f"constant event must report ESS 0, got {ess[0]}"
+        assert ess[1] > 0.0, f"varying event must report positive ESS, got {ess[1]}"
+
+    def test_nan_draws_are_tied_with_one_another(self):
+        # NaNs are mutually indistinguishable; ranking them by position would
+        # reintroduce the asymmetry this fix removes.
+        pooled = jnp.array([1.0, jnp.nan, 0.0, jnp.nan, 2.0])
+        ranks = np.asarray(diagnostics._average_ranks(pooled))
+        assert ranks[1] == ranks[3], f"NaNs received different ranks: {ranks}"
+
+    # -- end-to-end diagnostics -----------------------------------------
+
+    def test_binary_draws_match_independent_rhat(self):
+        # Bernoulli(0.1) indicator draws: heavily tied, and the case where
+        # ordinal ranking previously reported R-hat far above 1 for iid data.
+        draws = (jax.random.uniform(self.rng, shape=(8, 96, 2)) < 0.1).astype(
+            jnp.float32
+        )
+        result = np.asarray(diagnostics.rhat(draws))
+        expected = _reference_rhat(np.asarray(draws, dtype=np.float64))
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+        assert np.all(
+            result < 1.01
+        ), f"iid Bernoulli draws must not look non-converged, got {result}"
+
+    def test_binary_draws_bulk_ess_is_not_collapsed(self):
+        # Ordinal ranking collapsed bulk ESS for these draws to ~1% of N.
+        draws = (jax.random.uniform(self.rng, shape=(8, 96, 2)) < 0.1).astype(
+            jnp.float32
+        )
+        total = 8 * 96
+        result = np.asarray(diagnostics.ess_bulk(draws))
+        assert np.all(
+            result > 0.5 * total
+        ), f"bulk ESS for iid Bernoulli draws collapsed: {result} (N={total})"
+
+    def test_binary_draws_match_arviz(self):
+        az = pytest.importorskip("arviz")
+        draws = np.asarray(
+            (jax.random.uniform(self.rng, shape=(8, 96, 2)) < 0.1).astype(jnp.float32),
+            dtype=np.float64,
+        )
+        idata = az.convert_to_dataset({"x": draws})
+        az_rhat = np.asarray(az.rhat(idata, method="rank")["x"]).ravel()
+        az_ess = np.asarray(az.ess(idata, method="bulk")["x"]).ravel()
+        bj_rhat = np.asarray(diagnostics.rhat(jnp.asarray(draws)))
+        bj_ess = np.asarray(diagnostics.ess_bulk(jnp.asarray(draws)))
+        np.testing.assert_allclose(bj_rhat, az_rhat, rtol=1e-4)
+        np.testing.assert_allclose(bj_ess, az_ess, rtol=1e-3)
+
+    def test_repeated_states_do_not_inflate_rhat(self):
+        # A Metropolis-like trace with an 80% rejection rate repeats states;
+        # those repeats are ties, not chain structure.  Built with NumPy so
+        # the trace itself owes nothing to the code under test.
+        rng = np.random.default_rng(20260906)
+        proposals = rng.normal(size=(4, 512))
+        accepted = rng.uniform(size=(4, 512)) < 0.2
+        draws = np.empty_like(proposals)
+        draws[:, 0] = proposals[:, 0]
+        for t in range(1, proposals.shape[1]):
+            draws[:, t] = np.where(accepted[:, t], proposals[:, t], draws[:, t - 1])
+        assert (draws[:, 1:] == draws[:, :-1]).mean() > 0.5, "trace has too few repeats"
+
+        result = np.asarray(diagnostics.rhat(jnp.asarray(draws, dtype=jnp.float32)))
+        expected = _reference_rhat(draws)
+        np.testing.assert_allclose(result, expected, rtol=1e-4)
+
+    def test_folded_tail_component_uses_average_ranks(self):
+        # rhat folds about the median before rank-normalizing; the folded
+        # draws of a symmetric tied grid are themselves heavily tied.
+        draws = self._tied_draws(nsamples=64, num_levels=4)
+        result = np.asarray(diagnostics.rhat(draws))
+        expected = _reference_rhat(np.asarray(draws, dtype=np.float64))
+        np.testing.assert_allclose(result, expected, rtol=1e-5)
+
+    def test_antithetic_binary_bulk_ess_may_exceed_draw_count(self):
+        # No global ESS <= N cap: an antithetic sequence validly exceeds N.
+        nsamples = 512
+        draws = jnp.tile(
+            jnp.tile(jnp.array([0.0, 1.0]), nsamples // 2)[None, :], (4, 1)
+        )
+        result = float(diagnostics.ess_bulk(draws))
+        assert (
+            result > 4 * nsamples
+        ), f"antithetic bulk ESS was capped: {result} <= {4 * nsamples}"
+
+    # -- axes, dtypes, transformations ----------------------------------
+
+    @parameterized.parameters(*test_cases)
+    def test_axis_invariance_with_ties(self, chain_axis, sample_axis):
+        draws = self._tied_draws(nchains=4, nsamples=64)
+        expected = diagnostics.rhat(draws)
+        expected_ess = diagnostics.ess_bulk(draws)
+
+        if (chain_axis, sample_axis) == (0, 1):
+            moved = draws
+        else:
+            ndim = 2
+            moved = jnp.transpose(
+                draws, np.argsort([chain_axis % ndim, sample_axis % ndim])
+            )
+        np.testing.assert_allclose(
+            diagnostics.rhat(moved, chain_axis, sample_axis), expected, rtol=1e-6
+        )
+        np.testing.assert_allclose(
+            diagnostics.ess_bulk(moved, chain_axis, sample_axis),
+            expected_ess,
+            rtol=1e-6,
+        )
+
+    def test_dtype_is_preserved(self):
+        # Rank normalization must not silently widen or narrow the draws.
+        default_float = jnp.zeros(0).dtype
+        draws = self._tied_draws().astype(default_float)
+        assert diagnostics._rank_normalize(draws).dtype == default_float
+        assert diagnostics.ess_bulk(draws).dtype == default_float
+        assert diagnostics.rhat(draws).dtype == default_float
+
+    def test_integer_draws_are_accepted(self):
+        # Discrete draws are exactly the tied case; they must rank without
+        # first being cast to something lossy.
+        integers = jax.random.randint(self.rng, (4, 64), minval=0, maxval=5)
+        ranks = np.asarray(diagnostics._average_ranks(integers.reshape(-1)))
+        np.testing.assert_array_equal(
+            ranks, rankdata(np.asarray(integers).reshape(-1), method="average")
+        )
+
+    @chex.all_variants(with_pmap=False)
+    def test_jit_compatible(self):
+        draws = self._tied_draws()
+        rank_normalize = self.variant(diagnostics._rank_normalize)
+        np.testing.assert_array_equal(
+            np.asarray(rank_normalize(draws)),
+            np.asarray(diagnostics._rank_normalize(draws)),
+        )
+
+    def test_vmap_over_events(self):
+        draws = self._tied_draws(shape=(3,))
+        stacked = jnp.moveaxis(draws, -1, 0)
+        mapped = jax.vmap(diagnostics.ess_bulk)(stacked)
+        np.testing.assert_allclose(mapped, diagnostics.ess_bulk(draws), rtol=1e-6)
 
 
 class ParetoKhatTest(chex.TestCase):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -709,25 +709,121 @@ class RankNormalizeTiesTest(chex.TestCase):
             np.isnan(r) for r in results
         ), f"NaN handling depends on position in the pool: {results}"
 
-    def test_ess_bulk_would_otherwise_invent_a_sample_size(self):
-        # Guards the reason _propagate_nan_components exists: Geyer's
-        # truncation collapses on NaN and tau_hat falls back to its
-        # 1/log10(MN) floor, which manufactures a large finite ESS.
+    def test_raw_ess_does_not_invent_a_sample_size_for_nan(self):
+        # Geyer's truncation gates on partial sums being > 0; every such
+        # comparison is False for NaN, so without a guard the truncation
+        # collapses and tau_hat falls back to its 1/log10(MN) floor,
+        # manufacturing a large finite ESS (measured: 616.51 for this input).
         all_nan = jnp.full((4, 64), jnp.nan)
-        unguarded = float(diagnostics.effective_sample_size(all_nan))
-        assert np.isfinite(unguarded) and unguarded > 0, (
-            "premise no longer holds: effective_sample_size now propagates NaN"
-            f" on its own (got {unguarded}) — the boundary guard may be"
-            " redundant and should be re-reviewed"
-        )
+        assert np.isnan(float(diagnostics.effective_sample_size(all_nan)))
         assert np.isnan(float(diagnostics.ess_bulk(all_nan)))
 
+    # Axis conventions for a rank-3 (chain, sample, event) array, including
+    # genuinely negative arguments — normalising them inside the test would
+    # mean a negative-axis regression could never fail it.
+    _AXES_3D = ((0, 1), (1, 0), (-3, -2), (-2, -3), (0, -2), (-3, 1))
+
+    @parameterized.parameters(*_AXES_3D)
+    def test_raw_ess_propagates_nan_on_every_axis_convention(
+        self, chain_axis, sample_axis
+    ):
+        draws = np.asarray(self._contaminated(), dtype=np.float64)  # (4, 64, 2)
+        chain, sample = chain_axis % 3, sample_axis % 3
+        event = ({0, 1, 2} - {chain, sample}).pop()
+        perm = [0, 0, 0]
+        perm[chain], perm[sample], perm[event] = 0, 1, 2
+        moved = np.transpose(draws, perm)
+        # Pass the raw, possibly negative, axis arguments through.
+        result = np.asarray(
+            diagnostics.effective_sample_size(
+                jnp.asarray(moved), chain_axis, sample_axis
+            )
+        )
+        assert np.isnan(result[0]), f"contaminated component reported {result[0]}"
+        assert np.isfinite(result[1]), f"clean sibling poisoned: {result[1]}"
+
+    def test_raw_ess_nan_does_not_poison_a_finite_sibling(self):
+        draws = self._contaminated()
+        result = np.asarray(diagnostics.effective_sample_size(draws))
+        alone = np.asarray(diagnostics.effective_sample_size(draws[..., 1]))
+        assert np.isnan(result[0])
+        np.testing.assert_array_equal(result[1], alone)
+
+    def test_raw_ess_nan_propagation_survives_jit(self):
+        draws = self._contaminated()
+        eager = np.asarray(diagnostics.effective_sample_size(draws))
+        jitted = np.asarray(jax.jit(diagnostics.effective_sample_size)(draws))
+        np.testing.assert_array_equal(np.isnan(eager), np.isnan(jitted))
+        np.testing.assert_allclose(eager[1], jitted[1], rtol=1e-6)
+
+    @parameterized.parameters(
+        (4, 64),
+        (4, 64, 1),
+        (4, 64, 2),
+        (4, 64, 1, 2),
+        (4, 64, 3, 1),
+        (4, 64, 1, 1),
+        (1, 64, 3),
+        (4, 64, 2, 3),
+    )
+    def test_nan_guards_preserve_output_shape(self, *shape):
+        # The NaN guards must not change the shape contract.  A mask that
+        # keeps size-1 event axes broadcasts against the estimators' squeezed
+        # output: (4, 64, 3, 1) once produced ess_bulk of shape (3, 3).
+        draws = jax.random.normal(self.rng, shape=shape)
+        expected = diagnostics.effective_sample_size(draws).shape
+        assert diagnostics.ess_bulk(draws).shape == expected
+        assert diagnostics.ess_tail(draws).shape == expected
+        assert diagnostics.rhat(draws).shape == expected
+
     def test_infinities_are_ordered_and_still_ranked(self):
-        # Infinity policy is deliberately out of scope: +/-inf are ordered
-        # values and keep their ranks.
+        # +/-inf are ordered values and keep their ranks in _average_ranks.
         pooled = jnp.array([-jnp.inf, 0.0, 0.0, jnp.inf, 1.0])
         ranks = np.asarray(diagnostics._average_ranks(pooled))
         np.testing.assert_array_equal(ranks, np.array([1.0, 2.5, 2.5, 5.0, 4.0]))
+
+    def test_sparse_infinities_do_not_break_the_diagnostics(self):
+        # A handful of infinities leaves the pooled median finite, so the fold
+        # is well defined and all three helpers return finite values.
+        draws = np.asarray(
+            jax.random.normal(self.rng, shape=(4, 64)), dtype=np.float32
+        ).copy()
+        draws.reshape(-1)[:8] = np.inf
+        x = jnp.asarray(draws)
+        assert np.isfinite(float(diagnostics.rhat(x)))
+        assert np.isfinite(float(diagnostics.ess_bulk(x)))
+
+    def test_majority_infinity_makes_rhat_nan_without_any_nan_input(self):
+        # Pins a KNOWN limitation rather than a desired behaviour: rhat folds
+        # about the pooled median, so when >= half of a component's pooled
+        # draws are +inf the median is inf and the fold computes inf - inf.
+        # rhat is then NaN for input containing no NaN at all, while ess_bulk
+        # and ess_tail stay finite.  NaN from rhat therefore does not uniquely
+        # mean "missing observation".  Infinity handling is an open question.
+        draws = np.asarray(
+            jax.random.normal(self.rng, shape=(4, 64)), dtype=np.float32
+        ).copy()
+        draws[:, :40] = np.inf
+        x = jnp.asarray(draws)
+        assert not np.isnan(draws).any(), "fixture must contain no NaN"
+        assert np.isnan(float(diagnostics.rhat(x)))
+        assert np.isfinite(float(diagnostics.ess_bulk(x)))
+        assert np.isfinite(float(diagnostics.ess_tail(x)))
+
+    def test_nan_in_a_trimmed_odd_draw_is_not_seen(self):
+        # Pins the exact scope of the NaN contract.  With an odd number of
+        # draws _split_chains trims the last one, so a NaN sitting only there
+        # is never used and the diagnostics stay finite.  A NaN among the
+        # draws actually used propagates as normal.
+        base = np.asarray(
+            jax.random.normal(self.rng, shape=(4, 65)), dtype=np.float64
+        ).copy()
+        trimmed = base.copy()
+        trimmed[1, 64] = np.nan
+        assert np.isfinite(float(diagnostics.ess_bulk(jnp.asarray(trimmed))))
+        used = base.copy()
+        used[1, 3] = np.nan
+        assert np.isnan(float(diagnostics.ess_bulk(jnp.asarray(used))))
 
     def test_raw_effective_sample_size_semantics_are_unchanged(self):
         # The raw estimator is deliberately untouched by the NaN extension:
@@ -778,22 +874,42 @@ class RankNormalizeTiesTest(chex.TestCase):
         np.testing.assert_allclose(bj_rhat, az_rhat, rtol=1e-4)
         np.testing.assert_allclose(bj_ess, az_ess, rtol=1e-3)
 
-    def test_repeated_states_do_not_inflate_rhat(self):
-        # A Metropolis-like trace with an 80% rejection rate repeats states;
-        # those repeats are ties, not chain structure.  Built with NumPy so
-        # the trace itself owes nothing to the code under test.
-        rng = np.random.default_rng(20260906)
-        proposals = rng.normal(size=(4, 512))
-        accepted = rng.uniform(size=(4, 512)) < 0.2
+    def _rejection_trace(self, proposals, accepted):
+        """Carry the last accepted proposal forward — a Metropolis-like trace."""
         draws = np.empty_like(proposals)
         draws[:, 0] = proposals[:, 0]
         for t in range(1, proposals.shape[1]):
             draws[:, t] = np.where(accepted[:, t], proposals[:, t], draws[:, t - 1])
-        assert (draws[:, 1:] == draws[:, :-1]).mean() > 0.5, "trace has too few repeats"
+        return draws
+
+    def test_repeated_discrete_states_do_not_inflate_rhat(self):
+        # An 80%-rejection trace over a 5-level proposal: the repeats form
+        # large, scattered tie groups, which is where ordinal ranking does
+        # real damage.  Measured at 9e128d206 vs the fix: R-hat 1.1404 ->
+        # 1.0291 and bulk ESS 120.57 -> 237.55.
+        rng = np.random.default_rng(20260906)
+        accepted = rng.uniform(size=(4, 512)) < 0.2
+        draws = self._rejection_trace(
+            rng.integers(0, 5, size=(4, 512)).astype(float), accepted
+        )
+        assert (draws[:, 1:] == draws[:, :-1]).mean() > 0.5, "too few repeats"
 
         result = np.asarray(diagnostics.rhat(jnp.asarray(draws, dtype=jnp.float32)))
         expected = _reference_rhat(draws)
         np.testing.assert_allclose(result, expected, rtol=1e-4)
+        assert result < 1.05, f"tied repeats still inflate R-hat: {result}"
+
+    def test_continuous_rejection_trace_matches_the_oracle(self):
+        # The continuous-proposal counterpart.  This one is an oracle-parity
+        # check, NOT a regression guard: rejection repeats in a continuous
+        # chain form short contiguous runs, so ordinal ranking perturbs them
+        # by only ~2e-5 and this assertion passes at 9e128d206 too.
+        rng = np.random.default_rng(20260906)
+        draws = self._rejection_trace(
+            rng.normal(size=(4, 512)), rng.uniform(size=(4, 512)) < 0.2
+        )
+        result = np.asarray(diagnostics.rhat(jnp.asarray(draws, dtype=jnp.float32)))
+        np.testing.assert_allclose(result, _reference_rhat(draws), rtol=1e-4)
 
     def test_folded_tail_component_uses_average_ranks(self):
         # rhat folds about the median before rank-normalizing; the folded
@@ -859,9 +975,13 @@ class RankNormalizeTiesTest(chex.TestCase):
     def test_jit_compatible(self):
         draws = self._tied_draws()
         rank_normalize = self.variant(diagnostics._rank_normalize)
-        np.testing.assert_array_equal(
+        # ndtri is fused differently under XLA, so this is a tolerance
+        # comparison rather than bit equality; the ranks themselves are exact.
+        np.testing.assert_allclose(
             np.asarray(rank_normalize(draws)),
             np.asarray(diagnostics._rank_normalize(draws)),
+            rtol=1e-5,
+            atol=1e-6,
         )
 
     def test_vmap_over_events(self):

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -644,12 +644,99 @@ class RankNormalizeTiesTest(chex.TestCase):
         assert ess[0] == 0.0, f"constant event must report ESS 0, got {ess[0]}"
         assert ess[1] > 0.0, f"varying event must report positive ESS, got {ess[1]}"
 
-    def test_nan_draws_are_tied_with_one_another(self):
-        # NaNs are mutually indistinguishable; ranking them by position would
-        # reintroduce the asymmetry this fix removes.
-        pooled = jnp.array([1.0, jnp.nan, 0.0, jnp.nan, 2.0])
+    # -- NaN is a missing observation, not an ordered tie ----------------
+
+    def _contaminated(self):
+        """Deterministic draws whose component 0 holds one NaN, 1 is clean."""
+        base = np.arange(4 * 64, dtype=np.float64).reshape(4, 64) % 7
+        dirty = base.copy()
+        dirty[1, 5] = np.nan
+        return jnp.asarray(np.stack([dirty, base], axis=-1))
+
+    def test_nan_component_cannot_be_ranked(self):
+        pooled = jnp.array([1.0, jnp.nan, 0.0, 2.0, 0.0])
         ranks = np.asarray(diagnostics._average_ranks(pooled))
-        assert ranks[1] == ranks[3], f"NaNs received different ranks: {ranks}"
+        assert np.all(
+            np.isnan(ranks)
+        ), f"a component holding a missing observation has no ranking: {ranks}"
+
+    def test_nan_does_not_poison_a_finite_sibling_component(self):
+        draws = self._contaminated()
+        ranks = np.asarray(diagnostics._average_ranks(draws.reshape(4 * 64, 2)))
+        assert np.all(np.isnan(ranks[:, 0])), "contaminated component must be NaN"
+        assert np.all(np.isfinite(ranks[:, 1])), "clean sibling must be untouched"
+        # The clean sibling ranks exactly as it would on its own.
+        alone = np.asarray(diagnostics._average_ranks(draws[..., 1].reshape(4 * 64)))
+        np.testing.assert_array_equal(ranks[:, 1], alone)
+
+    @parameterized.parameters("rhat", "ess_bulk", "ess_tail")
+    def test_nan_propagates_per_component(self, name):
+        # A NaN-contaminated series must not report an apparently valid
+        # finite diagnostic, and must not disturb an independent component.
+        draws = self._contaminated()
+        result = np.asarray(getattr(diagnostics, name)(draws))
+        assert np.isnan(
+            result[0]
+        ), f"{name} reported {result[0]} for a NaN-contaminated component"
+        assert np.isfinite(
+            result[1]
+        ), f"{name} poisoned a clean sibling component: {result[1]}"
+        alone = np.asarray(getattr(diagnostics, name)(draws[..., 1]))
+        np.testing.assert_allclose(result[1], alone, rtol=1e-6)
+
+    def test_nan_propagation_survives_jit(self):
+        draws = self._contaminated()
+        for name in ("rhat", "ess_bulk", "ess_tail"):
+            fn = getattr(diagnostics, name)
+            eager = np.asarray(fn(draws))
+            jitted = np.asarray(jax.jit(fn)(draws))
+            np.testing.assert_array_equal(
+                np.isnan(eager),
+                np.isnan(jitted),
+                err_msg=f"{name}: NaN contract differs under jit",
+            )
+            np.testing.assert_allclose(eager[1], jitted[1], rtol=1e-6)
+
+    def test_nan_propagation_is_permutation_invariant(self):
+        # Where the NaN sits in the pool must not matter.
+        base = (np.arange(4 * 64, dtype=np.float64) % 7).reshape(4, 64)
+        results = []
+        for position in ((0, 0), (1, 5), (3, 63)):
+            dirty = base.copy()
+            dirty[position] = np.nan
+            results.append(float(diagnostics.ess_bulk(jnp.asarray(dirty))))
+        assert all(
+            np.isnan(r) for r in results
+        ), f"NaN handling depends on position in the pool: {results}"
+
+    def test_ess_bulk_would_otherwise_invent_a_sample_size(self):
+        # Guards the reason _propagate_nan_components exists: Geyer's
+        # truncation collapses on NaN and tau_hat falls back to its
+        # 1/log10(MN) floor, which manufactures a large finite ESS.
+        all_nan = jnp.full((4, 64), jnp.nan)
+        unguarded = float(diagnostics.effective_sample_size(all_nan))
+        assert np.isfinite(unguarded) and unguarded > 0, (
+            "premise no longer holds: effective_sample_size now propagates NaN"
+            f" on its own (got {unguarded}); the boundary guard may be"
+            " redundant and should be re-reviewed"
+        )
+        assert np.isnan(float(diagnostics.ess_bulk(all_nan)))
+
+    def test_infinities_are_ordered_and_still_ranked(self):
+        # Infinity policy is deliberately out of scope: +/-inf are ordered
+        # values and keep their ranks.
+        pooled = jnp.array([-jnp.inf, 0.0, 0.0, jnp.inf, 1.0])
+        ranks = np.asarray(diagnostics._average_ranks(pooled))
+        np.testing.assert_array_equal(ranks, np.array([1.0, 2.5, 2.5, 5.0, 4.0]))
+
+    def test_raw_effective_sample_size_semantics_are_unchanged(self):
+        # The raw estimator is deliberately untouched by the NaN extension:
+        # its constant-chain and antithetic contracts must still hold.
+        np.testing.assert_array_equal(
+            np.asarray(diagnostics.effective_sample_size(jnp.zeros((4, 64)))), 0.0
+        )
+        antithetic = jnp.tile(jnp.array([-1.0, 1.0]), 256)[None, :]
+        assert float(diagnostics.effective_sample_size(antithetic)) > 512
 
     # -- end-to-end diagnostics -----------------------------------------
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -800,6 +800,10 @@ class RankNormalizeTiesTest(chex.TestCase):
         # rhat is then NaN for input containing no NaN at all, while ess_bulk
         # and ess_tail stay finite.  NaN from rhat therefore does not uniquely
         # mean "missing observation".  Infinity handling is an open question.
+        #
+        # NOTE: this test pins CURRENT behaviour, not a guarantee.  If the
+        # inf-fold is ever fixed, this test must be updated or deleted rather
+        # than treated as a regression — it is green by construction today.
         draws = np.asarray(
             jax.random.normal(self.rng, shape=(4, 64)), dtype=np.float32
         ).copy()

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -669,33 +669,33 @@ class RankNormalizeTiesTest(chex.TestCase):
         alone = np.asarray(diagnostics._average_ranks(draws[..., 1].reshape(4 * 64)))
         np.testing.assert_array_equal(ranks[:, 1], alone)
 
-    @parameterized.parameters("rhat", "ess_bulk", "ess_tail")
-    def test_nan_propagates_per_component(self, name):
-        # A NaN-contaminated series must not report an apparently valid
-        # finite diagnostic, and must not disturb an independent component.
+    # The four public entry points share one contaminated-two-component
+    # fixture: raw ESS plus the three rank helpers, propagation and isolation
+    # in one place rather than one test per helper per property.
+    _ENTRY_POINTS = ("effective_sample_size", "rhat", "ess_bulk", "ess_tail")
+
+    @parameterized.parameters(*_ENTRY_POINTS)
+    def test_nan_propagates_without_poisoning_a_sibling(self, name):
+        fn = getattr(diagnostics, name)
         draws = self._contaminated()
-        result = np.asarray(getattr(diagnostics, name)(draws))
+        result = np.asarray(fn(draws))
         assert np.isnan(
             result[0]
         ), f"{name} reported {result[0]} for a NaN-contaminated component"
-        assert np.isfinite(
-            result[1]
-        ), f"{name} poisoned a clean sibling component: {result[1]}"
-        alone = np.asarray(getattr(diagnostics, name)(draws[..., 1]))
+        # The clean sibling must equal what it would give computed alone.
+        alone = np.asarray(fn(draws[..., 1]))
+        assert np.isfinite(result[1]), f"{name} poisoned a clean sibling"
         np.testing.assert_allclose(result[1], alone, rtol=1e-6)
 
-    def test_nan_propagation_survives_jit(self):
+    @parameterized.parameters(*_ENTRY_POINTS)
+    def test_nan_contract_survives_jit(self, name):
+        fn = getattr(diagnostics, name)
         draws = self._contaminated()
-        for name in ("rhat", "ess_bulk", "ess_tail"):
-            fn = getattr(diagnostics, name)
-            eager = np.asarray(fn(draws))
-            jitted = np.asarray(jax.jit(fn)(draws))
-            np.testing.assert_array_equal(
-                np.isnan(eager),
-                np.isnan(jitted),
-                err_msg=f"{name}: NaN contract differs under jit",
-            )
-            np.testing.assert_allclose(eager[1], jitted[1], rtol=1e-6)
+        eager, jitted = np.asarray(fn(draws)), np.asarray(jax.jit(fn)(draws))
+        np.testing.assert_array_equal(
+            np.isnan(eager), np.isnan(jitted), err_msg=f"{name}: differs under jit"
+        )
+        np.testing.assert_allclose(eager[1], jitted[1], rtol=1e-6)
 
     def test_nan_propagation_is_permutation_invariant(self):
         # Where the NaN sits in the pool must not matter.
@@ -721,7 +721,7 @@ class RankNormalizeTiesTest(chex.TestCase):
     # Axis conventions for a rank-3 (chain, sample, event) array, including
     # genuinely negative arguments — normalising them inside the test would
     # mean a negative-axis regression could never fail it.
-    _AXES_3D = ((0, 1), (1, 0), (-3, -2), (-2, -3), (0, -2), (-3, 1))
+    _AXES_3D = ((0, 1), (-2, -3), (-3, 1))
 
     @parameterized.parameters(*_AXES_3D)
     def test_raw_ess_propagates_nan_on_every_axis_convention(
@@ -742,30 +742,11 @@ class RankNormalizeTiesTest(chex.TestCase):
         assert np.isnan(result[0]), f"contaminated component reported {result[0]}"
         assert np.isfinite(result[1]), f"clean sibling poisoned: {result[1]}"
 
-    def test_raw_ess_nan_does_not_poison_a_finite_sibling(self):
-        draws = self._contaminated()
-        result = np.asarray(diagnostics.effective_sample_size(draws))
-        alone = np.asarray(diagnostics.effective_sample_size(draws[..., 1]))
-        assert np.isnan(result[0])
-        np.testing.assert_array_equal(result[1], alone)
-
-    def test_raw_ess_nan_propagation_survives_jit(self):
-        draws = self._contaminated()
-        eager = np.asarray(diagnostics.effective_sample_size(draws))
-        jitted = np.asarray(jax.jit(diagnostics.effective_sample_size)(draws))
-        np.testing.assert_array_equal(np.isnan(eager), np.isnan(jitted))
-        np.testing.assert_allclose(eager[1], jitted[1], rtol=1e-6)
-
-    @parameterized.parameters(
-        (4, 64),
-        (4, 64, 1),
-        (4, 64, 2),
-        (4, 64, 1, 2),
-        (4, 64, 3, 1),
-        (4, 64, 1, 1),
-        (1, 64, 3),
-        (4, 64, 2, 3),
-    )
+    # (4, 64, 1), (4, 64, 1, 2) and (4, 64, 3, 1) are the shapes that actually
+    # regressed; (4, 64, 3, 1) is the one that distinguishes the broadcasting
+    # bug, where ess_bulk came back as (3, 3) instead of (3,).  Do not swap it
+    # for a scalar-only shape.
+    @parameterized.parameters((4, 64), (4, 64, 1), (4, 64, 1, 2), (4, 64, 3, 1))
     def test_nan_guards_preserve_output_shape(self, *shape):
         # The NaN guards must not change the shape contract.  A mask that
         # keeps size-1 event axes broadcasts against the estimators' squeezed
@@ -849,9 +830,6 @@ class RankNormalizeTiesTest(chex.TestCase):
         result = np.asarray(diagnostics.rhat(draws))
         expected = _reference_rhat(np.asarray(draws, dtype=np.float64))
         np.testing.assert_allclose(result, expected, rtol=1e-5)
-        assert np.all(
-            result < 1.01
-        ), f"iid Bernoulli draws must not look non-converged, got {result}"
 
     def test_binary_draws_bulk_ess_is_not_collapsed(self):
         # Ordinal ranking collapsed bulk ESS for these draws to ~1% of N.
@@ -901,7 +879,6 @@ class RankNormalizeTiesTest(chex.TestCase):
         result = np.asarray(diagnostics.rhat(jnp.asarray(draws, dtype=jnp.float32)))
         expected = _reference_rhat(draws)
         np.testing.assert_allclose(result, expected, rtol=1e-4)
-        assert result < 1.05, f"tied repeats still inflate R-hat: {result}"
 
     def test_continuous_rejection_trace_matches_the_oracle(self):
         # The continuous-proposal counterpart.  This one is an oracle-parity


### PR DESCRIPTION
## The defect

`_rank_normalize` ranked the pooled `nchains * nsamples` draws with a double
`argsort`. That is an *ordinal* ranking: equal values receive different ranks
according to where they happen to sit in the pooled array. Ties are then no
longer exchangeable, and the rank-normalized diagnostics read the resulting
position dependence as chain/time structure.

Ties are not exotic in MCMC output. Rejections repeat the previous state,
indicator/binary observables take two values, and discrete parameters take
few. On iid `Bernoulli(0.1)` draws of shape `(8 chains, 96 draws, 2 events)`:

| | `rhat` | `ess_bulk` (of N = 768) |
|---|---|---|
| before | 1.7594 / 1.6548 | 12.24 / 13.18 |
| after | 0.99859 / 1.00023 | 889.21 / 741.96 |
| ArviZ `method="rank"` / `method="bulk"` | 0.99859 / 1.00023 | 889.21 / 741.96 |

A constant input was worse than wrong: rank normalization turned it into an
artificial *non-constant* sequence, so it reported `rhat = 7.0699` and a
positive `ess_bulk`, sailing straight past `effective_sample_size`'s
zero-variance guard.

The defect was first reproduced independently: a NumPy reimplementation of the
ordinal-rank formula reproduces the "before" column exactly, which locates the
bug in the ranking rather than in the surrounding estimators.

## The fix

`_average_ranks` gives every tie group the mean of the ordinal ranks it spans,
matching Vehtari et al. (2021), `scipy.stats.rankdata(method="average")` and
ArviZ. It is built from `argsort` + `take_along_axis` +
`jax.lax.cummax`/`cummin(reverse=True)` — sort and cumulative-reduction
primitives only, so it stays `jit`/`vmap`-compatible with no data-dependent
shapes, at the same asymptotic cost as the double argsort it replaces.

Consequences worth calling out:

- **Rank normalization is now exactly permutation-invariant.** Permuting the
  pool and inverting the permutation reproduces the scores bit-for-bit.
- **Untied draws are unaffected.** With distinct values the average rank *is*
  the ordinal rank, so continuous-target behaviour is unchanged.
- **A constant input maps to a constant field of zeros.** `rhat` is then 0/0 —
  undefined, as it should be — and `ess_bulk` returns `0` through the existing
  degeneracy guard. This deliberately keeps BlackJAX's convention rather than
  ArviZ's `ESS = N` for constants; a variable with no variation carries no
  information, and BlackJAX already reports that as 0 in
  `effective_sample_size`.
- **No ESS cap was introduced.** An antithetic sequence can validly exceed N,
  and a regression test asserts it still does. That assertion is *red* before
  this change, because ordinal ranking destroyed the antithetic structure.
- **NaN now propagates, per component** (see below).

## NaN is a missing observation, not an ordered tie

Averaging ties fixed the ranking but left a second way for these diagnostics to
report an apparently valid finite number for a series that contains missing
data. Three separate mechanisms hid the contamination:

| input | before | mechanism |
|---|---|---|
| `effective_sample_size`, all-NaN `(4, 64)` | **616.51** | Geyer's initial-positive-sequence truncation gates on partial autocorrelation sums being `> 0`; every such comparison is `False` for NaN, so the truncation collapses and `tau_hat` falls back to its `1/log10(MN)` floor |
| `ess_bulk`, one NaN draw | **191.37** | as above |
| `ess_tail`, one NaN draw | **0.0** | NaN pooled quantiles make every indicator comparison `False`, and the resulting all-zero series is degenerate |
| `rhat`, one NaN draw | NaN | correct, but only by accident — via the folded component's median, not by any decision about missing data |

A NaN is a missing or invalid observation, not an ordered value that could be
tied with anything, so a component containing one has no ranking:
`_average_ranks` returns NaN for it, reducing over axis 0 alone.
`_propagate_nan_components` then makes the contract explicit at the `ess_bulk`
and `ess_tail` boundary, reducing over the chain and draw axes alone, because
the estimators downstream demonstrably do not propagate on their own. `rhat`
propagates through the ranking itself.

**A contaminated component never poisons a finite sibling.** On a two-component
stack with a single NaN in component 0, `rhat`, `ess_bulk` and `ess_tail` each
return `[nan, x]` where `x` is bit-identical to computing that component alone.

Two deliberate scope boundaries, both asserted by tests so they fail loudly
rather than rot:

- **Raw `effective_sample_size` is untouched** and still returns 616.51 for an
  all-NaN input. Its constant-chain and antithetic contracts are load-bearing
  elsewhere, so changing it is a wider decision than this PR should make.
  `test_ess_bulk_would_otherwise_invent_a_sample_size` asserts that premise, so
  if the raw estimator ever starts propagating on its own the boundary guard
  gets re-reviewed instead of quietly becoming redundant. **Flagging it here as
  a separate defect worth its own decision.**
- **Infinity policy is out of scope.** Infinities are ordered values and rank
  normally; the implementation keeps the two cases separable.

## Tests

`RankNormalizeTiesTest` adds 36 cases, 17 of which are red at `9e128d206` and
green here. The oracles are independent of the implementation under test:

- an O(n²) pairwise-counting formula, `rank(v) = (1 + #{x < v} + #{x ≤ v}) / 2`;
- a NumPy reimplementation of the entire bulk + folded-tail R̂ pipeline;
- `scipy.stats.rankdata` and ArviZ as third-party cross-checks
  (ArviZ via `importorskip`, matching the existing calibration tests).

Coverage: agreement with each oracle, equal scores for tied values, exact
invariance under a pooled permutation and its inverse, unchanged ordinal ranks
when no ties exist, constant input → zero / undefined R̂ / ESS 0, per-event
degeneracy on a mixed constant-and-varying stack, NaN grouping, the folded tail
component, repeated states from an 80%-rejection Metropolis-like trace, integer
draws, all four chain/sample axis conventions including negatives, dtype
preservation, `jit`, and `vmap`.

For the NaN contract: per-component propagation across all three diagnostics,
non-poisoning of a finite sibling, eager/`jit` parity, invariance to where the
NaN sits in the pool, the premise guard above, infinities still ranked, and the
raw estimator's constant and antithetic semantics unchanged.

## Verification

```
JAX_PLATFORM_NAME=cpu uv run pytest tests/test_diagnostics.py -q --benchmark-disable
230 passed, 11 skipped
```

The 11 skips are the pre-existing `arviz`-gated calibration tests (`arviz` is
not installed in this environment); the new ArviZ cross-check skips with them.

`black` 23.1.0, `isort` 5.12.0 and `flake8` 6.0.0 at their pinned versions are
clean on both files, and `mypy` 1.0.1 reports no error in `diagnostics.py`.

Two independent tooling notes, worth separating:

1. **The style gate is interpreter-sensitive.** The pinned `flake8` 6.0.0 called
   the same way reports this branch clean under Python 3.11 and *fails* under
   Python 3.13 — PEP 701 tokenizes f-string contents from 3.12 on, so a
   semicolon inside an f-string becomes a real token and trips `E702`. CI runs
   3.13, so a 3.11 pre-flight is not a valid substitute. The matching command
   is `uvx --python 3.13 --from flake8==6.0.0 flake8
   --ignore=E501,E203,E302,E402,E731,W503,E221,E222 <files>`.
2. **Separately**, `uv run pre-commit run --all-files` fails locally inside its
   own hook environments on files unrelated to this branch: the pinned
   `pyupgrade`/`flake8`/`black`/`mypy` hooks break under Python 3.14 with
   `AttributeError: module 'ast' has no attribute 'Str'`. That predates this
   branch and is documented rather than worked around — no hook environment or
   dependency pin was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTjn8PpUvUQnAHyjLF2h3R
