### PR TITLE
Add coupled HMC: two marginals sharing their random inputs

### DIFF
--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -530,19 +530,18 @@ def whitened_difference(
     first_state: hmc.HMCState,
     second_state: hmc.HMCState,
     first_metric: metrics.Metric,
-    second_metric: metrics.Metric,
 ) -> Array:
     """Default reflection direction: the position difference, whitened.
 
     Returns :math:`A^{-1}(x_1 - x_2)` in flat coordinates, where :math:`A` is
-    the **first** marginal's momentum square root.  ``Metric.scale`` with
+    the first marginal's momentum square root.  ``Metric.scale`` with
     ``inv=True, trans=True`` is exactly that inverse map.
 
-    The second marginal's metric is accepted for signature completeness and
-    deliberately unused: when the two marginals carry different metrics this
-    direction is first-metric-based, and no property is claimed for the pair.
+    Only the first marginal's metric is used.  When the two marginals carry
+    different metrics this is therefore a first-metric-based direction, and no
+    property is claimed for the pair.  A policy needing the second metric can
+    close over it.
     """
-    del second_metric
     delta = jax.tree.map(
         lambda a, b: a - b, first_state.position, second_state.position
     )
@@ -585,7 +584,7 @@ def _build_prescribed_pair(
         integrator,
         divergence_threshold,
     )
-    second_metric, second_step = _build_prescribed_marginal(
+    _, second_step = _build_prescribed_marginal(
         logdensity_fns[1],
         inverse_mass_matrices[1],
         step_sizes[1],
@@ -602,7 +601,7 @@ def _build_prescribed_pair(
 
         if coupling == "reflection":
             direction = jnp.asarray(
-                direction_fn(state.first, state.second, first_metric, second_metric)
+                direction_fn(state.first, state.second, first_metric)
             )
             if direction.shape != flat.shape:
                 raise ValueError(
@@ -692,8 +691,8 @@ def build_kernel(
         reflected copy.
     direction_fn
         Only for ``"reflection"``.  A callable
-        ``(first_state, second_state, first_metric, second_metric) -> Array``
-        returning a flat direction; defaults to :func:`whitened_difference`.
+        ``(first_state, second_state, first_metric) -> Array`` returning a
+        flat direction; defaults to :func:`whitened_difference`.
         Passing one under synchronous coupling is an error, since it would
         have no effect.
 
@@ -761,7 +760,6 @@ def as_top_level_api(
     direction_fn: Callable | None = None,
     integrator: Callable = integrators.velocity_verlet,
     divergence_threshold: float = 1000,
-    validate: bool = True,
 ) -> SamplingAlgorithm:
     """Build a ``SamplingAlgorithm`` for a coupled HMC pair.
 
@@ -795,12 +793,15 @@ def as_top_level_api(
         Symplectic integrator used by both marginals.
     divergence_threshold
         Per-marginal divergence threshold.
-    validate
-        When true (the default), each marginal's concrete metric and
-        integration settings are checked eagerly by
-        :func:`validate_marginal_inputs`.  Those checks read concrete values
-        on the host and so cover the arguments given here; they say nothing
-        about traced values appearing later under ``jit`` or ``vmap``.
+
+    Notes
+    -----
+    Each marginal's concrete metric and integration settings are checked here
+    by :func:`validate_marginal_inputs`.  Those checks read concrete values on
+    the host, so they cover the arguments given here and say nothing about
+    traced values appearing later under ``jit`` or ``vmap``.  Callers who need
+    to supply traced metrics use :func:`build_kernel` directly, which performs
+    no eager numerical validation.
 
     Returns
     -------
@@ -812,13 +813,12 @@ def as_top_level_api(
     integration_steps = _as_pair(num_integration_steps, "num_integration_steps")
     _as_pair(logdensity_fn, "logdensity_fn")
 
-    if validate:
-        for index in (0, 1):
-            validate_marginal_inputs(
-                inverse_mass_matrices[index],
-                step_sizes[index],
-                integration_steps[index],
-            )
+    for index in (0, 1):
+        validate_marginal_inputs(
+            inverse_mass_matrices[index],
+            step_sizes[index],
+            integration_steps[index],
+        )
 
     kernel = build_kernel(
         integrator,

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -291,7 +291,11 @@ def _check_paired_positions(first_position, second_position) -> None:
     # each chain and so does not mean the same thing to both.
     first_leaves = jax.tree.leaves(first_position)
     second_leaves = jax.tree.leaves(second_position)
-    for index, (first_leaf, second_leaf) in enumerate(zip(first_leaves, second_leaves)):
+    # `strict=True` states the dependence on the structure check above, which is
+    # what guarantees the two leaf lists have equal length.
+    for index, (first_leaf, second_leaf) in enumerate(
+        zip(first_leaves, second_leaves, strict=True)
+    ):
         if jnp.shape(first_leaf) != jnp.shape(second_leaf):
             raise ValueError(
                 "paired positions must have matching leaf shapes, leaf "
@@ -316,14 +320,38 @@ def _declared_dtype(value):
     weakly typed, exactly as elsewhere in JAX, so it is adopted into the
     position dtype rather than refused.
     """
+    if getattr(value, "weak_type", False):
+        # JAX's own weak-typing flag. A weakly typed array is adopted into the
+        # surrounding dtype everywhere else in JAX, so refusing it here would
+        # contradict the convention this function claims to follow.
+        return None
     dtype = getattr(value, "dtype", None)
     return None if dtype is None else np.dtype(dtype)
 
 
 def _declared_shape(value):
-    """The shape the value declares, treating a bare Python scalar as ``()``."""
-    shape = getattr(value, "shape", None)
-    return () if shape is None else tuple(shape)
+    """The shape of the value as given, without converting it.
+
+    ``np.shape`` rather than a ``.shape`` attribute lookup: the attribute is
+    absent on a plain Python list, which would then be reported as a scalar,
+    slip past the shape check, and fail later inside ``float()`` with a message
+    that never names the argument.
+    """
+    return tuple(np.shape(value))
+
+
+def _metric_dimension(inverse_mass_matrix):
+    """The dimension the metric is defined on, from static shapes only.
+
+    Read from shapes rather than values, so it is safe on tracers. Returns
+    ``None`` when the shape is not one of the supported forms, leaving the
+    existing kind checks to speak.
+    """
+    if isinstance(inverse_mass_matrix, metrics.LowRankInverseMassMatrix):
+        shape = jnp.shape(inverse_mass_matrix.sigma)
+        return shape[0] if len(shape) == 1 else None
+    shape = jnp.shape(inverse_mass_matrix)
+    return shape[0] if len(shape) in (1, 2) else None
 
 
 def _check_innovations(standard_normal, uniform, flat_position) -> None:
@@ -585,7 +613,9 @@ def _build_prescribed_marginal(
     unchanged; the remainder of the transition is BlackJAX's own trajectory,
     endpoint flip, energy difference and Metropolis test.
     """
-    metric = metrics.default_metric(_check_metric_kind(inverse_mass_matrix))
+    inverse_mass_matrix = _check_metric_kind(inverse_mass_matrix)
+    metric = metrics.default_metric(inverse_mass_matrix)
+    metric_dimension = _metric_dimension(inverse_mass_matrix)
     symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
     generate = hmc.hmc_proposal(
         symplectic_integrator,
@@ -600,6 +630,16 @@ def _build_prescribed_marginal(
         state: hmc.HMCState, standard_normal: Array, uniform: Array
     ) -> tuple[hmc.HMCState, hmc.HMCInfo]:
         flat, unravel = _flat_position(state.position)
+        # A metric of the wrong dimension does not necessarily fail: a
+        # length-one diagonal broadcasts silently across any position, so one
+        # marginal could run isotropic while its partner runs anisotropic with
+        # nothing said. A mismatched-but-non-broadcasting length fails much
+        # later, in a message naming neither the metric nor which marginal.
+        if metric_dimension is not None and flat.shape[0] != metric_dimension:
+            raise ValueError(
+                "the inverse mass matrix must have the same dimension as the "
+                f"position, got {metric_dimension}, expected {flat.shape[0]}"
+            )
         _check_innovations(standard_normal, uniform, flat)
         momentum = metric.scale(
             state.position, unravel(standard_normal), inv=False, trans=False

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -61,10 +61,12 @@ below draw a single :math:`z` and hand each marginal a transformed copy:
 
         z' = z - 2 e (e^\\top z)
 
-    for a unit vector :math:`e`.  Because that map is an orthogonal
-    reflection it preserves :math:`N(0, I)` exactly, so the second marginal's
+    for a unit vector :math:`e`.  That map is an orthogonal reflection, so in
+    exact arithmetic it preserves :math:`N(0, I)` and the second marginal's
     momentum law is unchanged **for any** unit :math:`e` that does not depend
-    on :math:`z`.  That is the whole of what reflection buys here: marginal
+    on :math:`z`.  In floating point the normalisation of :math:`e` carries a
+    rounding error of a few units in the last place, so the preservation is
+    exact in the mathematics and accurate to that tolerance in the code.  That is the whole of what reflection buys here: marginal
     correctness.  It is not a statement about contraction, meeting, or
     coupling quality, and none is made.
 
@@ -281,9 +283,12 @@ def _check_paired_positions(first_position, second_position) -> None:
         )
     # Per-leaf shapes, not merely equal flattened size.  Two positions can share
     # a tree structure and a total size while splitting it differently -- say
-    # {"a": (2,), "b": (3,)} against {"a": (3,), "b": (2,)} -- and then the one
-    # shared flat innovation is unravelled across different leaf boundaries in
-    # each marginal, so "the same z" silently means two different things.
+    # {"a": (2,), "b": (3,)} against {"a": (3,), "b": (2,)}.  This enforces the
+    # documented contract that the pair has matching leaf shapes.  Each marginal
+    # would still be individually valid in that situation, since each unravels
+    # the flat innovation consistently with its own position; what breaks is the
+    # pairing, because the shared vector lands on different leaf boundaries in
+    # each chain and so does not mean the same thing to both.
     first_leaves = jax.tree.leaves(first_position)
     second_leaves = jax.tree.leaves(second_position)
     for index, (first_leaf, second_leaf) in enumerate(zip(first_leaves, second_leaves)):
@@ -727,8 +732,12 @@ def _build_prescribed_pair(
                     f"position, got {direction.shape}, expected {flat.shape}"
                 )
             if direction.dtype != flat.dtype:
+                # Name the likely cause rather than only the messenger: with
+                # the default direction this mismatch comes from a metric whose
+                # dtype differs from the position's, not from anything the
+                # caller wrote.
                 raise TypeError(
-                    "`direction_fn` must return the position dtype, got "
+                    "the reflection direction must have the position dtype, got "
                     f"{direction.dtype}, expected {flat.dtype}"
                 )
             unit = _reflection_unit(direction)

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -216,7 +216,11 @@ def _as_pair(value, name: str) -> tuple:
     Nothing is broadcast: a value shared by both marginals must be written
     ``(value, value)``.  Positions, metrics and step sizes can themselves be
     tuples, so inferring a pair from a bare value would be ambiguous exactly
-    where the mistake is most costly.
+    where the mistake is most costly -- and the cost is silent.  A bare dense
+    ``(d, d)`` inverse mass matrix, if it were unpacked as a pair, would index
+    to its first two ROWS: the first marginal would run with row 0 as a
+    *diagonal* metric and the second with row 1.  The shapes are plausible, the
+    run completes, and the results are wrong with nothing raised anywhere.
     """
     if isinstance(value, tuple) and len(value) == 2:
         return value
@@ -682,8 +686,15 @@ def _reflection_unit(direction: Array) -> Array:
 
     The direction is first divided by its largest absolute entry, so a
     direction whose norm would overflow or underflow in the working dtype is
-    still normalised correctly.  A direction that is exactly zero is returned
-    as zero, which makes the reflection the identity map.
+    still normalised correctly.  This is load-bearing rather than defensive, and
+    the failure it prevents is silent.  At float32 -- BlackJAX's default -- a
+    difference like ``[1e20, -2e20, 5e19, 3e20]`` has a norm that overflows, so
+    a naive ``d / norm(d)`` yields exactly zero: the reflection would quietly
+    become the identity and the pair would report ``reflection_unit = 0`` while
+    running synchronous coupling under a reflection label.  The mirrored
+    underflow case yields infinities.  Both are reachable for a diverging chain.
+    A direction that is exactly zero is returned as zero, which makes the
+    reflection the identity map -- that case is intended and documented.
 
     A direction containing a non-finite entry propagates as non-finite rather
     than silently producing a plausible-looking unit vector.

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -71,10 +71,12 @@ below draw a single :math:`z` and hand each marginal a transformed copy:
     coupling quality, and none is made.
 
     ``e`` comes from ``direction_fn``, which is fixed when the kernel is
-    built and is evaluated on the *incoming* pair of states, before any
-    randomness for the transition is drawn and without being given any of it.
-    Supplying a ``direction_fn`` that is a pure function of its arguments is
-    the caller's part of the contract.  The default direction is the
+    built and is applied to the *incoming* pair of states.  It is given the two
+    states and the first metric, and no innovations.  Note that this is a
+    statement about its arguments, not about ordering: the kernel draws ``z``
+    and the uniform first and only then runs the transition that evaluates
+    ``direction_fn``.  Supplying a ``direction_fn`` that is a pure function of
+    its arguments is the caller's part of the contract.  The default direction is the
     difference of the two positions whitened by the **first** marginal's
     metric, :math:`e \\propto A^{-1}(x_1 - x_2)`.  That particular choice is a
     heuristic: it is the direction along which, to leading order, the two
@@ -257,7 +259,26 @@ def _check_metric_kind(inverse_mass_matrix):
 
 
 def _flat_position(position: ArrayLikeTree) -> tuple[Array, Callable]:
-    """Flatten a position, requiring one nonempty real floating dtype."""
+    """Flatten a position, requiring one nonempty real floating dtype.
+
+    The dtype compared here is the **effective** one -- what the leaf becomes
+    once JAX has it, via ``jnp.asarray`` -- not the dtype the caller's object
+    declares.  That is deliberate and is the opposite choice from
+    :func:`_check_innovations`, so the difference is worth stating.
+
+    A position is the thing everything else is measured against, and
+    ``ravel_pytree`` will convert its leaves regardless, so what matters is the
+    dtype they end up with.  Under JAX's default configuration a float64 leaf
+    becomes float32, and a position mixing float64 and float32 leaves is
+    therefore accepted: after conversion they genuinely agree, and there is no
+    later step at which they could disagree.
+
+    An innovation is a different case.  There the caller supplies a value that
+    is compared against an acceptance probability, so narrowing it silently
+    changes the number the Metropolis test uses.  :func:`_check_innovations`
+    consequently inspects the *declared* dtype and refuses a mismatch instead
+    of converting.  Neither function promises both notions at once.
+    """
     leaves = jax.tree.leaves(position)
     if not leaves:
         raise TypeError("positions must have at least one array leaf")
@@ -305,6 +326,8 @@ def _check_paired_positions(first_position, second_position) -> None:
     second_flat, _ = _flat_position(second_position)
     # No separate flat-shape check: equal tree structure with equal per-leaf
     # shapes already implies equal flattened shape.
+    # Effective dtype, per `_flat_position`: this compares what the positions
+    # become in the computation, not what the caller's objects declared.
     if first_flat.dtype != second_flat.dtype:
         raise TypeError(
             "paired positions must have matching floating dtypes, got "
@@ -363,17 +386,12 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
     comparing dtypes afterwards compares two values that already agree and
     checks nothing.
 
-    Narrowing an innovation is not cosmetic.  A float64 uniform strictly below
-    one becomes exactly ``1.0`` in float32, which then fails ``uniform <
-    p_accept`` even when ``p_accept`` is one, silently turning a certain
-    acceptance into a rejection; and a float64 uniform anywhere in range
-    becomes a *different* float32, so the Metropolis test would use a value the
-    caller never supplied.
-
-    An array that declares a dtype must therefore match the position exactly.
-    A bare Python scalar declares none, is weakly typed, and is adopted -- so
-    for those the domain is checked on the value **as it will be used**, after
-    conversion, which is where a bad Python float would otherwise slip past.
+    Narrowing is not cosmetic: a float64 uniform below one becomes exactly
+    ``1.0`` in float32 and then rejects a certain acceptance, and one in range
+    becomes a *different* float32, so the test would use a value the caller
+    never gave.  An array declaring a dtype must match the position exactly; a
+    bare Python scalar declares none, is weakly typed and is adopted, so its
+    domain is checked after conversion instead.
     """
     if _declared_shape(standard_normal) != flat_position.shape:
         raise ValueError(
@@ -420,12 +438,10 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
 def _concrete_real_scalar(value, name: str) -> float:
     """Read a concrete real scalar, accepting the array forms BlackJAX produces.
 
-    Warmup returns a step size as a zero-dimensional JAX array rather than a
-    Python float, and NumPy scalars are just as ordinary, so all of those are
-    accepted here: requiring callers to hand-cast routine BlackJAX output would
-    be a gratuitous obstacle.  Booleans, complex values, non-scalars and
-    non-finite values are still refused, and so are tracers -- this reads the
-    value, which is only possible when it is concrete.
+    Warmup returns a step size as a zero-dimensional JAX array, so requiring a
+    Python float would force callers to hand-cast routine BlackJAX output.
+    Booleans, complex values, non-scalars, non-finite values and tracers are
+    still refused.
     """
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
@@ -452,11 +468,11 @@ def _concrete_real_scalar(value, name: str) -> float:
 def _concrete_integer_scalar(value, name: str) -> int:
     """Read a concrete integer scalar, accepting NumPy and JAX scalar forms.
 
-    A floating value is refused here rather than left to fail later.  It would
-    not be silently truncated in any case -- ``fori_loop`` rejects a float bound
-    -- but it does so with a message about loop bound types that never names the
-    parameter, and only once a trajectory is being built.  Refusing it at the
-    validation boundary is a diagnostic improvement, not a correctness guard.
+    A floating value is refused here rather than left to fail later. Nothing
+    truncates it -- ``fori_loop`` rejects a float bound -- but it does so with a
+    message about loop bound types that never names the parameter, and only
+    once a trajectory is being built. This is a diagnostic improvement, not a
+    correctness guard.
     """
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
@@ -724,11 +740,11 @@ def _build_prescribed_pair(
     function, which is what makes the coupling separately checkable without
     also reasoning about key splitting.  It is internal to this module.
 
-    The reflection direction is measured here, and this function passes
-    ``direction_fn`` nothing but the incoming states and the first metric: the
-    innovations are not among its arguments.  Whether the returned direction is
-    genuinely free of them is a contract the caller keeps, since a callable may
-    close over anything.
+    This function passes ``direction_fn`` nothing but the incoming states and
+    the first metric -- the innovations it receives are not among its
+    arguments, though they do already exist by the time it is called. Whether
+    the returned direction is genuinely free of them is a contract the caller
+    keeps, since a callable may close over anything.
     """
     logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
     step_sizes = _as_pair(step_size, "step_size")
@@ -835,16 +851,18 @@ def build_kernel(
     """Build a coupled HMC kernel.
 
     ``coupling`` and ``direction_fn`` are fixed here, when the kernel is
-    built, and not at call time.  The kernel evaluates ``direction_fn`` on the
-    pair of incoming states before drawing any randomness for the transition,
-    and supplies it no innovations.
+    built, and not at call time.  ``direction_fn`` is applied to the pair of
+    incoming states and the first metric, and is supplied no innovations.
 
-    That is a statement about what this API hands over, not a guarantee about
-    what a caller's callable does.  A ``direction_fn`` that closes over
-    innovations, or draws its own randomness, breaks the reflection's marginal
-    correctness, and nothing here can detect it.  Keeping it a pure function of
-    the arguments it is given is the caller's part of the contract -- the same
-    purity convention every BlackJAX kernel already assumes.
+    It is worth being exact about what that does and does not say, because an
+    earlier version of this docstring overstated it.  The kernel draws ``z``
+    and the uniform *before* running the transition in which ``direction_fn``
+    is evaluated, so the guarantee is **not** one of ordering.  It is that the
+    innovations are not among the arguments handed over.  A ``direction_fn``
+    that closes over innovations, or draws its own randomness, breaks the
+    reflection's marginal correctness and nothing here can detect it. Keeping
+    it a pure function of the arguments it is given is the caller's part of the
+    contract -- the same purity convention every BlackJAX kernel assumes.
 
     Parameters
     ----------

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -320,6 +320,22 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
             "`uniform` dtype must match the position dtype exactly (no "
             f"narrowing); got {uniform.dtype}, expected {flat_position.dtype}"
         )
+    # A uniform outside [0, 1) is refused, never clipped and never allowed to
+    # masquerade as an ordinary Metropolis rejection.  The value can only be
+    # read when it is concrete, so under `jit` or `vmap` this remains a
+    # documented precondition rather than a check.
+    if not isinstance(uniform, jax.core.Tracer):
+        value = float(uniform)
+        if not 0.0 <= value < 1.0:
+            raise ValueError(
+                f"`uniform` must lie in [0, 1); got {value!r}. It is not "
+                "clipped, because a clipped uniform would silently become an "
+                "ordinary rejection."
+            )
+    if not isinstance(standard_normal, jax.core.Tracer) and not bool(
+        jnp.all(jnp.isfinite(standard_normal))
+    ):
+        raise ValueError("`standard_normal` must be finite")
 
 
 def validate_marginal_inputs(inverse_mass_matrix, step_size, num_integration_steps):

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -1,0 +1,797 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Two HMC chains advanced from a shared source of randomness.
+
+This module runs two ordinary HMC marginals side by side and couples them
+*only through their random inputs*: the standard normal that becomes each
+momentum, and the single uniform that drives each Metropolis test.
+
+.. warning::
+
+    The scope of what is implemented here is deliberately narrow.  This
+    module provides a **coupling of the random inputs**.  It makes no claim
+    that the pair is invariant for the product of the two targets, that the
+    chains meet (exactly, maximally, or at all), that any estimator built
+    from the pair is unbiased, or that coupling improves sampling efficiency
+    in any sense.  None of those properties is implemented or tested.
+
+The contract
+------------
+
+The one property this module does assert, and test, is:
+
+    Coupling changes only the *joint law* of the two marginals' random
+    inputs.  It never changes either marginal's transition function, its
+    Metropolis decision rule, or its cached log-density and gradient.
+
+Concretely, given the same ``(state, standard_normal, uniform)`` triple, each
+marginal here performs exactly the transition an uncoupled HMC marginal built
+from the same target, metric, step size and integration count would perform,
+and returns exactly the same state and info.  The two marginals share a
+uniform but each compares it against **its own** acceptance probability, so a
+shared uniform is emphatically *not* a shared decision.  Each marginal carries
+its own ``logdensity``/``logdensity_grad`` cache.
+
+Mathematical semantics
+----------------------
+
+Write :math:`M` for a marginal's mass matrix and :math:`A` for the momentum
+square root BlackJAX uses, so that a momentum drawn as :math:`p = A z` with
+:math:`z \\sim N(0, I)` has covariance :math:`A A^\\top = M`.  Both couplings
+below draw a single :math:`z` and hand each marginal a transformed copy:
+
+``synchronous``
+    Both marginals receive the same :math:`z`.
+
+``reflection``
+    The first marginal receives :math:`z`; the second receives
+
+    .. math::
+
+        z' = z - 2 e (e^\\top z)
+
+    for a unit vector :math:`e`.  Because that map is an orthogonal
+    reflection it preserves :math:`N(0, I)` exactly, so the second marginal's
+    momentum law is unchanged **for any** unit :math:`e` that does not depend
+    on :math:`z`.  That is the whole of what reflection buys here: marginal
+    correctness.  It is not a statement about contraction, meeting, or
+    coupling quality, and none is made.
+
+    ``e`` comes from ``direction_fn``, which is fixed when the kernel is
+    built and is evaluated on the *incoming* pair of states, before any
+    randomness for the transition is drawn.  The default direction is the
+    difference of the two positions whitened by the **first** marginal's
+    metric, :math:`e \\propto A^{-1}(x_1 - x_2)`.  That particular choice is a
+    heuristic: it is the direction along which, to leading order, the two
+    chains' displacements respond oppositely, since the velocity
+    :math:`\\partial K / \\partial p` equals :math:`A^{-\\top} z` and hence
+    :math:`\\langle x_1 - x_2, \\partial K/\\partial p\\rangle = \\langle
+    A^{-1}(x_1 - x_2), z\\rangle`.  When the two marginals use *different*
+    metrics the default still uses the first marginal's metric only; it is
+    then a first-metric-based direction with no claimed property for the
+    pair.  A zero direction is the identity map, i.e. reflection degenerates
+    to synchronous coupling for that transition.
+
+Relation to ``blackjax.hmc``
+----------------------------
+
+Each marginal applies the same *mathematical* Metropolis rule as ordinary
+HMC: accept with probability :math:`\\min(1, e^{\\Delta})`.  It realises that
+rule by comparing a supplied uniform against the acceptance probability,
+whereas :func:`~blackjax.mcmc.proposal.static_binomial_sampling` realises it
+with :func:`jax.random.bernoulli`.  The two agree as distributions and do
+**not** agree draw-for-draw: feeding the same key to this kernel and to
+``blackjax.hmc`` will not reproduce the same accept/reject sequence, and no
+such parity is claimed or tested.
+
+Usage
+-----
+
+There is deliberately no top-level ``blackjax.coupled_hmc``; reach this
+module at ``blackjax.mcmc.coupled_hmc``.  Every per-marginal parameter is
+passed as an explicit ``(first, second)`` pair -- including when both
+marginals share a value, which is written ``(value, value)``.  Nothing is
+broadcast or inferred, because positions, metrics and step sizes may
+themselves legitimately be tuples.
+
+.. code::
+
+    import blackjax.mcmc.coupled_hmc as coupled_hmc
+
+    algorithm = coupled_hmc.as_top_level_api(
+        (logdensity_fn, logdensity_fn),
+        step_size=(0.1, 0.1),
+        inverse_mass_matrix=(inverse_mass_matrix, inverse_mass_matrix),
+        num_integration_steps=(10, 10),
+        coupling="reflection",
+    )
+    state = algorithm.init((position_one, position_two))
+    state, info = algorithm.step(rng_key, state)
+
+"""
+from typing import Callable, NamedTuple, Sequence
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.flatten_util import ravel_pytree
+
+import blackjax.mcmc.hmc as hmc
+import blackjax.mcmc.integrators as integrators
+import blackjax.mcmc.metrics as metrics
+from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.types import Array, ArrayLikeTree, PRNGKey
+
+__all__ = [
+    "CoupledHMCState",
+    "CoupledHMCInfo",
+    "init",
+    "build_kernel",
+    "as_top_level_api",
+    "validate_marginal_inputs",
+]
+
+
+class CoupledHMCState(NamedTuple):
+    """State of a pair of coupled HMC chains.
+
+    The two marginals are held as two complete, independent
+    :class:`~blackjax.mcmc.hmc.HMCState` values, so each carries its own
+    position and its own cached ``logdensity``/``logdensity_grad``.  Keeping
+    them separate makes crossing the two caches an obvious error rather than
+    a silent one -- it does not make it impossible, so the test suite checks
+    it explicitly.
+
+    first
+        State of the first marginal chain.
+    second
+        State of the second marginal chain.
+
+    """
+
+    first: hmc.HMCState
+    second: hmc.HMCState
+
+
+class CoupledHMCInfo(NamedTuple):
+    """Additional information on a coupled HMC transition.
+
+    Both marginals' complete :class:`~blackjax.mcmc.hmc.HMCInfo` objects are
+    preserved untouched, so every per-chain diagnostic (momentum, acceptance
+    rate, acceptance decision, divergence flag, energy, proposal, integration
+    count) stays separately visible.  The remaining three fields describe the
+    shared randomness itself.
+
+    first
+        Transition information for the first marginal.
+    second
+        Transition information for the second marginal.
+    common_normal
+        The flat standard normal vector handed to the first marginal.  The
+        second marginal receives this vector under the coupling map, i.e.
+        unchanged for ``"synchronous"`` and reflected for ``"reflection"``.
+    reflection_unit
+        The unit vector used by the reflection, in the same flat coordinates
+        as ``common_normal``.  Exactly zero under synchronous coupling, and
+        exactly zero for a reflection whose direction was zero (both denote
+        the identity map).
+    uniform
+        The single uniform variate shared by both Metropolis tests.  Each
+        marginal compares it against its own acceptance probability.
+
+    """
+
+    first: hmc.HMCInfo
+    second: hmc.HMCInfo
+    common_normal: Array
+    reflection_unit: Array
+    uniform: float
+
+
+# --------------------------------------------------------------------
+#                       PAIRS AND INPUT CHECKING
+# --------------------------------------------------------------------
+
+
+def _as_pair(value, name: str) -> tuple:
+    """Require an explicit two-element pair.
+
+    Nothing is broadcast: a value shared by both marginals must be written
+    ``(value, value)``.  Positions, metrics and step sizes can themselves be
+    tuples, so inferring a pair from a bare value would be ambiguous exactly
+    where the mistake is most costly.
+    """
+    if isinstance(value, tuple) and len(value) == 2:
+        return value
+    if isinstance(value, list) and len(value) == 2:
+        return tuple(value)
+    raise TypeError(
+        f"`{name}` must be an explicit (first, second) pair; pass "
+        f"`({name}, {name})` when both marginals share a value."
+    )
+
+
+def _check_metric_kind(inverse_mass_matrix):
+    """Reject metric inputs this module does not support, without tracing.
+
+    Only the three array-shaped Euclidean metric payloads are accepted: a
+    one-dimensional diagonal, a two-dimensional dense matrix, and a
+    :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`.  A callable
+    (Riemannian) metric and a pre-built :class:`~blackjax.mcmc.metrics.Metric`
+    are refused rather than assumed valid: the coupling maps momenta through
+    ``Metric.scale``, and that this reproduces ``Metric.sample_momentum``
+    cannot be verified for an opaque or position-dependent metric.
+
+    This is a static type check only.  It performs no array conversion and is
+    safe on tracers; the numerical checks live in
+    :func:`validate_marginal_inputs`.
+    """
+    if isinstance(inverse_mass_matrix, metrics.LowRankInverseMassMatrix):
+        return inverse_mass_matrix
+    if isinstance(inverse_mass_matrix, metrics.Metric):
+        raise TypeError(
+            "coupled_hmc does not accept a pre-built Metric; pass a diagonal "
+            "array, a dense array, or a LowRankInverseMassMatrix."
+        )
+    if callable(inverse_mass_matrix):
+        raise TypeError(
+            "coupled_hmc does not accept a callable (Riemannian) metric; the "
+            "coupling is defined for fixed Gaussian Euclidean metrics only."
+        )
+    return inverse_mass_matrix
+
+
+def _flat_position(position: ArrayLikeTree) -> tuple[Array, Callable]:
+    """Flatten a position, requiring one nonempty real floating dtype."""
+    leaves = jax.tree.leaves(position)
+    if not leaves:
+        raise TypeError("positions must have at least one array leaf")
+    dtypes = {jnp.asarray(leaf).dtype for leaf in leaves}
+    if len(dtypes) != 1:
+        raise TypeError(
+            f"all position leaves must share one floating dtype; got {sorted(map(str, dtypes))}"
+        )
+    flat, unravel = ravel_pytree(position)
+    if not jnp.issubdtype(flat.dtype, jnp.floating) or flat.size == 0:
+        raise TypeError("positions must have nonempty real floating coordinates")
+    return flat, unravel
+
+
+def _check_paired_positions(first_position, second_position) -> None:
+    """Require identical tree structure, leaf shapes and dtype across the pair."""
+    first_structure = jax.tree.structure(first_position)
+    second_structure = jax.tree.structure(second_position)
+    if first_structure != second_structure:
+        raise ValueError(
+            "paired positions must share one pytree structure; got "
+            f"{first_structure} and {second_structure}"
+        )
+    first_flat, _ = _flat_position(first_position)
+    second_flat, _ = _flat_position(second_position)
+    if first_flat.shape != second_flat.shape:
+        raise ValueError(
+            "paired positions must have matching flat shapes; got "
+            f"{first_flat.shape} and {second_flat.shape}"
+        )
+    if first_flat.dtype != second_flat.dtype:
+        raise TypeError(
+            "paired positions must have matching floating dtypes; got "
+            f"{first_flat.dtype} and {second_flat.dtype}"
+        )
+
+
+def _check_innovations(standard_normal, uniform, flat_position) -> None:
+    """Require prescribed innovations to match the position shape and dtype exactly.
+
+    No conversion is performed, on purpose.  Casting a caller's uniform into
+    the position dtype can *narrow* it: a float64 value strictly below one can
+    become exactly ``1.0`` in float32, which then fails ``uniform <
+    p_accept`` even when ``p_accept`` is one, silently turning a certain
+    acceptance into a rejection.  Refusing the mismatch removes that failure
+    mode instead of hiding it.
+    """
+    standard_normal = jnp.asarray(standard_normal)
+    uniform = jnp.asarray(uniform)
+    if standard_normal.shape != flat_position.shape:
+        raise ValueError(
+            "`standard_normal` must be a flat vector matching the position; got "
+            f"{standard_normal.shape}, expected {flat_position.shape}"
+        )
+    if standard_normal.dtype != flat_position.dtype:
+        raise TypeError(
+            "`standard_normal` dtype must match the position dtype exactly "
+            f"(no narrowing); got {standard_normal.dtype}, expected {flat_position.dtype}"
+        )
+    if uniform.shape != ():
+        raise ValueError(f"`uniform` must be a scalar; got shape {uniform.shape}")
+    if uniform.dtype != flat_position.dtype:
+        raise TypeError(
+            "`uniform` dtype must match the position dtype exactly (no "
+            f"narrowing); got {uniform.dtype}, expected {flat_position.dtype}"
+        )
+
+
+def validate_marginal_inputs(inverse_mass_matrix, step_size, num_integration_steps):
+    """Eagerly validate one marginal's concrete metric and integration settings.
+
+    These are host-side numerical checks on *concrete* values: they use NumPy
+    and cannot run on tracers, so they are performed once when an algorithm is
+    constructed and are deliberately absent from the traced kernel.
+
+    .. important::
+
+        Passing this check says the values supplied *now* are admissible.  It
+        says nothing about values that appear later inside a jitted or
+        vmapped computation, which are never seen by this function.  A caller
+        who builds a kernel with :func:`build_kernel` and feeds it traced
+        metrics is responsible for their admissibility.
+
+    Raises
+    ------
+    TypeError, ValueError
+        If the metric is not a supported kind, is not finite, is not positive
+        definite, or the integration settings are not positive and finite.
+
+    """
+    inverse_mass_matrix = _check_metric_kind(inverse_mass_matrix)
+
+    if isinstance(step_size, bool) or not isinstance(step_size, (int, float)):
+        raise TypeError("`step_size` must be a real scalar")
+    if not np.isfinite(step_size) or step_size <= 0:
+        raise ValueError("`step_size` must be positive and finite")
+    if isinstance(num_integration_steps, bool) or not isinstance(
+        num_integration_steps, (int, np.integer)
+    ):
+        raise TypeError("`num_integration_steps` must be an integer")
+    if num_integration_steps <= 0:
+        raise ValueError("`num_integration_steps` must be positive")
+
+    if isinstance(inverse_mass_matrix, metrics.LowRankInverseMassMatrix):
+        sigma, basis, eigenvalues = (np.asarray(x) for x in inverse_mass_matrix)
+        if sigma.ndim != 1 or not sigma.size:
+            raise ValueError("`sigma` must be a nonempty vector")
+        if basis.ndim != 2 or basis.shape[0] != sigma.size:
+            raise ValueError("`U` must have shape (dimension, rank)")
+        if eigenvalues.shape != (basis.shape[1],):
+            raise ValueError("`lam` must have shape (rank,)")
+        arrays = (sigma, basis, eigenvalues)
+        if not all(np.issubdtype(x.dtype, np.floating) for x in arrays):
+            raise TypeError("metric arrays must have real floating dtypes")
+        if not all(np.isfinite(x).all() for x in arrays):
+            raise ValueError("metric arrays must be finite")
+        if np.any(sigma <= 0) or np.any(eigenvalues <= 0):
+            raise ValueError("`sigma` and `lam` must be positive")
+        tolerance = 100 * max(np.finfo(x.dtype).eps for x in arrays)
+        # Columns with an eigenvalue of exactly one are neutral, so only the
+        # active columns need to be orthonormal.
+        active = basis[:, eigenvalues != 1]
+        if active.shape[1] and not np.allclose(
+            active.T @ active,
+            np.eye(active.shape[1]),
+            atol=tolerance,
+            rtol=tolerance,
+        ):
+            raise ValueError(
+                "active `U` columns must be orthonormal; lam=1 columns are neutral"
+            )
+        return
+
+    matrix = np.asarray(inverse_mass_matrix)
+    if not np.issubdtype(matrix.dtype, np.floating):
+        raise TypeError("the inverse mass matrix must have a real floating dtype")
+    if matrix.ndim not in (1, 2) or not matrix.size:
+        raise ValueError(
+            "the inverse mass matrix must be a nonempty vector or square matrix"
+        )
+    if not np.isfinite(matrix).all():
+        raise ValueError("the inverse mass matrix must be finite")
+    if matrix.ndim == 1:
+        if np.any(matrix <= 0):
+            raise ValueError("a diagonal inverse mass matrix must be positive")
+        return
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("a dense inverse mass matrix must be square")
+    # Do not silently symmetrize a caller's kinetic energy.
+    if not np.array_equal(matrix, matrix.T):
+        raise ValueError("a dense inverse mass matrix must be exactly symmetric")
+    try:
+        np.linalg.cholesky(matrix)
+    except np.linalg.LinAlgError as error:
+        raise ValueError(
+            "a dense inverse mass matrix must be positive definite"
+        ) from error
+
+
+# --------------------------------------------------------------------
+#                        THE MARGINAL TRANSITION
+# --------------------------------------------------------------------
+
+
+def _uniform_binomial_sampling(uniform, log_p_accept, proposal, new_proposal):
+    """Accept or reject using a supplied uniform rather than a key.
+
+    This is :func:`~blackjax.mcmc.proposal.static_binomial_sampling` with the
+    Bernoulli draw replaced by a comparison against a uniform the caller
+    provides, which is what lets two marginals share one variate.  The
+    mathematical rule is identical -- accept with probability
+    ``min(1, exp(log_p_accept))`` -- and the realisation is not: it does not
+    reproduce ``jax.random.bernoulli`` draw-for-draw.
+
+    The uniform is required to lie in ``[0, 1)``.  Under that precondition the
+    endpoints behave correctly: ``p_accept == 0`` (including a divergence,
+    where ``log_p_accept`` is ``-inf``) always rejects, and ``p_accept == 1``
+    always accepts.  The value is never clipped, so an out-of-domain uniform
+    is not quietly converted into an ordinary Metropolis rejection.
+    """
+    p_accept = jnp.clip(jnp.exp(log_p_accept), max=1)
+    do_accept = uniform < p_accept
+    info = do_accept, p_accept, log_p_accept
+    return (
+        jax.lax.cond(
+            do_accept,
+            lambda: new_proposal,
+            lambda: proposal,
+        ),
+        info,
+    )
+
+
+def _build_prescribed_marginal(
+    logdensity_fn: Callable,
+    inverse_mass_matrix: metrics.MetricTypes,
+    step_size: float,
+    num_integration_steps: int,
+    integrator: Callable,
+    divergence_threshold: float,
+):
+    """Build one marginal whose randomness is supplied rather than drawn.
+
+    Returns ``(metric, step)`` where
+    ``step(state, standard_normal, uniform) -> (HMCState, HMCInfo)`` is a pure
+    function of its arguments.
+
+    The momentum is obtained as ``metric.scale(position, z, inv=False,
+    trans=False)``, which is precisely the map ``Metric.sample_momentum``
+    applies to a standard normal for the three supported Euclidean metric
+    kinds.  Externalising the draw therefore leaves the marginal momentum law
+    unchanged; the remainder of the transition is BlackJAX's own trajectory,
+    endpoint flip, energy difference and Metropolis test.
+    """
+    metric = metrics.default_metric(_check_metric_kind(inverse_mass_matrix))
+    symplectic_integrator = integrator(logdensity_fn, metric.kinetic_energy)
+    generate = hmc.hmc_proposal(
+        symplectic_integrator,
+        metric.kinetic_energy,
+        step_size,
+        num_integration_steps,
+        divergence_threshold,
+        sample_proposal=_uniform_binomial_sampling,
+    )
+
+    def step(
+        state: hmc.HMCState, standard_normal: Array, uniform: Array
+    ) -> tuple[hmc.HMCState, hmc.HMCInfo]:
+        flat, unravel = _flat_position(state.position)
+        _check_innovations(standard_normal, uniform, flat)
+        momentum = metric.scale(
+            state.position, unravel(standard_normal), inv=False, trans=False
+        )
+        integrator_state = integrators.IntegratorState(
+            state.position, momentum, state.logdensity, state.logdensity_grad
+        )
+        selected, info, _ = generate(uniform, integrator_state)
+        new_state = hmc.HMCState(
+            selected.position, selected.logdensity, selected.logdensity_grad
+        )
+        return new_state, info
+
+    return metric, step
+
+
+# --------------------------------------------------------------------
+#                          THE COUPLING MAPS
+# --------------------------------------------------------------------
+
+
+def _reflection_unit(direction: Array) -> Array:
+    """Normalise a direction robustly; a zero direction gives the identity.
+
+    The direction is first divided by its largest absolute entry, so a
+    direction whose norm would overflow or underflow in the working dtype is
+    still normalised correctly.  A direction that is exactly zero is returned
+    as zero, which makes the reflection the identity map.
+
+    A direction containing a non-finite entry propagates as non-finite rather
+    than silently producing a plausible-looking unit vector.
+    """
+    maximum = jnp.max(jnp.abs(direction))
+    scaled = direction / jnp.where(maximum == 0, 1, maximum)
+    norm = jnp.linalg.norm(scaled)
+    return scaled / jnp.where(norm == 0, 1, norm)
+
+
+def _reflect(standard_normal: Array, unit: Array) -> Array:
+    """Reflect ``standard_normal`` in the hyperplane orthogonal to ``unit``."""
+    return standard_normal - 2 * unit * jnp.dot(unit, standard_normal)
+
+
+def whitened_difference(
+    first_state: hmc.HMCState,
+    second_state: hmc.HMCState,
+    first_metric: metrics.Metric,
+    second_metric: metrics.Metric,
+) -> Array:
+    """Default reflection direction: the position difference, whitened.
+
+    Returns :math:`A^{-1}(x_1 - x_2)` in flat coordinates, where :math:`A` is
+    the **first** marginal's momentum square root.  ``Metric.scale`` with
+    ``inv=True, trans=True`` is exactly that inverse map.
+
+    The second marginal's metric is accepted for signature completeness and
+    deliberately unused: when the two marginals carry different metrics this
+    direction is first-metric-based, and no property is claimed for the pair.
+    """
+    del second_metric
+    delta = jax.tree.map(
+        lambda a, b: a - b, first_state.position, second_state.position
+    )
+    scaled = first_metric.scale(first_state.position, delta, inv=True, trans=True)
+    return ravel_pytree(scaled)[0]
+
+
+# --------------------------------------------------------------------
+#                            PUBLIC API
+# --------------------------------------------------------------------
+
+
+def init(
+    position: Sequence[ArrayLikeTree], logdensity_fn: Sequence[Callable]
+) -> CoupledHMCState:
+    """Initialise a coupled pair.
+
+    Parameters
+    ----------
+    position
+        An explicit ``(first_position, second_position)`` pair.  The two
+        positions must share a pytree structure, leaf shapes and one floating
+        dtype.
+    logdensity_fn
+        An explicit ``(first_logdensity_fn, second_logdensity_fn)`` pair.  The
+        two may target different distributions.
+
+    """
+    positions = _as_pair(position, "position")
+    logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
+    _check_paired_positions(*positions)
+    return CoupledHMCState(
+        hmc.init(positions[0], logdensity_fns[0]),
+        hmc.init(positions[1], logdensity_fns[1]),
+    )
+
+
+def build_kernel(
+    integrator: Callable = integrators.velocity_verlet,
+    divergence_threshold: float = 1000,
+    *,
+    coupling: str = "synchronous",
+    direction_fn: Callable | None = None,
+):
+    """Build a coupled HMC kernel.
+
+    ``coupling`` and ``direction_fn`` are fixed here, when the kernel is
+    built, and not at call time.  The kernel evaluates ``direction_fn`` on the
+    pair of incoming states before drawing any randomness for the transition,
+    so under BlackJAX's ordinary pure-function convention -- kernels take all
+    randomness through their ``rng_key`` argument and hold no hidden state --
+    the direction cannot depend on the innovations it will be used to reflect.
+    That is a property of the data flow here, not something enforceable
+    against an arbitrary Python callable.
+
+    Parameters
+    ----------
+    integrator
+        Symplectic integrator used by both marginals.
+    divergence_threshold
+        Energy difference above which a marginal transition is flagged
+        divergent.  Applied to each marginal separately.
+    coupling
+        ``"synchronous"``, which gives both marginals the same standard
+        normal, or ``"reflection"``, which gives the second marginal a
+        reflected copy.
+    direction_fn
+        Only for ``"reflection"``.  A callable
+        ``(first_state, second_state, first_metric, second_metric) -> Array``
+        returning a flat direction; defaults to :func:`whitened_difference`.
+        Passing one under synchronous coupling is an error, since it would
+        have no effect.
+
+    Returns
+    -------
+    A kernel ``(rng_key, state, logdensity_fn, step_size,
+    inverse_mass_matrix, num_integration_steps) -> (CoupledHMCState,
+    CoupledHMCInfo)`` in which every per-marginal parameter is an explicit
+    ``(first, second)`` pair.
+
+    """
+    if coupling not in ("synchronous", "reflection"):
+        raise ValueError(
+            f'`coupling` must be "synchronous" or "reflection"; got {coupling!r}'
+        )
+    if coupling == "synchronous":
+        if direction_fn is not None:
+            raise ValueError(
+                "synchronous coupling does not use a direction; pass "
+                'coupling="reflection" to reflect.'
+            )
+    elif direction_fn is None:
+        direction_fn = whitened_difference
+
+    def kernel(
+        rng_key: PRNGKey,
+        state: CoupledHMCState,
+        logdensity_fn: Sequence[Callable],
+        step_size: Sequence[float],
+        inverse_mass_matrix: Sequence[metrics.MetricTypes],
+        num_integration_steps: Sequence[int],
+    ) -> tuple[CoupledHMCState, CoupledHMCInfo]:
+        """Advance a coupled pair by one transition."""
+        logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
+        step_sizes = _as_pair(step_size, "step_size")
+        inverse_mass_matrices = _as_pair(inverse_mass_matrix, "inverse_mass_matrix")
+        integration_steps = _as_pair(num_integration_steps, "num_integration_steps")
+        _check_paired_positions(state.first.position, state.second.position)
+
+        first_metric, first_step = _build_prescribed_marginal(
+            logdensity_fns[0],
+            inverse_mass_matrices[0],
+            step_sizes[0],
+            integration_steps[0],
+            integrator,
+            divergence_threshold,
+        )
+        second_metric, second_step = _build_prescribed_marginal(
+            logdensity_fns[1],
+            inverse_mass_matrices[1],
+            step_sizes[1],
+            integration_steps[1],
+            integrator,
+            divergence_threshold,
+        )
+
+        flat, _ = _flat_position(state.first.position)
+
+        # The coupling direction is measured on the incoming states, before
+        # any innovation for this transition exists.
+        if coupling == "reflection":
+            direction = jnp.asarray(
+                direction_fn(state.first, state.second, first_metric, second_metric)
+            )
+            if direction.shape != flat.shape:
+                raise ValueError(
+                    "`direction_fn` must return a flat direction matching the "
+                    f"position; got {direction.shape}, expected {flat.shape}"
+                )
+            if direction.dtype != flat.dtype:
+                raise TypeError(
+                    "`direction_fn` must return the position dtype; got "
+                    f"{direction.dtype}, expected {flat.dtype}"
+                )
+            unit = _reflection_unit(direction)
+        else:
+            unit = jnp.zeros(flat.shape, flat.dtype)
+
+        key_normal, key_uniform = jax.random.split(rng_key, 2)
+        standard_normal = jax.random.normal(key_normal, flat.shape, flat.dtype)
+        # jax.random.uniform returns a value in [0, 1) in the requested dtype,
+        # so the Metropolis precondition holds by construction and no cast --
+        # hence no narrowing -- is needed.
+        uniform = jax.random.uniform(key_uniform, (), flat.dtype)
+
+        if coupling == "reflection":
+            second_normal = _reflect(standard_normal, unit)
+        else:
+            second_normal = standard_normal
+
+        first_state, first_info = first_step(state.first, standard_normal, uniform)
+        second_state, second_info = second_step(state.second, second_normal, uniform)
+
+        return (
+            CoupledHMCState(first_state, second_state),
+            CoupledHMCInfo(first_info, second_info, standard_normal, unit, uniform),
+        )
+
+    return kernel
+
+
+def as_top_level_api(
+    logdensity_fn: Sequence[Callable],
+    step_size: Sequence[float],
+    inverse_mass_matrix: Sequence[metrics.MetricTypes],
+    num_integration_steps: Sequence[int],
+    *,
+    coupling: str = "synchronous",
+    direction_fn: Callable | None = None,
+    integrator: Callable = integrators.velocity_verlet,
+    divergence_threshold: float = 1000,
+    validate: bool = True,
+) -> SamplingAlgorithm:
+    """Build a ``SamplingAlgorithm`` for a coupled HMC pair.
+
+    There is deliberately no top-level ``blackjax.coupled_hmc``; reach this
+    through ``blackjax.mcmc.coupled_hmc.as_top_level_api``.
+
+    Every per-marginal argument is an explicit ``(first, second)`` pair, so a
+    shared value is written twice.  The two marginals may target different
+    distributions and use different fixed Gaussian Euclidean metrics, step
+    sizes and integration counts, but their positions must share a pytree
+    structure, leaf shapes and one floating dtype.
+
+    Parameters
+    ----------
+    logdensity_fn
+        Pair of log-density functions.
+    step_size
+        Pair of integration step sizes.
+    inverse_mass_matrix
+        Pair of inverse mass matrices.  Each is a diagonal array, a dense
+        array, or a :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`;
+        callable (Riemannian) metrics and pre-built
+        :class:`~blackjax.mcmc.metrics.Metric` objects are not supported.
+    num_integration_steps
+        Pair of integration step counts.
+    coupling
+        ``"synchronous"`` or ``"reflection"``; see :func:`build_kernel`.
+    direction_fn
+        Reflection direction policy; see :func:`build_kernel`.
+    integrator
+        Symplectic integrator used by both marginals.
+    divergence_threshold
+        Per-marginal divergence threshold.
+    validate
+        When true (the default), each marginal's concrete metric and
+        integration settings are checked eagerly by
+        :func:`validate_marginal_inputs`.  Those checks read concrete values
+        on the host and so cover the arguments given here; they say nothing
+        about traced values appearing later under ``jit`` or ``vmap``.
+
+    Returns
+    -------
+    A ``SamplingAlgorithm`` whose ``init`` takes a pair of positions.
+
+    """
+    step_sizes = _as_pair(step_size, "step_size")
+    inverse_mass_matrices = _as_pair(inverse_mass_matrix, "inverse_mass_matrix")
+    integration_steps = _as_pair(num_integration_steps, "num_integration_steps")
+    _as_pair(logdensity_fn, "logdensity_fn")
+
+    if validate:
+        for index in (0, 1):
+            validate_marginal_inputs(
+                inverse_mass_matrices[index],
+                step_sizes[index],
+                integration_steps[index],
+            )
+
+    kernel = build_kernel(
+        integrator,
+        divergence_threshold,
+        coupling=coupling,
+        direction_fn=direction_fn,
+    )
+    return build_sampling_algorithm(
+        kernel,
+        init,
+        logdensity_fn,
+        kernel_args=(step_sizes, inverse_mass_matrices, integration_steps),
+    )

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -132,7 +132,7 @@ from jax.flatten_util import ravel_pytree
 import blackjax.mcmc.hmc as hmc
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
-from blackjax.base import SamplingAlgorithm, build_sampling_algorithm
+from blackjax.base import Info, Position, SamplingAlgorithm, State
 from blackjax.types import Array, ArrayLikeTree, PRNGKey
 
 __all__ = [
@@ -219,7 +219,7 @@ def _as_pair(value, name: str) -> tuple:
     if isinstance(value, list) and len(value) == 2:
         return tuple(value)
     raise TypeError(
-        f"`{name}` must be an explicit (first, second) pair; pass "
+        f"`{name}` must be an explicit (first, second) pair. Pass "
         f"`({name}, {name})` when both marginals share a value."
     )
 
@@ -262,7 +262,7 @@ def _flat_position(position: ArrayLikeTree) -> tuple[Array, Callable]:
     dtypes = {jnp.asarray(leaf).dtype for leaf in leaves}
     if len(dtypes) != 1:
         raise TypeError(
-            f"all position leaves must share one floating dtype; got {sorted(map(str, dtypes))}"
+            f"all position leaves must share one floating dtype, got {sorted(map(str, dtypes))}"
         )
     flat, unravel = ravel_pytree(position)
     if not jnp.issubdtype(flat.dtype, jnp.floating) or flat.size == 0:
@@ -276,19 +276,19 @@ def _check_paired_positions(first_position, second_position) -> None:
     second_structure = jax.tree.structure(second_position)
     if first_structure != second_structure:
         raise ValueError(
-            "paired positions must share one pytree structure; got "
+            "paired positions must share one pytree structure, got "
             f"{first_structure} and {second_structure}"
         )
     first_flat, _ = _flat_position(first_position)
     second_flat, _ = _flat_position(second_position)
     if first_flat.shape != second_flat.shape:
         raise ValueError(
-            "paired positions must have matching flat shapes; got "
+            "paired positions must have matching flat shapes, got "
             f"{first_flat.shape} and {second_flat.shape}"
         )
     if first_flat.dtype != second_flat.dtype:
         raise TypeError(
-            "paired positions must have matching floating dtypes; got "
+            "paired positions must have matching floating dtypes, got "
             f"{first_flat.dtype} and {second_flat.dtype}"
         )
 
@@ -307,20 +307,20 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
     uniform = jnp.asarray(uniform)
     if standard_normal.shape != flat_position.shape:
         raise ValueError(
-            "`standard_normal` must be a flat vector matching the position; got "
+            "`standard_normal` must be a flat vector matching the position, got "
             f"{standard_normal.shape}, expected {flat_position.shape}"
         )
     if standard_normal.dtype != flat_position.dtype:
         raise TypeError(
             "`standard_normal` dtype must match the position dtype exactly "
-            f"(no narrowing); got {standard_normal.dtype}, expected {flat_position.dtype}"
+            f"(no narrowing), got {standard_normal.dtype}, expected {flat_position.dtype}"
         )
     if uniform.shape != ():
-        raise ValueError(f"`uniform` must be a scalar; got shape {uniform.shape}")
+        raise ValueError(f"`uniform` must be a scalar, got shape {uniform.shape}")
     if uniform.dtype != flat_position.dtype:
         raise TypeError(
             "`uniform` dtype must match the position dtype exactly (no "
-            f"narrowing); got {uniform.dtype}, expected {flat_position.dtype}"
+            f"narrowing), got {uniform.dtype}, expected {flat_position.dtype}"
         )
     # A uniform outside [0, 1) is refused, never clipped and never allowed to
     # masquerade as an ordinary Metropolis rejection.  The value can only be
@@ -330,7 +330,7 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
         value = float(uniform)
         if not 0.0 <= value < 1.0:
             raise ValueError(
-                f"`uniform` must lie in [0, 1); got {value!r}. It is not "
+                f"`uniform` must lie in [0, 1), got {value!r}. It is not "
                 "clipped, because a clipped uniform would silently become an "
                 "ordinary rejection."
             )
@@ -352,23 +352,23 @@ def _concrete_real_scalar(value, name: str) -> float:
     """
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
-            f"`{name}` must be concrete here; a traced value cannot be checked "
+            f"`{name}` must be concrete here -- a traced value cannot be checked "
             "eagerly. Use `build_kernel`, which performs no eager validation."
         )
     if isinstance(value, (bool, np.bool_)):
         raise TypeError(f"`{name}` must be a real number, not a boolean")
     array = np.asarray(value)
     if array.ndim != 0:
-        raise ValueError(f"`{name}` must be a scalar; got shape {array.shape}")
+        raise ValueError(f"`{name}` must be a scalar, got shape {array.shape}")
     if array.dtype == np.bool_ or not (
         np.issubdtype(array.dtype, np.floating)
         or np.issubdtype(array.dtype, np.integer)
     ):
         raise TypeError(
-            f"`{name}` must have a real floating or integer dtype; got {array.dtype}"
+            f"`{name}` must have a real floating or integer dtype, got {array.dtype}"
         )
     if not np.isfinite(array):
-        raise ValueError(f"`{name}` must be finite; got {array!r}")
+        raise ValueError(f"`{name}` must be finite, got {array!r}")
     return float(array)
 
 
@@ -380,17 +380,17 @@ def _concrete_integer_scalar(value, name: str) -> int:
     """
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
-            f"`{name}` must be concrete here; a traced value cannot be checked "
+            f"`{name}` must be concrete here -- a traced value cannot be checked "
             "eagerly. Use `build_kernel`, which performs no eager validation."
         )
     if isinstance(value, (bool, np.bool_)):
         raise TypeError(f"`{name}` must be an integer, not a boolean")
     array = np.asarray(value)
     if array.ndim != 0:
-        raise ValueError(f"`{name}` must be a scalar; got shape {array.shape}")
+        raise ValueError(f"`{name}` must be a scalar, got shape {array.shape}")
     if not np.issubdtype(array.dtype, np.integer):
         raise TypeError(
-            f"`{name}` must have an integer dtype; got {array.dtype}. It is not "
+            f"`{name}` must have an integer dtype, got {array.dtype}. It is not "
             "rounded, because a silently truncated count would change the "
             "trajectory."
         )
@@ -646,6 +646,9 @@ def _build_prescribed_pair(
     step_sizes = _as_pair(step_size, "step_size")
     inverse_mass_matrices = _as_pair(inverse_mass_matrix, "inverse_mass_matrix")
     integration_steps = _as_pair(num_integration_steps, "num_integration_steps")
+    if coupling == "reflection" and direction_fn is None:
+        raise ValueError("reflection coupling requires a direction function")
+    measure_direction = direction_fn
 
     first_metric, first_step = _build_prescribed_marginal(
         logdensity_fns[0],
@@ -671,17 +674,18 @@ def _build_prescribed_pair(
         flat, _ = _flat_position(state.first.position)
 
         if coupling == "reflection":
+            assert measure_direction is not None  # narrowed above
             direction = jnp.asarray(
-                direction_fn(state.first, state.second, first_metric)
+                measure_direction(state.first, state.second, first_metric)
             )
             if direction.shape != flat.shape:
                 raise ValueError(
                     "`direction_fn` must return a flat direction matching the "
-                    f"position; got {direction.shape}, expected {flat.shape}"
+                    f"position, got {direction.shape}, expected {flat.shape}"
                 )
             if direction.dtype != flat.dtype:
                 raise TypeError(
-                    "`direction_fn` must return the position dtype; got "
+                    "`direction_fn` must return the position dtype, got "
                     f"{direction.dtype}, expected {flat.dtype}"
                 )
             unit = _reflection_unit(direction)
@@ -706,9 +710,7 @@ def _build_prescribed_pair(
 # --------------------------------------------------------------------
 
 
-def init(
-    position: Sequence[ArrayLikeTree], logdensity_fn: Sequence[Callable]
-) -> CoupledHMCState:
+def init(position: Position, logdensity_fn: Sequence[Callable]) -> CoupledHMCState:
     """Initialise a coupled pair.
 
     Parameters
@@ -780,7 +782,7 @@ def build_kernel(
     """
     if coupling not in ("synchronous", "reflection"):
         raise ValueError(
-            f'`coupling` must be "synchronous" or "reflection"; got {coupling!r}'
+            f'`coupling` must be "synchronous" or "reflection", got {coupling!r}'
         )
     if coupling == "synchronous":
         if direction_fn is not None:
@@ -900,9 +902,22 @@ def as_top_level_api(
         coupling=coupling,
         direction_fn=direction_fn,
     )
-    return build_sampling_algorithm(
-        kernel,
-        init,
-        logdensity_fn,
-        kernel_args=(step_sizes, inverse_mass_matrices, integration_steps),
-    )
+
+    # `build_sampling_algorithm` is typed for a single ``logdensity_fn``; this
+    # algorithm takes a pair, so the two-line wrapper is written out rather than
+    # forced through a helper whose contract does not cover it.
+    def init_fn(position: Position, rng_key: PRNGKey | None = None) -> State:
+        del rng_key
+        return init(position, logdensity_fn)
+
+    def step_fn(rng_key: PRNGKey, state: State) -> tuple[State, Info]:
+        return kernel(
+            rng_key,
+            state,
+            logdensity_fn,
+            step_sizes,
+            inverse_mass_matrices,
+            integration_steps,
+        )
+
+    return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -70,7 +70,9 @@ below draw a single :math:`z` and hand each marginal a transformed copy:
 
     ``e`` comes from ``direction_fn``, which is fixed when the kernel is
     built and is evaluated on the *incoming* pair of states, before any
-    randomness for the transition is drawn.  The default direction is the
+    randomness for the transition is drawn and without being given any of it.
+    Supplying a ``direction_fn`` that is a pure function of its arguments is
+    the caller's part of the contract.  The default direction is the
     difference of the two positions whitened by the **first** marginal's
     metric, :math:`e \\propto A^{-1}(x_1 - x_2)`.  That particular choice is a
     heuristic: it is the direction along which, to leading order, the two
@@ -338,6 +340,63 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
         raise ValueError("`standard_normal` must be finite")
 
 
+def _concrete_real_scalar(value, name: str) -> float:
+    """Read a concrete real scalar, accepting the array forms BlackJAX produces.
+
+    Warmup returns a step size as a zero-dimensional JAX array rather than a
+    Python float, and NumPy scalars are just as ordinary, so all of those are
+    accepted here: requiring callers to hand-cast routine BlackJAX output would
+    be a gratuitous obstacle.  Booleans, complex values, non-scalars and
+    non-finite values are still refused, and so are tracers -- this reads the
+    value, which is only possible when it is concrete.
+    """
+    if isinstance(value, jax.core.Tracer):
+        raise TypeError(
+            f"`{name}` must be concrete here; a traced value cannot be checked "
+            "eagerly. Use `build_kernel`, which performs no eager validation."
+        )
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"`{name}` must be a real number, not a boolean")
+    array = np.asarray(value)
+    if array.ndim != 0:
+        raise ValueError(f"`{name}` must be a scalar; got shape {array.shape}")
+    if array.dtype == np.bool_ or not (
+        np.issubdtype(array.dtype, np.floating)
+        or np.issubdtype(array.dtype, np.integer)
+    ):
+        raise TypeError(
+            f"`{name}` must have a real floating or integer dtype; got {array.dtype}"
+        )
+    if not np.isfinite(array):
+        raise ValueError(f"`{name}` must be finite; got {array!r}")
+    return float(array)
+
+
+def _concrete_integer_scalar(value, name: str) -> int:
+    """Read a concrete integer scalar, accepting NumPy and JAX scalar forms.
+
+    A floating value is refused rather than truncated: silently rounding an
+    integration count would change the trajectory without telling anyone.
+    """
+    if isinstance(value, jax.core.Tracer):
+        raise TypeError(
+            f"`{name}` must be concrete here; a traced value cannot be checked "
+            "eagerly. Use `build_kernel`, which performs no eager validation."
+        )
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"`{name}` must be an integer, not a boolean")
+    array = np.asarray(value)
+    if array.ndim != 0:
+        raise ValueError(f"`{name}` must be a scalar; got shape {array.shape}")
+    if not np.issubdtype(array.dtype, np.integer):
+        raise TypeError(
+            f"`{name}` must have an integer dtype; got {array.dtype}. It is not "
+            "rounded, because a silently truncated count would change the "
+            "trajectory."
+        )
+    return int(array)
+
+
 def validate_marginal_inputs(inverse_mass_matrix, step_size, num_integration_steps):
     """Eagerly validate one marginal's concrete metric and integration settings.
 
@@ -362,15 +421,9 @@ def validate_marginal_inputs(inverse_mass_matrix, step_size, num_integration_ste
     """
     inverse_mass_matrix = _check_metric_kind(inverse_mass_matrix)
 
-    if isinstance(step_size, bool) or not isinstance(step_size, (int, float)):
-        raise TypeError("`step_size` must be a real scalar")
-    if not np.isfinite(step_size) or step_size <= 0:
-        raise ValueError("`step_size` must be positive and finite")
-    if isinstance(num_integration_steps, bool) or not isinstance(
-        num_integration_steps, (int, np.integer)
-    ):
-        raise TypeError("`num_integration_steps` must be an integer")
-    if num_integration_steps <= 0:
+    if _concrete_real_scalar(step_size, "step_size") <= 0:
+        raise ValueError("`step_size` must be positive")
+    if _concrete_integer_scalar(num_integration_steps, "num_integration_steps") <= 0:
         raise ValueError("`num_integration_steps` must be positive")
 
     if isinstance(inverse_mass_matrix, metrics.LowRankInverseMassMatrix):
@@ -583,9 +636,11 @@ def _build_prescribed_pair(
     function, which is what makes the coupling separately checkable without
     also reasoning about key splitting.  It is internal to this module.
 
-    The reflection direction is measured here, from the incoming states only.
-    Neither ``direction_fn`` nor anything it is given has access to the
-    innovations this transition will use.
+    The reflection direction is measured here, and this function passes
+    ``direction_fn`` nothing but the incoming states and the first metric: the
+    innovations are not among its arguments.  Whether the returned direction is
+    genuinely free of them is a contract the caller keeps, since a callable may
+    close over anything.
     """
     logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
     step_sizes = _as_pair(step_size, "step_size")
@@ -688,11 +743,14 @@ def build_kernel(
     ``coupling`` and ``direction_fn`` are fixed here, when the kernel is
     built, and not at call time.  The kernel evaluates ``direction_fn`` on the
     pair of incoming states before drawing any randomness for the transition,
-    so under BlackJAX's ordinary pure-function convention -- kernels take all
-    randomness through their ``rng_key`` argument and hold no hidden state --
-    the direction cannot depend on the innovations it will be used to reflect.
-    That is a property of the data flow here, not something enforceable
-    against an arbitrary Python callable.
+    and supplies it no innovations.
+
+    That is a statement about what this API hands over, not a guarantee about
+    what a caller's callable does.  A ``direction_fn`` that closes over
+    innovations, or draws its own randomness, breaks the reflection's marginal
+    correctness, and nothing here can detect it.  Keeping it a pure function of
+    the arguments it is given is the caller's part of the contract -- the same
+    purity convention every BlackJAX kernel already assumes.
 
     Parameters
     ----------

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -202,7 +202,7 @@ class CoupledHMCInfo(NamedTuple):
     second: hmc.HMCInfo
     common_normal: Array
     reflection_unit: Array
-    uniform: float
+    uniform: Array
 
 
 # --------------------------------------------------------------------
@@ -298,7 +298,13 @@ def _flat_position(position: ArrayLikeTree) -> tuple[Array, Callable]:
 
 
 def _check_paired_positions(first_position, second_position) -> None:
-    """Require identical tree structure, leaf shapes and dtype across the pair."""
+    """Require identical tree structure, leaf shapes and dtype across the pair.
+
+    The dtype compared is the **effective** one, see :func:`_flat_position`, so
+    this guarantee is configuration-relative: under JAX's default settings two
+    positions declaring float64 and float32 agree here, because both become
+    float32.  It is not a promise that their declared dtypes match.
+    """
     first_structure = jax.tree.structure(first_position)
     second_structure = jax.tree.structure(second_position)
     if first_structure != second_structure:
@@ -405,8 +411,9 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
     declared = _declared_dtype(standard_normal)
     if declared is not None and declared != flat_position.dtype:
         raise TypeError(
-            "`standard_normal` dtype must match the position dtype exactly "
-            f"(no narrowing), got {declared}, expected {flat_position.dtype}"
+            "`standard_normal` must declare the position's effective dtype "
+            f"exactly (no narrowing), got {declared}, expected "
+            f"{flat_position.dtype}"
         )
     if _declared_shape(uniform) != ():
         raise ValueError(
@@ -415,8 +422,8 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
     declared = _declared_dtype(uniform)
     if declared is not None and declared != flat_position.dtype:
         raise TypeError(
-            "`uniform` dtype must match the position dtype exactly (no "
-            f"narrowing), got {declared}, expected {flat_position.dtype}"
+            "`uniform` must declare the position's effective dtype exactly "
+            f"(no narrowing), got {declared}, expected {flat_position.dtype}"
         )
 
     # A uniform outside [0, 1) is refused, never clipped and never allowed to

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -375,8 +375,11 @@ def _concrete_real_scalar(value, name: str) -> float:
 def _concrete_integer_scalar(value, name: str) -> int:
     """Read a concrete integer scalar, accepting NumPy and JAX scalar forms.
 
-    A floating value is refused rather than truncated: silently rounding an
-    integration count would change the trajectory without telling anyone.
+    A floating value is refused here rather than left to fail later.  It would
+    not be silently truncated in any case -- ``fori_loop`` rejects a float bound
+    -- but it does so with a message about loop bound types that never names the
+    parameter, and only once a trajectory is being built.  Refusing it at the
+    validation boundary is a diagnostic improvement, not a correctness guard.
     """
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
@@ -389,11 +392,7 @@ def _concrete_integer_scalar(value, name: str) -> int:
     if array.ndim != 0:
         raise ValueError(f"`{name}` must be a scalar, got shape {array.shape}")
     if not np.issubdtype(array.dtype, np.integer):
-        raise TypeError(
-            f"`{name}` must have an integer dtype, got {array.dtype}. It is not "
-            "rounded, because a silently truncated count would change the "
-            "trajectory."
-        )
+        raise TypeError(f"`{name}` must have an integer dtype, got {array.dtype}")
     return int(array)
 
 

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -550,6 +550,87 @@ def whitened_difference(
     return ravel_pytree(scaled)[0]
 
 
+def _build_prescribed_pair(
+    logdensity_fn: Sequence[Callable],
+    inverse_mass_matrix: Sequence[metrics.MetricTypes],
+    step_size: Sequence[float],
+    num_integration_steps: Sequence[int],
+    integrator: Callable,
+    divergence_threshold: float,
+    coupling: str,
+    direction_fn: Callable | None,
+):
+    """Build the coupled transition whose randomness is supplied, not drawn.
+
+    Returns ``step(state, standard_normal, uniform) -> (CoupledHMCState,
+    CoupledHMCInfo)``.  This is the deterministic core of the kernel: given
+    the pair of incoming states and one ``(z, u)`` pair it is an ordinary pure
+    function, which is what makes the coupling separately checkable without
+    also reasoning about key splitting.  It is internal to this module.
+
+    The reflection direction is measured here, from the incoming states only.
+    Neither ``direction_fn`` nor anything it is given has access to the
+    innovations this transition will use.
+    """
+    logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
+    step_sizes = _as_pair(step_size, "step_size")
+    inverse_mass_matrices = _as_pair(inverse_mass_matrix, "inverse_mass_matrix")
+    integration_steps = _as_pair(num_integration_steps, "num_integration_steps")
+
+    first_metric, first_step = _build_prescribed_marginal(
+        logdensity_fns[0],
+        inverse_mass_matrices[0],
+        step_sizes[0],
+        integration_steps[0],
+        integrator,
+        divergence_threshold,
+    )
+    second_metric, second_step = _build_prescribed_marginal(
+        logdensity_fns[1],
+        inverse_mass_matrices[1],
+        step_sizes[1],
+        integration_steps[1],
+        integrator,
+        divergence_threshold,
+    )
+
+    def step(
+        state: CoupledHMCState, standard_normal: Array, uniform: Array
+    ) -> tuple[CoupledHMCState, CoupledHMCInfo]:
+        _check_paired_positions(state.first.position, state.second.position)
+        flat, _ = _flat_position(state.first.position)
+
+        if coupling == "reflection":
+            direction = jnp.asarray(
+                direction_fn(state.first, state.second, first_metric, second_metric)
+            )
+            if direction.shape != flat.shape:
+                raise ValueError(
+                    "`direction_fn` must return a flat direction matching the "
+                    f"position; got {direction.shape}, expected {flat.shape}"
+                )
+            if direction.dtype != flat.dtype:
+                raise TypeError(
+                    "`direction_fn` must return the position dtype; got "
+                    f"{direction.dtype}, expected {flat.dtype}"
+                )
+            unit = _reflection_unit(direction)
+            second_normal = _reflect(standard_normal, unit)
+        else:
+            unit = jnp.zeros(flat.shape, flat.dtype)
+            second_normal = standard_normal
+
+        first_state, first_info = first_step(state.first, standard_normal, uniform)
+        second_state, second_info = second_step(state.second, second_normal, uniform)
+
+        return (
+            CoupledHMCState(first_state, second_state),
+            CoupledHMCInfo(first_info, second_info, standard_normal, unit, uniform),
+        )
+
+    return step
+
+
 # --------------------------------------------------------------------
 #                            PUBLIC API
 # --------------------------------------------------------------------
@@ -646,50 +727,17 @@ def build_kernel(
         num_integration_steps: Sequence[int],
     ) -> tuple[CoupledHMCState, CoupledHMCInfo]:
         """Advance a coupled pair by one transition."""
-        logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
-        step_sizes = _as_pair(step_size, "step_size")
-        inverse_mass_matrices = _as_pair(inverse_mass_matrix, "inverse_mass_matrix")
-        integration_steps = _as_pair(num_integration_steps, "num_integration_steps")
-        _check_paired_positions(state.first.position, state.second.position)
-
-        first_metric, first_step = _build_prescribed_marginal(
-            logdensity_fns[0],
-            inverse_mass_matrices[0],
-            step_sizes[0],
-            integration_steps[0],
+        step = _build_prescribed_pair(
+            logdensity_fn,
+            inverse_mass_matrix,
+            step_size,
+            num_integration_steps,
             integrator,
             divergence_threshold,
+            coupling,
+            direction_fn,
         )
-        second_metric, second_step = _build_prescribed_marginal(
-            logdensity_fns[1],
-            inverse_mass_matrices[1],
-            step_sizes[1],
-            integration_steps[1],
-            integrator,
-            divergence_threshold,
-        )
-
         flat, _ = _flat_position(state.first.position)
-
-        # The coupling direction is measured on the incoming states, before
-        # any innovation for this transition exists.
-        if coupling == "reflection":
-            direction = jnp.asarray(
-                direction_fn(state.first, state.second, first_metric, second_metric)
-            )
-            if direction.shape != flat.shape:
-                raise ValueError(
-                    "`direction_fn` must return a flat direction matching the "
-                    f"position; got {direction.shape}, expected {flat.shape}"
-                )
-            if direction.dtype != flat.dtype:
-                raise TypeError(
-                    "`direction_fn` must return the position dtype; got "
-                    f"{direction.dtype}, expected {flat.dtype}"
-                )
-            unit = _reflection_unit(direction)
-        else:
-            unit = jnp.zeros(flat.shape, flat.dtype)
 
         key_normal, key_uniform = jax.random.split(rng_key, 2)
         standard_normal = jax.random.normal(key_normal, flat.shape, flat.dtype)
@@ -698,18 +746,7 @@ def build_kernel(
         # hence no narrowing -- is needed.
         uniform = jax.random.uniform(key_uniform, (), flat.dtype)
 
-        if coupling == "reflection":
-            second_normal = _reflect(standard_normal, unit)
-        else:
-            second_normal = standard_normal
-
-        first_state, first_info = first_step(state.first, standard_normal, uniform)
-        second_state, second_info = second_step(state.second, second_normal, uniform)
-
-        return (
-            CoupledHMCState(first_state, second_state),
-            CoupledHMCInfo(first_info, second_info, standard_normal, unit, uniform),
-        )
+        return step(state, standard_normal, uniform)
 
     return kernel
 

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -279,13 +279,23 @@ def _check_paired_positions(first_position, second_position) -> None:
             "paired positions must share one pytree structure, got "
             f"{first_structure} and {second_structure}"
         )
+    # Per-leaf shapes, not merely equal flattened size.  Two positions can share
+    # a tree structure and a total size while splitting it differently -- say
+    # {"a": (2,), "b": (3,)} against {"a": (3,), "b": (2,)} -- and then the one
+    # shared flat innovation is unravelled across different leaf boundaries in
+    # each marginal, so "the same z" silently means two different things.
+    first_leaves = jax.tree.leaves(first_position)
+    second_leaves = jax.tree.leaves(second_position)
+    for index, (first_leaf, second_leaf) in enumerate(zip(first_leaves, second_leaves)):
+        if jnp.shape(first_leaf) != jnp.shape(second_leaf):
+            raise ValueError(
+                "paired positions must have matching leaf shapes, leaf "
+                f"{index} has {jnp.shape(first_leaf)} and {jnp.shape(second_leaf)}"
+            )
     first_flat, _ = _flat_position(first_position)
     second_flat, _ = _flat_position(second_position)
-    if first_flat.shape != second_flat.shape:
-        raise ValueError(
-            "paired positions must have matching flat shapes, got "
-            f"{first_flat.shape} and {second_flat.shape}"
-        )
+    # No separate flat-shape check: equal tree structure with equal per-leaf
+    # shapes already implies equal flattened shape.
     if first_flat.dtype != second_flat.dtype:
         raise TypeError(
             "paired positions must have matching floating dtypes, got "
@@ -293,49 +303,83 @@ def _check_paired_positions(first_position, second_position) -> None:
         )
 
 
-def _check_innovations(standard_normal, uniform, flat_position) -> None:
-    """Require prescribed innovations to match the position shape and dtype exactly.
+def _declared_dtype(value):
+    """The dtype the value itself declares, or ``None`` if it declares none.
 
-    No conversion is performed, on purpose.  Casting a caller's uniform into
-    the position dtype can *narrow* it: a float64 value strictly below one can
-    become exactly ``1.0`` in float32, which then fails ``uniform <
-    p_accept`` even when ``p_accept`` is one, silently turning a certain
-    acceptance into a rejection.  Refusing the mismatch removes that failure
-    mode instead of hiding it.
+    A NumPy or JAX array carries a dtype and is therefore making a claim about
+    its precision.  A bare Python ``float`` or ``int`` carries none and is
+    weakly typed, exactly as elsewhere in JAX, so it is adopted into the
+    position dtype rather than refused.
     """
-    standard_normal = jnp.asarray(standard_normal)
-    uniform = jnp.asarray(uniform)
-    if standard_normal.shape != flat_position.shape:
+    dtype = getattr(value, "dtype", None)
+    return None if dtype is None else np.dtype(dtype)
+
+
+def _declared_shape(value):
+    """The shape the value declares, treating a bare Python scalar as ``()``."""
+    shape = getattr(value, "shape", None)
+    return () if shape is None else tuple(shape)
+
+
+def _check_innovations(standard_normal, uniform, flat_position) -> None:
+    """Require prescribed innovations to match the position shape and dtype.
+
+    The inputs are inspected **as given**, before any conversion.  That
+    ordering is the whole point: ``jnp.asarray`` narrows a float64 input to
+    float32 under JAX's default configuration, so converting first and
+    comparing dtypes afterwards compares two values that already agree and
+    checks nothing.
+
+    Narrowing an innovation is not cosmetic.  A float64 uniform strictly below
+    one becomes exactly ``1.0`` in float32, which then fails ``uniform <
+    p_accept`` even when ``p_accept`` is one, silently turning a certain
+    acceptance into a rejection; and a float64 uniform anywhere in range
+    becomes a *different* float32, so the Metropolis test would use a value the
+    caller never supplied.
+
+    An array that declares a dtype must therefore match the position exactly.
+    A bare Python scalar declares none, is weakly typed, and is adopted -- so
+    for those the domain is checked on the value **as it will be used**, after
+    conversion, which is where a bad Python float would otherwise slip past.
+    """
+    if _declared_shape(standard_normal) != flat_position.shape:
         raise ValueError(
             "`standard_normal` must be a flat vector matching the position, got "
-            f"{standard_normal.shape}, expected {flat_position.shape}"
+            f"{_declared_shape(standard_normal)}, expected {flat_position.shape}"
         )
-    if standard_normal.dtype != flat_position.dtype:
+    declared = _declared_dtype(standard_normal)
+    if declared is not None and declared != flat_position.dtype:
         raise TypeError(
             "`standard_normal` dtype must match the position dtype exactly "
-            f"(no narrowing), got {standard_normal.dtype}, expected {flat_position.dtype}"
+            f"(no narrowing), got {declared}, expected {flat_position.dtype}"
         )
-    if uniform.shape != ():
-        raise ValueError(f"`uniform` must be a scalar, got shape {uniform.shape}")
-    if uniform.dtype != flat_position.dtype:
+    if _declared_shape(uniform) != ():
+        raise ValueError(
+            f"`uniform` must be a scalar, got shape {_declared_shape(uniform)}"
+        )
+    declared = _declared_dtype(uniform)
+    if declared is not None and declared != flat_position.dtype:
         raise TypeError(
             "`uniform` dtype must match the position dtype exactly (no "
-            f"narrowing), got {uniform.dtype}, expected {flat_position.dtype}"
+            f"narrowing), got {declared}, expected {flat_position.dtype}"
         )
+
     # A uniform outside [0, 1) is refused, never clipped and never allowed to
     # masquerade as an ordinary Metropolis rejection.  The value can only be
     # read when it is concrete, so under `jit` or `vmap` this remains a
-    # documented precondition rather than a check.
+    # documented precondition rather than a check.  It is read after conversion
+    # to the position dtype, because that is the value the Metropolis test will
+    # actually compare.
     if not isinstance(uniform, jax.core.Tracer):
-        value = float(uniform)
+        value = float(jnp.asarray(uniform, flat_position.dtype))
         if not 0.0 <= value < 1.0:
             raise ValueError(
-                f"`uniform` must lie in [0, 1), got {value!r}. It is not "
-                "clipped, because a clipped uniform would silently become an "
-                "ordinary rejection."
+                f"`uniform` must lie in [0, 1) in the position dtype, got {value!r}. "
+                "It is not clipped, because a clipped uniform would silently "
+                "become an ordinary rejection."
             )
     if not isinstance(standard_normal, jax.core.Tracer) and not bool(
-        jnp.all(jnp.isfinite(standard_normal))
+        np.all(np.isfinite(np.asarray(standard_normal)))
     ):
         raise ValueError("`standard_normal` must be finite")
 

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -774,6 +774,58 @@ class CoupledHMCContractTest(BlackJAXTest):
             with self.assertRaisesRegex(TypeError, "no narrowing"):
                 step(state, noise, just_below_one)
 
+    @parameterized.named_parameters(
+        {"testcase_name": "one", "uniform": 1.0},
+        {"testcase_name": "above_one", "uniform": 1.5},
+        {"testcase_name": "negative", "uniform": -0.1},
+        {"testcase_name": "nan", "uniform": float("nan")},
+    )
+    def test_an_out_of_domain_uniform_is_refused_not_clipped(self, uniform):
+        """An inadmissible uniform must raise, not become a rejection.
+
+        Clipping or comparing it anyway would turn caller error into an
+        ordinary Metropolis rejection, which is indistinguishable from a
+        legitimate one and so would never be noticed.
+        """
+        with _x64():
+            position = jnp.zeros((_DIM,), jnp.float64)
+            state = HMCState(
+                position,
+                _standard_normal_logdensity(position),
+                jax.grad(_standard_normal_logdensity)(position),
+            )
+            _, step = coupled_hmc._build_prescribed_marginal(
+                _standard_normal_logdensity,
+                jnp.ones((_DIM,), jnp.float64),
+                0.1,
+                2,
+                integrators.velocity_verlet,
+                1000.0,
+            )
+            noise = jnp.zeros((_DIM,), jnp.float64)
+            with self.assertRaisesRegex(ValueError, r"must lie in \[0, 1\)"):
+                step(state, noise, jnp.asarray(uniform, jnp.float64))
+
+    def test_a_non_finite_innovation_is_refused(self):
+        with _x64():
+            position = jnp.zeros((_DIM,), jnp.float64)
+            state = HMCState(
+                position,
+                _standard_normal_logdensity(position),
+                jax.grad(_standard_normal_logdensity)(position),
+            )
+            _, step = coupled_hmc._build_prescribed_marginal(
+                _standard_normal_logdensity,
+                jnp.ones((_DIM,), jnp.float64),
+                0.1,
+                2,
+                integrators.velocity_verlet,
+                1000.0,
+            )
+            bad = jnp.asarray([jnp.inf, 0.0, 0.0, 0.0], jnp.float64)
+            with self.assertRaisesRegex(ValueError, "must be finite"):
+                step(state, bad, jnp.asarray(0.5, jnp.float64))
+
     def test_prescribed_innovations_must_match_shape_and_dtype(self):
         with _x64():
             position = jnp.zeros((_DIM,), jnp.float64)

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -184,6 +184,26 @@ def _oracle_marginal(
     )
 
 
+def _reference_unit(state, first_mass, coupling):
+    """The reflection unit, built independently of the module's own report.
+
+    Uses the documented rule -- ``whitened_difference`` on the FIRST marginal's
+    metric -- then normalises in NumPy, so a test comparing against it can see
+    both a wrong reflection map and a policy wired to the wrong metric.
+    """
+    if coupling != "reflection":
+        return None
+    direction = np.asarray(
+        coupled_hmc.whitened_difference(
+            state.first, state.second, metrics.default_metric(first_mass)
+        )
+    )
+    scale = np.max(np.abs(direction))
+    direction = direction / (scale if scale else 1.0)
+    norm = np.linalg.norm(direction)
+    return jnp.asarray(direction / (norm if norm else 1.0), jnp.float64)
+
+
 def _reflect_with_numpy(noise, unit, coupling):
     """Reconstruct the second marginal's innovation without the module's help.
 
@@ -388,71 +408,6 @@ class CoupledHMCMathTest(BlackJAXTest):
                 atol=1e-12,
             )
 
-    def test_trajectory_matches_an_independent_numpy_leapfrog(self):
-        """The marginal trajectory agrees with a from-scratch NumPy integrator."""
-        with _x64():
-            step_size, num_steps = 0.1, 6
-            inverse_mass = np.array([1.0, 2.0, 0.5, 1.5])
-            position = np.array([0.3, -0.7, 1.1, 0.05])
-            noise = np.array([0.2, 0.4, -0.6, 0.9])
-
-            # NumPy oracle: grad of -0.5 * sum(x^2) is -x.
-            momentum = noise / np.sqrt(inverse_mass)
-            oracle_position = position.copy()
-            oracle_momentum = momentum.copy()
-            oracle_momentum = oracle_momentum + 0.5 * step_size * (-oracle_position)
-            for step in range(num_steps):
-                oracle_position = (
-                    oracle_position + step_size * inverse_mass * oracle_momentum
-                )
-                weight = 0.5 if step == num_steps - 1 else 1.0
-                oracle_momentum = oracle_momentum + weight * step_size * (
-                    -oracle_position
-                )
-
-            metric = metrics.default_metric(jnp.asarray(inverse_mass, jnp.float64))
-            integrator = integrators.velocity_verlet(
-                _standard_normal_logdensity, metric.kinetic_energy
-            )
-            build = trajectory.static_integration(integrator)
-            jax_position = jnp.asarray(position, jnp.float64)
-            start = integrators.IntegratorState(
-                jax_position,
-                jnp.asarray(momentum, jnp.float64),
-                _standard_normal_logdensity(jax_position),
-                jax.grad(_standard_normal_logdensity)(jax_position),
-            )
-            end = build(start, step_size, num_steps)
-
-            np.testing.assert_allclose(
-                np.asarray(end.position), oracle_position, rtol=1e-11
-            )
-            np.testing.assert_allclose(
-                np.asarray(end.momentum), oracle_momentum, rtol=1e-11
-            )
-
-    def test_endpoint_map_is_an_involution(self):
-        """Integrating from the flipped endpoint returns the starting state."""
-        with _x64():
-            metric = metrics.default_metric(jnp.ones((_DIM,), jnp.float64))
-            integrator = integrators.velocity_verlet(
-                _tilted_logdensity, metric.kinetic_energy
-            )
-            build = trajectory.static_integration(integrator)
-            position = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
-            momentum = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
-            start = integrators.IntegratorState(
-                position,
-                momentum,
-                _tilted_logdensity(position),
-                jax.grad(_tilted_logdensity)(position),
-            )
-            end = flip_momentum(build(start, 0.09, 5))
-            back = flip_momentum(build(end, 0.09, 5))
-
-            chex.assert_trees_all_close(back.position, start.position, atol=1e-10)
-            chex.assert_trees_all_close(back.momentum, start.momentum, atol=1e-10)
-
 
 # ---------------------------------------------------------------------------
 # The interface contract
@@ -531,29 +486,15 @@ class CoupledHMCContractTest(BlackJAXTest):
             # the states are seeded from the current date, so a fixed value is
             # not reliably on the side of the threshold it was picked for.
             _, probe_info = step(state, noise, jnp.asarray(0.0, jnp.float64))
-            # Recompute the unit from `whitened_difference` on the FIRST
-            # marginal's metric rather than reading it from the module's own
-            # info. Reading it back would make this comparison blind to the
-            # policy being wired to the wrong metric: the reported unit and the
-            # unit actually used would agree with each other while both being
-            # wrong.
-            if coupling == "reflection":
-                expected_direction = coupled_hmc.whitened_difference(
-                    state.first, state.second, metrics.default_metric(first_mass)
-                )
-                independent_unit = np.asarray(expected_direction)
-                scale = np.max(np.abs(independent_unit))
-                independent_unit = independent_unit / (scale if scale else 1.0)
-                norm = np.linalg.norm(independent_unit)
-                independent_unit = independent_unit / (norm if norm else 1.0)
-                chex.assert_trees_all_close(
-                    probe_info.reflection_unit,
-                    jnp.asarray(independent_unit, jnp.float64),
-                    atol=1e-12,
-                )
-            second_noise = _reflect_with_numpy(
-                noise, probe_info.reflection_unit, coupling
-            )
+            # The reference innovation is built entirely outside the module:
+            # the direction from `whitened_difference` on the FIRST marginal's
+            # metric, normalised and reflected in NumPy. Nothing is read back
+            # from the production info, so this comparison stays blind to
+            # neither a wrong `_reflect` nor a policy wired to the wrong metric
+            # -- reading the reported unit back would let both be wrong
+            # together and still agree.
+            reference_unit = _reference_unit(state, first_mass, coupling)
+            second_noise = _reflect_with_numpy(noise, reference_unit, coupling)
             probe_first = _oracle_marginal(
                 first_fn,
                 first_mass,
@@ -610,6 +551,12 @@ class CoupledHMCContractTest(BlackJAXTest):
             # wrong. Confirm the unit did not change between the probe and the
             # real call, since the direction is measured from the incoming
             # states only and must not depend on the uniform.
+            # The reported unit must match the independently built one, and
+            # must not have changed between the probe call and this one, since
+            # the direction depends on the incoming states alone.
+            chex.assert_trees_all_close(
+                info.reflection_unit, reference_unit, atol=1e-12
+            )
             chex.assert_trees_all_equal(
                 info.reflection_unit, probe_info.reflection_unit
             )
@@ -731,25 +678,6 @@ class CoupledHMCContractTest(BlackJAXTest):
         noise = jax.random.normal(jax.random.key(7), (_DIM,), jnp.float64)
         return state, step, noise
 
-    def test_every_decision_is_that_marginal_s_own_uniform_comparison(self):
-        """``is_accepted`` equals ``uniform < acceptance_rate``, per marginal.
-
-        This is the exact statement of the shared-uniform contract, and it is
-        what fails if a marginal is fed anything other than the reported
-        uniform, or is handed the other marginal's verdict.
-        """
-        with _x64():
-            state, step, noise = self._intermediate_pair()
-            for value in (0.0, 0.1, 0.3, 0.5, 0.68, 0.7, 0.9, 0.999):
-                _, info = step(state, noise, jnp.asarray(value, jnp.float64))
-                with self.subTest(uniform=value):
-                    self.assertEqual(float(info.uniform), value)
-                    for marginal in (info.first, info.second):
-                        self.assertEqual(
-                            bool(marginal.is_accepted),
-                            float(info.uniform) < float(marginal.acceptance_rate),
-                        )
-
     def test_the_shared_uniform_drives_each_marginal_separately(self):
         """One uniform, two probabilities: the second flips where the first cannot.
 
@@ -781,6 +709,19 @@ class CoupledHMCContractTest(BlackJAXTest):
 
             self.assertTrue(bool(below.second.is_accepted))
             self.assertFalse(bool(above.second.is_accepted))
+            # The rule itself, stated exactly, for both marginals on both sides:
+            # each verdict is that marginal's own comparison against the shared
+            # variate. This is what a pair sharing its *decision* could not do.
+            for label, info in (
+                ("below", below),
+                ("above", above),
+            ):
+                for marginal in (info.first, info.second):
+                    with self.subTest(side=label):
+                        self.assertEqual(
+                            bool(marginal.is_accepted),
+                            float(info.uniform) < float(marginal.acceptance_rate),
+                        )
             # The first marginal is unmoved by the same sweep.
             self.assertTrue(bool(below.first.is_accepted))
             self.assertTrue(bool(above.first.is_accepted))
@@ -1167,15 +1108,17 @@ class CoupledHMCContractTest(BlackJAXTest):
         new_state, _ = algorithm.step(self.next_key(), state)
         self.assertTrue(bool(jnp.all(jnp.isfinite(new_state.first.position))))
 
-    @parameterized.named_parameters(
-        {"testcase_name": "python_float", "value": 0.1},
-        {"testcase_name": "python_int", "value": 1},
-        {"testcase_name": "numpy_float32", "value": np.float32(0.1)},
-        {"testcase_name": "numpy_float64", "value": np.float64(0.1)},
-        {"testcase_name": "jax_scalar_f32", "value": jnp.asarray(0.1, jnp.float32)},
-    )
-    def test_step_size_accepts_ordinary_scalar_forms(self, value):
-        coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), value, 4)
+    def test_step_size_accepts_ordinary_scalar_forms(self):
+        """One representative of each kind that reaches this in practice.
+
+        Not every spelling: a bare Python float (weakly typed), a NumPy scalar,
+        and a zero-dimensional JAX array, which is what ``window_adaptation``
+        returns. Adding the remaining spellings would protect no distinct
+        failure mode.
+        """
+        for value in (0.1, np.float32(0.1), jnp.asarray(0.1, jnp.float32)):
+            with self.subTest(value=repr(value)):
+                coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), value, 4)
 
     @parameterized.named_parameters(
         {"testcase_name": "bool", "value": True, "error": TypeError},
@@ -1196,7 +1139,6 @@ class CoupledHMCContractTest(BlackJAXTest):
 
     @parameterized.named_parameters(
         {"testcase_name": "python_int", "value": 4},
-        {"testcase_name": "numpy_int32", "value": np.int32(4)},
         {"testcase_name": "jax_scalar_i32", "value": jnp.asarray(4, jnp.int32)},
     )
     def test_integration_count_accepts_integer_scalar_forms(self, value):
@@ -1455,8 +1397,18 @@ class CoupledHMCContractTest(BlackJAXTest):
 
         eager_state, eager_info = algorithm.step(key, state)
         jitted_state, jitted_info = jax.jit(algorithm.step)(key, state)
-        chex.assert_trees_all_equal(eager_state, jitted_state)
-        chex.assert_trees_all_equal(eager_info, jitted_info)
+        # Floating results are compared with a tolerance: XLA may fuse or
+        # reassociate under `jit`, so bitwise agreement with the eager path is
+        # not a contract this module can promise. The DECISIONS and the
+        # structure are exact, because those must not drift.
+        chex.assert_trees_all_close(eager_state, jitted_state, atol=1e-12)
+        self.assertEqual(
+            bool(eager_info.first.is_accepted), bool(jitted_info.first.is_accepted)
+        )
+        self.assertEqual(
+            bool(eager_info.second.is_accepted), bool(jitted_info.second.is_accepted)
+        )
+        chex.assert_trees_all_equal_structs(eager_state, jitted_state)
 
         def body(carry, step_key):
             new_state, _ = algorithm.step(step_key, carry)
@@ -1501,48 +1453,23 @@ class CoupledHMCContractTest(BlackJAXTest):
         self.assertIsInstance(final, coupled_hmc.CoupledHMCState)
         self.assertEqual(history[0].first.position.shape, (10, _DIM))
 
-    def test_pytree_positions_are_supported(self):
-        with _x64():
-            position = {
-                "a": jnp.ones((2,), jnp.float64),
-                "b": jnp.zeros((2,), jnp.float64),
-            }
-            other = jax.tree.map(lambda leaf: leaf - 1.0, position)
-            mass = jnp.ones((4,), jnp.float64)
-            algorithm = coupled_hmc.as_top_level_api(
-                (_standard_normal_logdensity,) * 2,
-                (0.2, 0.2),
-                (mass, mass),
-                (4, 4),
-                coupling="reflection",
-            )
-            state = algorithm.init((position, other))
-            new_state, info = algorithm.step(self.next_key(), state)
-            chex.assert_trees_all_equal_structs(new_state.first.position, position)
-            self.assertEqual(info.common_normal.shape, (4,))
-
-    def test_heterogeneous_marginals_run(self):
-        """Different targets, metrics, step sizes and integration counts."""
-        with _x64():
-            payloads = _metric_payloads(jnp.float64)
-            algorithm = coupled_hmc.as_top_level_api(
-                (_standard_normal_logdensity, _tilted_logdensity),
-                (0.07, 0.19),
-                (payloads["dense"], payloads["low_rank"]),
-                (3, 6),
-                coupling="reflection",
-            )
-            state = algorithm.init(
-                (
-                    jnp.ones((_DIM,), jnp.float64),
-                    -jnp.ones((_DIM,), jnp.float64),
-                )
-            )
-            new_state, info = algorithm.step(self.next_key(), state)
-            self.assertEqual(info.first.num_integration_steps, 3)
-            self.assertEqual(info.second.num_integration_steps, 6)
-            self.assertTrue(bool(jnp.all(jnp.isfinite(new_state.first.position))))
-            self.assertTrue(bool(jnp.all(jnp.isfinite(new_state.second.position))))
+        # A pytree position drives the same path: the pair is itself a pytree,
+        # which is what makes the generic runner work, so this is the one
+        # distinct thing the old separate pytree smoke test asserted.
+        tree_position = {"a": jnp.ones((2,)), "b": jnp.zeros((2,))}
+        tree_algorithm = coupled_hmc.as_top_level_api(
+            (_standard_normal_logdensity,) * 2,
+            (0.2, 0.2),
+            (jnp.ones((4,)), jnp.ones((4,))),
+            (4, 4),
+            coupling="reflection",
+        )
+        tree_state = tree_algorithm.init(
+            (tree_position, jax.tree.map(lambda leaf: leaf - 1.0, tree_position))
+        )
+        stepped, tree_info = tree_algorithm.step(self.next_key(), tree_state)
+        chex.assert_trees_all_equal_structs(stepped.first.position, tree_position)
+        self.assertEqual(tree_info.common_normal.shape, (4,))
 
 
 if __name__ == "__main__":

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -554,9 +554,16 @@ class CoupledHMCContractTest(BlackJAXTest):
             # The reported unit must match the independently built one, and
             # must not have changed between the probe call and this one, since
             # the direction depends on the incoming states alone.
-            chex.assert_trees_all_close(
-                info.reflection_unit, reference_unit, atol=1e-12
-            )
+            if coupling == "reflection":
+                chex.assert_trees_all_close(
+                    info.reflection_unit, reference_unit, atol=1e-12
+                )
+            else:
+                # Synchronous reports an exactly zero unit, which is the
+                # documented encoding of "the identity map".
+                chex.assert_trees_all_equal(
+                    info.reflection_unit, jnp.zeros((_DIM,), jnp.float64)
+                )
             chex.assert_trees_all_equal(
                 info.reflection_unit, probe_info.reflection_unit
             )
@@ -989,7 +996,7 @@ class CoupledHMCContractTest(BlackJAXTest):
 
             with self.assertRaisesRegex(ValueError, "flat vector matching"):
                 step(state, jnp.zeros((_DIM + 1,), jnp.float64), good_uniform)
-            with self.assertRaisesRegex(TypeError, "dtype must match"):
+            with self.assertRaisesRegex(TypeError, "effective dtype"):
                 step(state, jnp.zeros((_DIM,), jnp.float32), good_uniform)
             with self.assertRaisesRegex(ValueError, "must be a scalar"):
                 step(state, good_noise, jnp.zeros((2,), jnp.float64))

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -531,6 +531,26 @@ class CoupledHMCContractTest(BlackJAXTest):
             # the states are seeded from the current date, so a fixed value is
             # not reliably on the side of the threshold it was picked for.
             _, probe_info = step(state, noise, jnp.asarray(0.0, jnp.float64))
+            # Recompute the unit from `whitened_difference` on the FIRST
+            # marginal's metric rather than reading it from the module's own
+            # info. Reading it back would make this comparison blind to the
+            # policy being wired to the wrong metric: the reported unit and the
+            # unit actually used would agree with each other while both being
+            # wrong.
+            if coupling == "reflection":
+                expected_direction = coupled_hmc.whitened_difference(
+                    state.first, state.second, metrics.default_metric(first_mass)
+                )
+                independent_unit = np.asarray(expected_direction)
+                scale = np.max(np.abs(independent_unit))
+                independent_unit = independent_unit / (scale if scale else 1.0)
+                norm = np.linalg.norm(independent_unit)
+                independent_unit = independent_unit / (norm if norm else 1.0)
+                chex.assert_trees_all_close(
+                    probe_info.reflection_unit,
+                    jnp.asarray(independent_unit, jnp.float64),
+                    atol=1e-12,
+                )
             second_noise = _reflect_with_numpy(
                 noise, probe_info.reflection_unit, coupling
             )

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -84,11 +84,15 @@ def _skewed_anisotropic_logdensity(x):
 
     The reference comparison needs both marginals to have an acceptance
     probability strictly inside (0, 1), so that one uniform can be chosen to
-    accept and another to reject. A Gaussian target cannot supply that
-    reliably: leapfrog energy error on a Gaussian stays bounded until the
-    stability limit and then blows up, so ``p_accept`` jumps from 1 to 0 with
-    almost no interval between. A skewed target gives a genuinely intermediate
-    probability.
+    accept and another to reject. On the Gaussian targets first tried here, a
+    coarse step-size grid moved from ``p_accept`` 1.0 to 0.0 between 0.70 and
+    0.80 without landing inside, which made the fixture hard to pick. That is
+    an observation about the grid that was scanned, NOT evidence that no
+    interior interval exists: for a fixed leapfrog count the energy error
+    varies continuously with the step size, so a narrower interval may well be
+    there and simply was not sampled. This skewed target is a controlled
+    choice that made an interior probability easy to find and pin, not a claim
+    about Gaussian targets being unusable.
     """
     flat, _ = jax.flatten_util.ravel_pytree(x)
     scales = jnp.arange(1, flat.size + 1, dtype=flat.dtype)
@@ -489,7 +493,8 @@ class CoupledHMCContractTest(BlackJAXTest):
             payloads = _metric_payloads(jnp.float64)
             # Two different non-Gaussian targets, two different metrics, two
             # different step sizes and integration counts. These settings are a
-            # fixture chosen so that BOTH reference acceptance probabilities are
+            # fixture found by scanning, chosen because BOTH reference
+            # acceptance probabilities are
             # strictly interior under both couplings (about 0.53 for the first,
             # and 0.82 synchronous / 0.75 reflected for the second), which is
             # what lets one uniform accept and another reject.
@@ -1270,6 +1275,102 @@ class CoupledHMCContractTest(BlackJAXTest):
             # And it is genuinely the pre-transition state, not the result.
             self.assertFalse(
                 bool(jnp.allclose(seen["first"], new_state.first.position))
+            )
+
+    def test_common_normal_reports_the_first_marginal_s_innovation(self):
+        """``common_normal`` is the innovation the FIRST marginal received.
+
+        The field's docstring promises exactly that, and under reflection the
+        two marginals receive different vectors, so reporting the second one
+        would make the field contradict its own documentation with nothing to
+        catch it.
+        """
+        with _x64():
+            mass = jnp.ones((_DIM,), jnp.float64)
+            first_position = jnp.ones((_DIM,), jnp.float64)
+            second_position = -jnp.ones((_DIM,), jnp.float64)
+            state = coupled_hmc.init(
+                (first_position, second_position),
+                (_standard_normal_logdensity,) * 2,
+            )
+            for coupling in ("synchronous", "reflection"):
+                step = coupled_hmc._build_prescribed_pair(
+                    (_standard_normal_logdensity,) * 2,
+                    (mass, mass),
+                    (0.2, 0.2),
+                    (3, 3),
+                    integrators.velocity_verlet,
+                    1000.0,
+                    coupling,
+                    (
+                        coupled_hmc.whitened_difference
+                        if coupling == "reflection"
+                        else None
+                    ),
+                )
+                noise = jax.random.normal(
+                    jax.random.key(_CONTROL_SEED), (_DIM,), jnp.float64
+                )
+                _, info = step(state, noise, jnp.asarray(0.3, jnp.float64))
+                with self.subTest(coupling=coupling):
+                    chex.assert_trees_all_equal(info.common_normal, noise)
+                    if coupling == "reflection":
+                        # The check has bite only if the second marginal really
+                        # received something else.
+                        second = _reflect_with_numpy(
+                            noise, info.reflection_unit, coupling
+                        )
+                        self.assertFalse(bool(jnp.allclose(second, noise, atol=1e-10)))
+
+    def test_direction_policy_receives_the_first_marginal_s_metric(self):
+        """The default direction is documented as first-metric-based.
+
+        Handing the policy the second marginal's metric would silently change
+        which direction is reflected along while leaving every marginal
+        property intact, so it has to be asserted directly.
+        """
+        with _x64():
+            payloads = _metric_payloads(jnp.float64)
+            first_mass, second_mass = payloads["dense"], payloads["low_rank"]
+            seen = {}
+
+            def recording_direction_fn(first, second, first_metric):
+                seen["metric"] = first_metric
+                return coupled_hmc.whitened_difference(first, second, first_metric)
+
+            state = self._pair_state(key=jax.random.key(_CONTROL_SEED))
+            step = coupled_hmc._build_prescribed_pair(
+                (_standard_normal_logdensity,) * 2,
+                (first_mass, second_mass),
+                (0.2, 0.2),
+                (3, 3),
+                integrators.velocity_verlet,
+                1000.0,
+                "reflection",
+                recording_direction_fn,
+            )
+            noise = jax.random.normal(
+                jax.random.key(_CONTROL_SEED), (_DIM,), jnp.float64
+            )
+            step(state, noise, jnp.asarray(0.3, jnp.float64))
+
+            # Identify the metric by what it computes, not by object identity.
+            probe = jax.random.normal(
+                jax.random.key(_CONTROL_SEED + 1), (_DIM,), jnp.float64
+            )
+            observed = seen["metric"].scale(
+                state.first.position, probe, inv=False, trans=False
+            )
+            expected_first = metrics.default_metric(first_mass).scale(
+                state.first.position, probe, inv=False, trans=False
+            )
+            expected_second = metrics.default_metric(second_mass).scale(
+                state.first.position, probe, inv=False, trans=False
+            )
+            chex.assert_trees_all_close(observed, expected_first, atol=1e-12)
+            # The two metrics must actually differ, or this proves nothing.
+            self.assertFalse(
+                bool(jnp.allclose(expected_first, expected_second, atol=1e-8))
             )
 
     def test_synchronous_coupling_keeps_identical_states_identical(self):

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -147,6 +147,22 @@ def _oracle_marginal(
     )
 
 
+def _reflect_with_numpy(noise, unit, coupling):
+    """Reconstruct the second marginal's innovation without the module's help.
+
+    Deliberately NumPy: calling ``coupled_hmc._reflect`` here would make every
+    comparison that uses this value circular for a defect in ``_reflect``.
+    """
+    if coupling != "reflection":
+        return noise
+    unit_array = np.asarray(unit)
+    noise_array = np.asarray(noise)
+    return jnp.asarray(
+        noise_array - 2 * unit_array * float(noise_array @ unit_array),
+        dtype=noise.dtype,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Mathematics and numerics
 # ---------------------------------------------------------------------------
@@ -202,6 +218,31 @@ class CoupledHMCMathTest(BlackJAXTest):
                 coupled_hmc._reflect(reflected, unit), noise, atol=1e-12
             )
             np.testing.assert_allclose(float(jnp.linalg.norm(unit)), 1.0, rtol=1e-12)
+
+    def test_reflection_negates_the_component_along_the_unit(self):
+        """The reflection must actually reflect.
+
+        Norm preservation, involution and a unit-norm ``e`` are all satisfied
+        by the identity map, so asserting only those leaves the map itself
+        unconstrained. What distinguishes a reflection is that the component
+        along ``e`` flips sign while the orthogonal complement is untouched.
+        """
+        with _x64():
+            unit = coupled_hmc._reflection_unit(
+                jnp.asarray([1.0, 2.0, -0.5, 0.25], jnp.float64)
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            reflected = coupled_hmc._reflect(noise, unit)
+
+            along_before = float(jnp.dot(unit, noise))
+            along_after = float(jnp.dot(unit, reflected))
+            self.assertNotAlmostEqual(along_before, 0.0, places=6)
+            np.testing.assert_allclose(along_after, -along_before, rtol=1e-12)
+
+            # The component orthogonal to `unit` is unchanged.
+            orthogonal_before = noise - unit * along_before
+            orthogonal_after = reflected - unit * along_after
+            chex.assert_trees_all_close(orthogonal_after, orthogonal_before, atol=1e-12)
 
     def test_reflection_preserves_the_standard_normal(self):
         """Finite-sample check that the reflected innovations are still N(0, I).
@@ -392,8 +433,13 @@ class CoupledHMCContractTest(BlackJAXTest):
         )
 
     # -- each marginal is unchanged by coupling -----------------------------
-    @parameterized.parameters("synchronous", "reflection")
-    def test_marginals_match_an_independent_reference(self, coupling):
+    @parameterized.named_parameters(
+        {"testcase_name": "sync_accept", "coupling": "synchronous", "accept": True},
+        {"testcase_name": "sync_reject", "coupling": "synchronous", "accept": False},
+        {"testcase_name": "reflect_accept", "coupling": "reflection", "accept": True},
+        {"testcase_name": "reflect_reject", "coupling": "reflection", "accept": False},
+    )
+    def test_marginals_match_an_independent_reference(self, coupling, accept):
         """Both marginals' state AND info equal the uncoupled reference's.
 
         Heterogeneous on purpose: different targets, metrics, step sizes and
@@ -417,15 +463,57 @@ class CoupledHMCContractTest(BlackJAXTest):
                 coupled_hmc.whitened_difference if coupling == "reflection" else None,
             )
             noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
-            uniform = jnp.asarray(0.4, jnp.float64)
+
+            # Running only an accepting case would leave the rejection branch
+            # uncompared, so a kernel that always returned the proposal would
+            # still match the reference. The uniform is therefore chosen from
+            # the REFERENCE's acceptance probabilities rather than hard-coded:
+            # the states are seeded from the current date, so a fixed value is
+            # not reliably on the side of the threshold it was picked for.
+            _, probe_info = step(state, noise, jnp.asarray(0.0, jnp.float64))
+            second_noise = _reflect_with_numpy(
+                noise, probe_info.reflection_unit, coupling
+            )
+            probe_first = _oracle_marginal(
+                first_fn,
+                first_mass,
+                step_sizes[0],
+                integration_steps[0],
+                state.first,
+                noise,
+                0.0,
+            )[2]
+            probe_second = _oracle_marginal(
+                second_fn,
+                second_mass,
+                step_sizes[1],
+                integration_steps[1],
+                state.second,
+                second_noise,
+                0.0,
+            )[2]
+            lowest = min(float(probe_first), float(probe_second))
+            highest = max(float(probe_first), float(probe_second))
+            # Both branches must be reachable for this case to mean anything.
+            self.assertGreater(lowest, 0.0)
+            self.assertLess(highest, 1.0)
+            # Acceptance is `uniform < p_accept`, so `uniform = highest` rejects
+            # both marginals and `uniform = 0` accepts both.
+            uniform = jnp.asarray(0.0 if accept else highest, jnp.float64)
 
             new_state, info = step(state, noise, uniform)
+            # Confirm this case exercises the branch it is named for.
+            self.assertEqual(bool(info.first.is_accepted), accept)
+            self.assertEqual(bool(info.second.is_accepted), accept)
 
-            # Reconstruct the innovation each marginal must have received.
-            second_noise = (
-                coupled_hmc._reflect(noise, info.reflection_unit)
-                if coupling == "reflection"
-                else noise
+            # `second_noise` was already reconstructed above with NumPy rather
+            # than by calling `coupled_hmc._reflect`, which would make the
+            # comparison circular for exactly the defect of `_reflect` being
+            # wrong. Confirm the unit did not change between the probe and the
+            # real call, since the direction is measured from the incoming
+            # states only and must not depend on the uniform.
+            chex.assert_trees_all_equal(
+                info.reflection_unit, probe_info.reflection_unit
             )
             for label, marginal_state, marginal_info, fn, mass, size, count, z in (
                 (
@@ -738,10 +826,22 @@ class CoupledHMCContractTest(BlackJAXTest):
                 _stiff_logdensity, mass, 5.0, 8, integrators.velocity_verlet, 1000.0
             )
             noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
-            _, info = step(state, noise, jnp.asarray(0.0, jnp.float64))
+            new_state, info = step(state, noise, jnp.asarray(0.0, jnp.float64))
             self.assertEqual(float(info.acceptance_rate), 0.0)
             self.assertFalse(bool(info.is_accepted))
-            chex.assert_trees_all_equal(info.proposal.position, info.proposal.position)
+            # The returned STATE must be the old one. Asserting only the flag
+            # would leave the rejection branch itself unconstrained: a kernel
+            # that reported `is_accepted=False` while returning the proposal
+            # would pass.
+            chex.assert_trees_all_equal(new_state.position, state.position)
+            chex.assert_trees_all_equal(new_state.logdensity, state.logdensity)
+            chex.assert_trees_all_equal(
+                new_state.logdensity_grad, state.logdensity_grad
+            )
+            # And the proposal really did move, so the check above has bite.
+            self.assertFalse(
+                bool(jnp.allclose(info.proposal.position, state.position, atol=1e-10))
+            )
 
     def test_prescribed_uniform_is_not_narrowed(self):
         """A float64 uniform must be refused by a float32 marginal, not cast.
@@ -880,8 +980,19 @@ class CoupledHMCContractTest(BlackJAXTest):
         fns = (_standard_normal_logdensity,) * 2
         with self.assertRaisesRegex(ValueError, "one pytree structure"):
             coupled_hmc.init((jnp.ones((_DIM,)), {"a": jnp.ones((_DIM,))}), fns)
-        with self.assertRaisesRegex(ValueError, "matching flat shapes"):
+        with self.assertRaisesRegex(ValueError, "matching leaf shapes"):
             coupled_hmc.init((jnp.ones((_DIM,)), jnp.ones((_DIM + 1,))), fns)
+        # Same structure and same total size, but split differently across
+        # leaves: the shared flat innovation would be unravelled across
+        # different leaf boundaries in each marginal.
+        with self.assertRaisesRegex(ValueError, "matching leaf shapes"):
+            coupled_hmc.init(
+                (
+                    {"a": jnp.ones((2,)), "b": jnp.ones((3,))},
+                    {"a": jnp.ones((3,)), "b": jnp.ones((2,))},
+                ),
+                fns,
+            )
         with _x64():
             with self.assertRaisesRegex(TypeError, "matching floating dtypes"):
                 coupled_hmc.init(

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -36,13 +36,29 @@ from blackjax.mcmc.hmc import HMCState, flip_momentum
 from blackjax.mcmc.proposal import safe_energy_diff
 from blackjax.mcmc.trajectory import hmc_energy
 from blackjax.util import generate_gaussian_noise, run_inference_algorithm
-from tests.fixtures import BlackJAXTest
+from tests.fixtures import BlackJAXTest, smooth_skewed_logdensity
 
 # ---------------------------------------------------------------------------
 # Targets and metric payloads
 # ---------------------------------------------------------------------------
 _DIM = 4
 _RANK = 2
+
+# Deterministic controls that must land on a chosen side of an acceptance
+# probability get their own fixed seed. `BlackJAXTest` seeds from today's date,
+# which is right for a test whose outcome must hold for any draw and wrong for
+# a control whose whole point is that `p_accept` is interior -- the same test
+# would pass or fail depending on the day it ran. This is a local fixture, not
+# a change to the shared key management.
+_CONTROL_SEED = 20260907
+
+# The reference comparison needs a fixture whose acceptance probabilities are
+# interior under BOTH couplings, since the second marginal receives a reflected
+# innovation and so has a different probability there. These values were chosen
+# by scanning seeds and step sizes for that property; the test asserts it rather
+# than trusting this comment.
+_REFERENCE_SEED = 11
+_REFERENCE_STEP_SIZES = (0.75, 0.90)
 
 
 def _standard_normal_logdensity(x):
@@ -61,6 +77,23 @@ def _stiff_logdensity(x):
     """Sharply curved, so a large step size makes rejection near-certain."""
     flat, _ = jax.flatten_util.ravel_pytree(x)
     return -0.5 * jnp.sum((flat * 60.0) ** 2)
+
+
+def _skewed_anisotropic_logdensity(x):
+    """A second non-Gaussian target, scaled differently from the first.
+
+    The reference comparison needs both marginals to have an acceptance
+    probability strictly inside (0, 1), so that one uniform can be chosen to
+    accept and another to reject. A Gaussian target cannot supply that
+    reliably: leapfrog energy error on a Gaussian stays bounded until the
+    stability limit and then blows up, so ``p_accept`` jumps from 1 to 0 with
+    almost no interval between. A skewed target gives a genuinely intermediate
+    probability.
+    """
+    flat, _ = jax.flatten_util.ravel_pytree(x)
+    scales = jnp.arange(1, flat.size + 1, dtype=flat.dtype)
+    y = flat / scales
+    return jnp.sum(y - jnp.exp(y))
 
 
 def _moderately_stiff_logdensity(x):
@@ -423,11 +456,18 @@ class CoupledHMCMathTest(BlackJAXTest):
 class CoupledHMCContractTest(BlackJAXTest):
     """Checks that coupling changes only the joint law of the inputs."""
 
-    def _pair_state(self, dtype=jnp.float64, first_fn=None, second_fn=None):
+    def _pair_state(self, dtype=jnp.float64, first_fn=None, second_fn=None, key=None):
+        """Build a paired state.
+
+        Pass ``key`` for a control that needs reproducible positions rather
+        than a fresh draw per day.
+        """
         first_fn = first_fn or _standard_normal_logdensity
         second_fn = second_fn or _standard_normal_logdensity
-        first_position = jax.random.normal(self.next_key(), (_DIM,), dtype)
-        second_position = jax.random.normal(self.next_key(), (_DIM,), dtype)
+        position_key = self.next_key() if key is None else key
+        first_key, second_key = jax.random.split(position_key)
+        first_position = jax.random.normal(first_key, (_DIM,), dtype)
+        second_position = jax.random.normal(second_key, (_DIM,), dtype)
         return coupled_hmc.init(
             (first_position, second_position), (first_fn, second_fn)
         )
@@ -447,11 +487,26 @@ class CoupledHMCContractTest(BlackJAXTest):
         """
         with _x64():
             payloads = _metric_payloads(jnp.float64)
-            first_fn, second_fn = _standard_normal_logdensity, _tilted_logdensity
+            # Two different non-Gaussian targets, two different metrics, two
+            # different step sizes and integration counts. These settings are a
+            # fixture chosen so that BOTH reference acceptance probabilities are
+            # strictly interior under both couplings (about 0.53 for the first,
+            # and 0.82 synchronous / 0.75 reflected for the second), which is
+            # what lets one uniform accept and another reject.
+            first_fn = smooth_skewed_logdensity
+            second_fn = _skewed_anisotropic_logdensity
             first_mass, second_mass = payloads["dense"], payloads["low_rank"]
-            step_sizes, integration_steps = (0.09, 0.23), (3, 5)
+            step_sizes, integration_steps = _REFERENCE_STEP_SIZES, (3, 5)
 
-            state = self._pair_state(first_fn=first_fn, second_fn=second_fn)
+            control_key, noise_key = jax.random.split(jax.random.key(_REFERENCE_SEED))
+            first_key, second_key = jax.random.split(control_key)
+            state = coupled_hmc.init(
+                (
+                    0.5 * jax.random.normal(first_key, (_DIM,), jnp.float64),
+                    0.5 * jax.random.normal(second_key, (_DIM,), jnp.float64),
+                ),
+                (first_fn, second_fn),
+            )
             step = coupled_hmc._build_prescribed_pair(
                 (first_fn, second_fn),
                 (first_mass, second_mass),
@@ -462,7 +517,7 @@ class CoupledHMCContractTest(BlackJAXTest):
                 coupling,
                 coupled_hmc.whitened_difference if coupling == "reflection" else None,
             )
-            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            noise = jax.random.normal(noise_key, (_DIM,), jnp.float64)
 
             # Running only an accepting case would leave the rejection branch
             # uncompared, so a kernel that always returned the proposal would
@@ -492,11 +547,29 @@ class CoupledHMCContractTest(BlackJAXTest):
                 second_noise,
                 0.0,
             )[2]
-            lowest = min(float(probe_first), float(probe_second))
+            # Both reference probabilities must be strictly INTERIOR, or this
+            # control cannot force both outcomes and asserts nothing. A
+            # probability that has rounded to exactly 1 makes the rejecting case
+            # unreachable; the fixture is chosen so that does not happen, and
+            # the test fails loudly rather than being skipped or clipped into
+            # passing if it ever does.
+            for label, probability in (
+                ("first", float(probe_first)),
+                ("second", float(probe_second)),
+            ):
+                self.assertGreater(
+                    probability,
+                    0.0,
+                    f"{label} reference p_accept is 0, no accepting uniform exists",
+                )
+                self.assertLess(
+                    probability,
+                    1.0,
+                    f"{label} reference p_accept rounded to 1, no rejecting "
+                    "uniform exists -- choose a different control fixture rather "
+                    "than skipping or clipping this case",
+                )
             highest = max(float(probe_first), float(probe_second))
-            # Both branches must be reachable for this case to mean anything.
-            self.assertGreater(lowest, 0.0)
-            self.assertLess(highest, 1.0)
             # Acceptance is `uniform < p_accept`, so `uniform = highest` rejects
             # both marginals and `uniform = 0` accepts both.
             uniform = jnp.asarray(0.0 if accept else highest, jnp.float64)
@@ -825,7 +898,9 @@ class CoupledHMCContractTest(BlackJAXTest):
             _, step = coupled_hmc._build_prescribed_marginal(
                 _stiff_logdensity, mass, 5.0, 8, integrators.velocity_verlet, 1000.0
             )
-            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            noise = jax.random.normal(
+                jax.random.key(_CONTROL_SEED), (_DIM,), jnp.float64
+            )
             new_state, info = step(state, noise, jnp.asarray(0.0, jnp.float64))
             self.assertEqual(float(info.acceptance_rate), 0.0)
             self.assertFalse(bool(info.is_accepted))

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -1,0 +1,1075 @@
+"""Tests for :mod:`blackjax.mcmc.coupled_hmc`.
+
+The tests are grouped so that the two groups fail for different reasons.
+
+:class:`CoupledHMCMathTest` checks the mathematics the coupling relies on:
+that externalising the momentum draw reproduces the metric's own momentum
+law, that the reflection is a norm-preserving involution which leaves the
+standard normal distribution intact, that the default direction really is the
+inverse momentum map, and that the trajectory agrees with an independent
+NumPy leapfrog.
+
+:class:`CoupledHMCContractTest` checks the interface contract: that each
+marginal's returned state *and* info equal what an independently reconstructed
+uncoupled marginal produces from the same inputs, that the shared uniform
+drives each marginal's own comparison rather than a shared verdict, and that
+invalid input is refused rather than quietly turned into a Metropolis
+rejection.
+
+The uncoupled reference in the second group is rebuilt from BlackJAX
+primitives (``trajectory.static_integration``, ``hmc.flip_momentum``,
+``hmc_energy``, ``safe_energy_diff``) rather than by calling the module's own
+prescribed helper a second time, so agreement is evidence about the module
+instead of a tautology.
+"""
+import chex
+import jax
+import jax.flatten_util
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+
+from blackjax.base import SamplingAlgorithm
+from blackjax.mcmc import coupled_hmc, integrators, metrics, trajectory
+from blackjax.mcmc.hmc import HMCState, flip_momentum
+from blackjax.mcmc.proposal import safe_energy_diff
+from blackjax.mcmc.trajectory import hmc_energy
+from blackjax.util import generate_gaussian_noise, run_inference_algorithm
+from tests.fixtures import BlackJAXTest
+
+# ---------------------------------------------------------------------------
+# Targets and metric payloads
+# ---------------------------------------------------------------------------
+_DIM = 4
+_RANK = 2
+
+
+def _standard_normal_logdensity(x):
+    flat, _ = jax.flatten_util.ravel_pytree(x)
+    return -0.5 * jnp.sum(flat**2)
+
+
+def _tilted_logdensity(x):
+    """A second, genuinely different target: anisotropic with a linear tilt."""
+    flat, _ = jax.flatten_util.ravel_pytree(x)
+    scales = jnp.arange(1, flat.size + 1, dtype=flat.dtype)
+    return -0.5 * jnp.sum((flat / scales) ** 2) + jnp.sum(0.3 * flat)
+
+
+def _stiff_logdensity(x):
+    """Sharply curved, so a large step size makes rejection near-certain."""
+    flat, _ = jax.flatten_util.ravel_pytree(x)
+    return -0.5 * jnp.sum((flat * 60.0) ** 2)
+
+
+def _moderately_stiff_logdensity(x):
+    """Curved just enough that a moderate step size gives an intermediate
+    acceptance probability, rather than a saturated 0 or 1."""
+    flat, _ = jax.flatten_util.ravel_pytree(x)
+    return -0.5 * jnp.sum((flat * 2.0) ** 2)
+
+
+def _metric_payloads(dtype):
+    """Return one payload per supported metric kind, in ``dtype``."""
+    rng = np.random.default_rng(20260907)
+    diagonal = jnp.asarray(np.abs(rng.normal(size=_DIM)) + 0.5, dtype=dtype)
+    root = rng.normal(size=(_DIM, _DIM))
+    dense = jnp.asarray(root @ root.T + _DIM * np.eye(_DIM), dtype=dtype)
+    basis, _ = np.linalg.qr(rng.normal(size=(_DIM, _RANK)))
+    low_rank = metrics.LowRankInverseMassMatrix(
+        jnp.asarray(np.abs(rng.normal(size=_DIM)) + 0.5, dtype=dtype),
+        jnp.asarray(basis, dtype=dtype),
+        jnp.asarray(np.abs(rng.normal(size=_RANK)) + 0.5, dtype=dtype),
+    )
+    return {"diagonal": diagonal, "dense": dense, "low_rank": low_rank}
+
+
+def _x64():
+    return jax.enable_x64()
+
+
+# ---------------------------------------------------------------------------
+# An uncoupled reference transition, rebuilt from BlackJAX primitives
+# ---------------------------------------------------------------------------
+def _oracle_marginal(
+    logdensity_fn,
+    inverse_mass_matrix,
+    step_size,
+    num_integration_steps,
+    state,
+    standard_normal,
+    uniform,
+    divergence_threshold=1000.0,
+):
+    """One uncoupled HMC transition from a prescribed ``(z, u)``.
+
+    Deliberately does not touch ``coupled_hmc``: the trajectory, endpoint
+    flip, energies and acceptance test are reassembled here from the library's
+    own pieces so that agreement is an independent check.
+
+    Returns ``(state, momentum, acceptance_rate, is_accepted, is_divergent,
+    energy, proposal)`` -- everything the production ``HMCInfo`` carries.
+    """
+    metric = metrics.default_metric(inverse_mass_matrix)
+    integrator = integrators.velocity_verlet(logdensity_fn, metric.kinetic_energy)
+    build_trajectory = trajectory.static_integration(integrator)
+    energy_fn = hmc_energy(metric.kinetic_energy)
+
+    _, unravel = jax.flatten_util.ravel_pytree(state.position)
+    momentum = metric.scale(
+        state.position, unravel(standard_normal), inv=False, trans=False
+    )
+    start = integrators.IntegratorState(
+        state.position, momentum, state.logdensity, state.logdensity_grad
+    )
+    end = flip_momentum(build_trajectory(start, step_size, num_integration_steps))
+
+    initial_energy = energy_fn(start)
+    new_energy = energy_fn(end)
+    delta_energy = safe_energy_diff(initial_energy, new_energy)
+    is_divergent = -delta_energy > divergence_threshold
+
+    p_accept = jnp.clip(jnp.exp(delta_energy), max=1)
+    is_accepted = uniform < p_accept
+    selected = jax.tree.map(lambda a, b: jnp.where(is_accepted, a, b), end, start)
+    new_state = HMCState(
+        selected.position, selected.logdensity, selected.logdensity_grad
+    )
+    return (
+        new_state,
+        momentum,
+        p_accept,
+        is_accepted,
+        is_divergent,
+        new_energy,
+        end,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mathematics and numerics
+# ---------------------------------------------------------------------------
+class CoupledHMCMathTest(BlackJAXTest):
+    """Checks the algebra the coupling relies on."""
+
+    @parameterized.parameters("diagonal", "dense", "low_rank")
+    def test_scale_reproduces_the_momentum_law(self, kind):
+        """``scale(z, inv=False, trans=False)`` is ``sample_momentum``'s map.
+
+        This is the identity that lets the momentum draw be externalised
+        without perturbing either marginal's law.
+        """
+        with _x64():
+            payload = _metric_payloads(jnp.float64)[kind]
+            metric = metrics.default_metric(payload)
+            key = self.next_key()
+            position = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+
+            reference = metric.sample_momentum(key, position)
+            noise = generate_gaussian_noise(key, position)
+            via_scale = metric.scale(position, noise, inv=False, trans=False)
+
+            chex.assert_trees_all_equal(reference, via_scale)
+
+    def test_scale_reproduces_the_momentum_law_on_a_pytree(self):
+        with _x64():
+            position = {
+                "a": jnp.ones((2,), jnp.float64),
+                "b": jnp.ones((3,), jnp.float64),
+            }
+            metric = metrics.default_metric(jnp.ones((5,), jnp.float64))
+            key = self.next_key()
+            reference = metric.sample_momentum(key, position)
+            via_scale = metric.scale(
+                position, generate_gaussian_noise(key, position), inv=False, trans=False
+            )
+            chex.assert_trees_all_equal(reference, via_scale)
+
+    def test_reflection_is_a_norm_preserving_involution(self):
+        with _x64():
+            direction = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            unit = coupled_hmc._reflection_unit(direction)
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+
+            reflected = coupled_hmc._reflect(noise, unit)
+            np.testing.assert_allclose(
+                float(jnp.linalg.norm(reflected)),
+                float(jnp.linalg.norm(noise)),
+                rtol=1e-12,
+            )
+            chex.assert_trees_all_close(
+                coupled_hmc._reflect(reflected, unit), noise, atol=1e-12
+            )
+            np.testing.assert_allclose(float(jnp.linalg.norm(unit)), 1.0, rtol=1e-12)
+
+    def test_reflection_preserves_the_standard_normal(self):
+        """Finite-sample check that the reflected innovations are still N(0, I).
+
+        This is the *only* property reflection is claimed to have.
+        """
+        with _x64():
+            unit = coupled_hmc._reflection_unit(
+                jnp.asarray([1.0, 2.0, -0.5, 0.25], jnp.float64)
+            )
+            noise = jax.random.normal(self.next_key(), (40000, _DIM), jnp.float64)
+            reflected = jax.vmap(coupled_hmc._reflect, in_axes=(0, None))(noise, unit)
+
+            mean = np.asarray(reflected.mean(axis=0))
+            covariance = np.cov(np.asarray(reflected), rowvar=False)
+            # 40000 draws: the standard error on a mean is 5e-3, on a
+            # covariance entry about 7e-3; these thresholds are ~6 sigma.
+            np.testing.assert_allclose(mean, 0.0, atol=3e-2)
+            np.testing.assert_allclose(covariance, np.eye(_DIM), atol=5e-2)
+
+    @parameterized.parameters("diagonal", "dense", "low_rank")
+    def test_whitened_difference_is_the_inverse_momentum_map(self, kind):
+        r"""``whitened_difference`` returns :math:`A^{-1}(x_1-x_2)`.
+
+        Verified through the identity that motivates it,
+        :math:`\langle \Delta x, \partial K/\partial p\rangle = \langle
+        A^{-1}\Delta x, z\rangle`, using autodiff on the library's own kinetic
+        energy rather than a hand-written formula.
+        """
+        with _x64():
+            payload = _metric_payloads(jnp.float64)[kind]
+            metric = metrics.default_metric(payload)
+            first = HMCState(
+                jax.random.normal(self.next_key(), (_DIM,), jnp.float64), 0.0, None
+            )
+            second = HMCState(
+                jax.random.normal(self.next_key(), (_DIM,), jnp.float64), 0.0, None
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+
+            direction = coupled_hmc.whitened_difference(first, second, metric)
+            momentum = metric.scale(first.position, noise, inv=False, trans=False)
+            velocity = jax.grad(metric.kinetic_energy)(momentum)
+            delta = first.position - second.position
+
+            np.testing.assert_allclose(
+                float(jnp.dot(delta, velocity)),
+                float(jnp.dot(direction, noise)),
+                rtol=1e-10,
+                atol=1e-12,
+            )
+
+    def test_zero_direction_is_the_identity(self):
+        with _x64():
+            unit = coupled_hmc._reflection_unit(jnp.zeros((_DIM,), jnp.float64))
+            chex.assert_trees_all_equal(unit, jnp.zeros((_DIM,), jnp.float64))
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            chex.assert_trees_all_equal(coupled_hmc._reflect(noise, unit), noise)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "tiny", "scale": 1e-300},
+        {"testcase_name": "huge", "scale": 1e300},
+        {"testcase_name": "ordinary", "scale": 1.0},
+    )
+    def test_reflection_unit_normalises_extreme_directions(self, scale):
+        """A direction whose norm would overflow or underflow still normalises."""
+        with _x64():
+            direction = scale * jnp.asarray([1.0, -2.0, 0.5, 3.0], jnp.float64)
+            unit = coupled_hmc._reflection_unit(direction)
+            np.testing.assert_allclose(float(jnp.linalg.norm(unit)), 1.0, rtol=1e-12)
+            # The unit vector is scale-free: it matches the ordinary case.
+            reference = coupled_hmc._reflection_unit(
+                jnp.asarray([1.0, -2.0, 0.5, 3.0], jnp.float64)
+            )
+            chex.assert_trees_all_close(unit, reference, atol=1e-12)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "nan", "bad": float("nan")},
+        {"testcase_name": "inf", "bad": float("inf")},
+    )
+    def test_reflection_unit_does_not_launder_a_non_finite_direction(self, bad):
+        """A non-finite direction must stay visible, not become a plausible unit."""
+        with _x64():
+            direction = jnp.asarray([bad, 1.0, 0.0, 0.0], jnp.float64)
+            unit = coupled_hmc._reflection_unit(direction)
+            self.assertFalse(bool(jnp.all(jnp.isfinite(unit))))
+
+    def test_low_rank_unit_eigenvalues_are_neutral(self):
+        """``lam = 1`` columns leave the low-rank metric equal to its diagonal."""
+        with _x64():
+            sigma = jnp.asarray([1.0, 2.0, 0.5, 1.5], jnp.float64)
+            basis, _ = np.linalg.qr(np.random.default_rng(0).normal(size=(_DIM, _RANK)))
+            padded = metrics.LowRankInverseMassMatrix(
+                sigma,
+                jnp.asarray(basis, jnp.float64),
+                jnp.ones((_RANK,), jnp.float64),
+            )
+            low_rank_metric = metrics.default_metric(padded)
+            diagonal_metric = metrics.default_metric(sigma**2)
+
+            position = jnp.zeros((_DIM,), jnp.float64)
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            chex.assert_trees_all_close(
+                low_rank_metric.scale(position, noise, inv=False, trans=False),
+                diagonal_metric.scale(position, noise, inv=False, trans=False),
+                atol=1e-12,
+            )
+
+    def test_trajectory_matches_an_independent_numpy_leapfrog(self):
+        """The marginal trajectory agrees with a from-scratch NumPy integrator."""
+        with _x64():
+            step_size, num_steps = 0.1, 6
+            inverse_mass = np.array([1.0, 2.0, 0.5, 1.5])
+            position = np.array([0.3, -0.7, 1.1, 0.05])
+            noise = np.array([0.2, 0.4, -0.6, 0.9])
+
+            # NumPy oracle: grad of -0.5 * sum(x^2) is -x.
+            momentum = noise / np.sqrt(inverse_mass)
+            oracle_position = position.copy()
+            oracle_momentum = momentum.copy()
+            oracle_momentum = oracle_momentum + 0.5 * step_size * (-oracle_position)
+            for step in range(num_steps):
+                oracle_position = (
+                    oracle_position + step_size * inverse_mass * oracle_momentum
+                )
+                weight = 0.5 if step == num_steps - 1 else 1.0
+                oracle_momentum = oracle_momentum + weight * step_size * (
+                    -oracle_position
+                )
+
+            metric = metrics.default_metric(jnp.asarray(inverse_mass, jnp.float64))
+            integrator = integrators.velocity_verlet(
+                _standard_normal_logdensity, metric.kinetic_energy
+            )
+            build = trajectory.static_integration(integrator)
+            jax_position = jnp.asarray(position, jnp.float64)
+            start = integrators.IntegratorState(
+                jax_position,
+                jnp.asarray(momentum, jnp.float64),
+                _standard_normal_logdensity(jax_position),
+                jax.grad(_standard_normal_logdensity)(jax_position),
+            )
+            end = build(start, step_size, num_steps)
+
+            np.testing.assert_allclose(
+                np.asarray(end.position), oracle_position, rtol=1e-11
+            )
+            np.testing.assert_allclose(
+                np.asarray(end.momentum), oracle_momentum, rtol=1e-11
+            )
+
+    def test_endpoint_map_is_an_involution(self):
+        """Integrating from the flipped endpoint returns the starting state."""
+        with _x64():
+            metric = metrics.default_metric(jnp.ones((_DIM,), jnp.float64))
+            integrator = integrators.velocity_verlet(
+                _tilted_logdensity, metric.kinetic_energy
+            )
+            build = trajectory.static_integration(integrator)
+            position = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            momentum = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            start = integrators.IntegratorState(
+                position,
+                momentum,
+                _tilted_logdensity(position),
+                jax.grad(_tilted_logdensity)(position),
+            )
+            end = flip_momentum(build(start, 0.09, 5))
+            back = flip_momentum(build(end, 0.09, 5))
+
+            chex.assert_trees_all_close(back.position, start.position, atol=1e-10)
+            chex.assert_trees_all_close(back.momentum, start.momentum, atol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# The interface contract
+# ---------------------------------------------------------------------------
+class CoupledHMCContractTest(BlackJAXTest):
+    """Checks that coupling changes only the joint law of the inputs."""
+
+    def _pair_state(self, dtype=jnp.float64, first_fn=None, second_fn=None):
+        first_fn = first_fn or _standard_normal_logdensity
+        second_fn = second_fn or _standard_normal_logdensity
+        first_position = jax.random.normal(self.next_key(), (_DIM,), dtype)
+        second_position = jax.random.normal(self.next_key(), (_DIM,), dtype)
+        return coupled_hmc.init(
+            (first_position, second_position), (first_fn, second_fn)
+        )
+
+    # -- each marginal is unchanged by coupling -----------------------------
+    @parameterized.parameters("synchronous", "reflection")
+    def test_marginals_match_an_independent_reference(self, coupling):
+        """Both marginals' state AND info equal the uncoupled reference's.
+
+        Heterogeneous on purpose: different targets, metrics, step sizes and
+        integration counts, so a parameter leaking across the pair shows up.
+        """
+        with _x64():
+            payloads = _metric_payloads(jnp.float64)
+            first_fn, second_fn = _standard_normal_logdensity, _tilted_logdensity
+            first_mass, second_mass = payloads["dense"], payloads["low_rank"]
+            step_sizes, integration_steps = (0.09, 0.23), (3, 5)
+
+            state = self._pair_state(first_fn=first_fn, second_fn=second_fn)
+            step = coupled_hmc._build_prescribed_pair(
+                (first_fn, second_fn),
+                (first_mass, second_mass),
+                step_sizes,
+                integration_steps,
+                integrators.velocity_verlet,
+                1000.0,
+                coupling,
+                coupled_hmc.whitened_difference if coupling == "reflection" else None,
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            uniform = jnp.asarray(0.4, jnp.float64)
+
+            new_state, info = step(state, noise, uniform)
+
+            # Reconstruct the innovation each marginal must have received.
+            second_noise = (
+                coupled_hmc._reflect(noise, info.reflection_unit)
+                if coupling == "reflection"
+                else noise
+            )
+            for label, marginal_state, marginal_info, fn, mass, size, count, z in (
+                (
+                    "first",
+                    state.first,
+                    info.first,
+                    first_fn,
+                    first_mass,
+                    step_sizes[0],
+                    integration_steps[0],
+                    noise,
+                ),
+                (
+                    "second",
+                    state.second,
+                    info.second,
+                    second_fn,
+                    second_mass,
+                    step_sizes[1],
+                    integration_steps[1],
+                    second_noise,
+                ),
+            ):
+                (
+                    oracle_state,
+                    oracle_momentum,
+                    oracle_rate,
+                    oracle_accepted,
+                    oracle_divergent,
+                    oracle_energy,
+                    oracle_proposal,
+                ) = _oracle_marginal(fn, mass, size, count, marginal_state, z, uniform)
+
+                produced = new_state.first if label == "first" else new_state.second
+                with self.subTest(marginal=label):
+                    chex.assert_trees_all_close(
+                        produced, oracle_state, atol=1e-12, rtol=1e-12
+                    )
+                    chex.assert_trees_all_close(
+                        marginal_info.momentum, oracle_momentum, atol=1e-12
+                    )
+                    chex.assert_trees_all_close(
+                        marginal_info.acceptance_rate, oracle_rate, atol=1e-12
+                    )
+                    self.assertEqual(
+                        bool(marginal_info.is_accepted), bool(oracle_accepted)
+                    )
+                    self.assertEqual(
+                        bool(marginal_info.is_divergent), bool(oracle_divergent)
+                    )
+                    chex.assert_trees_all_close(
+                        marginal_info.energy, oracle_energy, atol=1e-12
+                    )
+                    chex.assert_trees_all_close(
+                        marginal_info.proposal, oracle_proposal, atol=1e-12
+                    )
+                    self.assertEqual(marginal_info.num_integration_steps, count)
+
+    # -- planted defects: confirm these checks actually bite ----------------
+    def test_crossing_the_caches_changes_the_transition(self):
+        """Swapping the two marginals' caches must change the result.
+
+        If it did not, the comparison against the independent reference could
+        not detect a crossed cache, and the checks above would be vacuous.
+        """
+        with _x64():
+            state = self._pair_state(
+                first_fn=_standard_normal_logdensity, second_fn=_tilted_logdensity
+            )
+            crossed = coupled_hmc.CoupledHMCState(
+                HMCState(
+                    state.first.position,
+                    state.second.logdensity,
+                    state.second.logdensity_grad,
+                ),
+                state.second,
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            uniform = jnp.asarray(0.3, jnp.float64)
+            mass = jnp.ones((_DIM,), jnp.float64)
+
+            honest, _, *_ = _oracle_marginal(
+                _standard_normal_logdensity, mass, 0.1, 4, state.first, noise, uniform
+            )
+            crossed_result, _, *_ = _oracle_marginal(
+                _standard_normal_logdensity, mass, 0.1, 4, crossed.first, noise, uniform
+            )
+            # The planted defect changes the transition, so the check bites.
+            self.assertFalse(
+                bool(jnp.allclose(honest.position, crossed_result.position, atol=1e-10))
+            )
+
+    def _intermediate_pair(self):
+        """A pair whose second marginal accepts with probability strictly inside
+        ``(0, 1)``.
+
+        This matters: a control built on a second marginal with ``p_accept ==
+        0`` would report "the two disagree" even if the uniform were ignored
+        entirely, because a zero probability rejects for every uniform.  Only
+        an intermediate probability makes the outcome actually depend on the
+        shared variate.  The settings below give ``p_accept`` near 0.69.
+        """
+        first_fn = _standard_normal_logdensity
+        second_fn = _moderately_stiff_logdensity
+        position = jnp.full((_DIM,), 0.5, jnp.float64)
+        state = coupled_hmc.init((position, position), (first_fn, second_fn))
+        step = coupled_hmc._build_prescribed_pair(
+            (first_fn, second_fn),
+            (jnp.ones((_DIM,), jnp.float64), jnp.ones((_DIM,), jnp.float64)),
+            (1e-6, 0.4),
+            (3, 3),
+            integrators.velocity_verlet,
+            1000.0,
+            "synchronous",
+            None,
+        )
+        noise = jax.random.normal(jax.random.key(7), (_DIM,), jnp.float64)
+        return state, step, noise
+
+    def test_every_decision_is_that_marginal_s_own_uniform_comparison(self):
+        """``is_accepted`` equals ``uniform < acceptance_rate``, per marginal.
+
+        This is the exact statement of the shared-uniform contract, and it is
+        what fails if a marginal is fed anything other than the reported
+        uniform, or is handed the other marginal's verdict.
+        """
+        with _x64():
+            state, step, noise = self._intermediate_pair()
+            for value in (0.0, 0.1, 0.3, 0.5, 0.68, 0.7, 0.9, 0.999):
+                _, info = step(state, noise, jnp.asarray(value, jnp.float64))
+                with self.subTest(uniform=value):
+                    self.assertEqual(float(info.uniform), value)
+                    for marginal in (info.first, info.second):
+                        self.assertEqual(
+                            bool(marginal.is_accepted),
+                            float(info.uniform) < float(marginal.acceptance_rate),
+                        )
+
+    def test_the_shared_uniform_drives_each_marginal_separately(self):
+        """One uniform, two probabilities: the second flips where the first cannot.
+
+        Sweeping the shared variate across the second marginal's acceptance
+        probability makes its verdict change while the first marginal, which
+        accepts with probability one, never does.  A pair that shared its
+        *decision* rather than its uniform could not produce this pattern.
+        """
+        with _x64():
+            state, step, noise = self._intermediate_pair()
+            _, probe = step(state, noise, jnp.asarray(0.5, jnp.float64))
+            second_probability = float(probe.second.acceptance_rate)
+            self.assertGreater(second_probability, 0.05)
+            self.assertLess(second_probability, 0.95)
+            np.testing.assert_allclose(
+                float(probe.first.acceptance_rate), 1.0, rtol=1e-9
+            )
+
+            _, below = step(
+                state,
+                noise,
+                jnp.asarray(second_probability - 1e-6, jnp.float64),
+            )
+            _, above = step(
+                state,
+                noise,
+                jnp.asarray(second_probability + 1e-6, jnp.float64),
+            )
+
+            self.assertTrue(bool(below.second.is_accepted))
+            self.assertFalse(bool(above.second.is_accepted))
+            # The first marginal is unmoved by the same sweep.
+            self.assertTrue(bool(below.first.is_accepted))
+            self.assertTrue(bool(above.first.is_accepted))
+
+    def test_a_zero_probability_marginal_rejects_whatever_the_partner_does(self):
+        """The ``p_accept == 0`` case, kept as an endpoint rather than a control."""
+        with _x64():
+            state = self._pair_state(
+                first_fn=_standard_normal_logdensity, second_fn=_stiff_logdensity
+            )
+            step = coupled_hmc._build_prescribed_pair(
+                (_standard_normal_logdensity, _stiff_logdensity),
+                (jnp.ones((_DIM,), jnp.float64), jnp.ones((_DIM,), jnp.float64)),
+                (0.05, 0.9),
+                (3, 3),
+                integrators.velocity_verlet,
+                1000.0,
+                "synchronous",
+                None,
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            _, info = step(state, noise, jnp.asarray(0.5, jnp.float64))
+
+            self.assertEqual(float(info.uniform), 0.5)
+            self.assertTrue(bool(info.first.is_accepted))
+            self.assertFalse(bool(info.second.is_accepted))
+            self.assertGreater(
+                float(info.first.acceptance_rate), float(info.second.acceptance_rate)
+            )
+
+    def test_each_marginal_keeps_its_own_cache(self):
+        """Returned caches match each marginal's OWN target, not the other's."""
+        with _x64():
+            first_fn, second_fn = _standard_normal_logdensity, _tilted_logdensity
+            state = self._pair_state(first_fn=first_fn, second_fn=second_fn)
+            kernel = coupled_hmc.build_kernel()
+            mass = jnp.ones((_DIM,), jnp.float64)
+            new_state, _ = kernel(
+                self.next_key(),
+                state,
+                (first_fn, second_fn),
+                (0.1, 0.1),
+                (mass, mass),
+                (4, 4),
+            )
+            for produced, fn in (
+                (new_state.first, first_fn),
+                (new_state.second, second_fn),
+            ):
+                chex.assert_trees_all_close(
+                    produced.logdensity, fn(produced.position), atol=1e-12
+                )
+                chex.assert_trees_all_close(
+                    produced.logdensity_grad,
+                    jax.grad(fn)(produced.position),
+                    atol=1e-12,
+                )
+            # The two targets really do differ, so the check above has bite.
+            self.assertNotAlmostEqual(
+                float(first_fn(new_state.first.position)),
+                float(second_fn(new_state.first.position)),
+            )
+
+    # -- the Metropolis rule and its endpoints ------------------------------
+    def test_acceptance_probability_matches_ordinary_hmc(self):
+        """The mathematical MH rule is ordinary HMC's.
+
+        The acceptance *probability* must agree exactly.  The realised
+        accept/reject draw is not compared: ordinary HMC uses
+        ``jax.random.bernoulli`` and this kernel uses a uniform comparison, so
+        no draw-for-draw parity exists or is claimed.
+        """
+        with _x64():
+            mass = jnp.ones((_DIM,), jnp.float64)
+            position = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            state = HMCState(
+                position,
+                _tilted_logdensity(position),
+                jax.grad(_tilted_logdensity)(position),
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+
+            _, prescribed_step = coupled_hmc._build_prescribed_marginal(
+                _tilted_logdensity,
+                mass,
+                0.35,
+                4,
+                integrators.velocity_verlet,
+                1000.0,
+            )
+            _, info = prescribed_step(state, noise, jnp.asarray(0.5, jnp.float64))
+            (
+                _,
+                _,
+                oracle_rate,
+                *_,
+            ) = _oracle_marginal(_tilted_logdensity, mass, 0.35, 4, state, noise, 0.5)
+            chex.assert_trees_all_close(info.acceptance_rate, oracle_rate, atol=1e-14)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "u_zero", "uniform": 0.0},
+        {"testcase_name": "u_just_below_one", "uniform": None},
+    )
+    def test_certain_acceptance_accepts_at_both_uniform_endpoints(self, uniform):
+        """``p_accept == 1`` accepts for every admissible uniform in [0, 1)."""
+        with _x64():
+            if uniform is None:
+                uniform = float(jnp.nextafter(jnp.float64(1.0), jnp.float64(0.0)))
+            mass = jnp.ones((_DIM,), jnp.float64)
+            position = jnp.zeros((_DIM,), jnp.float64)
+            state = HMCState(
+                position,
+                _standard_normal_logdensity(position),
+                jax.grad(_standard_normal_logdensity)(position),
+            )
+            # A vanishing step size makes the energy error ~0, so p_accept == 1.
+            _, step = coupled_hmc._build_prescribed_marginal(
+                _standard_normal_logdensity,
+                mass,
+                1e-8,
+                2,
+                integrators.velocity_verlet,
+                1000.0,
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            _, info = step(state, noise, jnp.asarray(uniform, jnp.float64))
+            np.testing.assert_allclose(float(info.acceptance_rate), 1.0, rtol=1e-12)
+            self.assertTrue(bool(info.is_accepted))
+
+    def test_certain_rejection_rejects_at_the_zero_uniform(self):
+        """``p_accept == 0`` (a divergence) rejects even at ``u == 0``."""
+        with _x64():
+            mass = jnp.ones((_DIM,), jnp.float64)
+            position = jnp.full((_DIM,), 3.0, jnp.float64)
+            state = HMCState(
+                position,
+                _stiff_logdensity(position),
+                jax.grad(_stiff_logdensity)(position),
+            )
+            _, step = coupled_hmc._build_prescribed_marginal(
+                _stiff_logdensity, mass, 5.0, 8, integrators.velocity_verlet, 1000.0
+            )
+            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            _, info = step(state, noise, jnp.asarray(0.0, jnp.float64))
+            self.assertEqual(float(info.acceptance_rate), 0.0)
+            self.assertFalse(bool(info.is_accepted))
+            chex.assert_trees_all_equal(info.proposal.position, info.proposal.position)
+
+    def test_prescribed_uniform_is_not_narrowed(self):
+        """A float64 uniform must be refused by a float32 marginal, not cast.
+
+        Casting would map a value strictly below one onto exactly ``1.0f``,
+        which then loses a certain acceptance.  The refusal is what prevents
+        that, so it is asserted directly -- including on the exact value that
+        exhibits the collapse.
+        """
+        with _x64():
+            just_below_one = jnp.nextafter(jnp.float64(1.0), jnp.float64(0.0))
+            # The collapse this guards against is real:
+            self.assertTrue(bool(just_below_one < 1))
+            self.assertEqual(float(just_below_one.astype(jnp.float32)), 1.0)
+
+            position = jnp.zeros((_DIM,), jnp.float32)
+            state = HMCState(
+                position,
+                _standard_normal_logdensity(position),
+                jax.grad(_standard_normal_logdensity)(position),
+            )
+            _, step = coupled_hmc._build_prescribed_marginal(
+                _standard_normal_logdensity,
+                jnp.ones((_DIM,), jnp.float32),
+                0.1,
+                2,
+                integrators.velocity_verlet,
+                1000.0,
+            )
+            noise = jnp.zeros((_DIM,), jnp.float32)
+            with self.assertRaisesRegex(TypeError, "no narrowing"):
+                step(state, noise, just_below_one)
+
+    def test_prescribed_innovations_must_match_shape_and_dtype(self):
+        with _x64():
+            position = jnp.zeros((_DIM,), jnp.float64)
+            state = HMCState(
+                position,
+                _standard_normal_logdensity(position),
+                jax.grad(_standard_normal_logdensity)(position),
+            )
+            _, step = coupled_hmc._build_prescribed_marginal(
+                _standard_normal_logdensity,
+                jnp.ones((_DIM,), jnp.float64),
+                0.1,
+                2,
+                integrators.velocity_verlet,
+                1000.0,
+            )
+            good_noise = jnp.zeros((_DIM,), jnp.float64)
+            good_uniform = jnp.asarray(0.5, jnp.float64)
+
+            with self.assertRaisesRegex(ValueError, "flat vector matching"):
+                step(state, jnp.zeros((_DIM + 1,), jnp.float64), good_uniform)
+            with self.assertRaisesRegex(TypeError, "dtype must match"):
+                step(state, jnp.zeros((_DIM,), jnp.float32), good_uniform)
+            with self.assertRaisesRegex(ValueError, "must be a scalar"):
+                step(state, good_noise, jnp.zeros((2,), jnp.float64))
+
+    # -- input discipline ---------------------------------------------------
+    def test_metric_kinds_outside_the_tested_set_are_refused(self):
+        mass = jnp.ones((_DIM,))
+        with self.assertRaisesRegex(TypeError, "callable"):
+            coupled_hmc._check_metric_kind(lambda position: mass)
+        with self.assertRaisesRegex(TypeError, "pre-built Metric"):
+            coupled_hmc._check_metric_kind(metrics.default_metric(mass))
+
+    @parameterized.parameters(
+        "logdensity_fn", "step_size", "inverse_mass_matrix", "num_integration_steps"
+    )
+    def test_every_per_marginal_parameter_must_be_an_explicit_pair(self, name):
+        mass = jnp.ones((_DIM,))
+        arguments = {
+            "logdensity_fn": (_standard_normal_logdensity,) * 2,
+            "step_size": (0.1, 0.1),
+            "inverse_mass_matrix": (mass, mass),
+            "num_integration_steps": (4, 4),
+        }
+        arguments[name] = arguments[name][0]
+        with self.assertRaisesRegex(TypeError, f"`{name}` must be an explicit"):
+            coupled_hmc.as_top_level_api(**arguments)
+
+    def test_paired_positions_must_agree(self):
+        fns = (_standard_normal_logdensity,) * 2
+        with self.assertRaisesRegex(ValueError, "one pytree structure"):
+            coupled_hmc.init((jnp.ones((_DIM,)), {"a": jnp.ones((_DIM,))}), fns)
+        with self.assertRaisesRegex(ValueError, "matching flat shapes"):
+            coupled_hmc.init((jnp.ones((_DIM,)), jnp.ones((_DIM + 1,))), fns)
+        with _x64():
+            with self.assertRaisesRegex(TypeError, "matching floating dtypes"):
+                coupled_hmc.init(
+                    (
+                        jnp.ones((_DIM,), jnp.float64),
+                        jnp.ones((_DIM,), jnp.float32),
+                    ),
+                    fns,
+                )
+
+    def test_coupling_and_direction_options_are_checked_at_build_time(self):
+        with self.assertRaisesRegex(ValueError, "synchronous.*reflection"):
+            coupled_hmc.build_kernel(coupling="antithetic")
+        with self.assertRaisesRegex(ValueError, "does not use a direction"):
+            coupled_hmc.build_kernel(
+                coupling="synchronous", direction_fn=coupled_hmc.whitened_difference
+            )
+
+    def test_eager_validation_rejects_inadmissible_metrics(self):
+        good = jnp.ones((_DIM,))
+        with self.assertRaisesRegex(ValueError, "exactly symmetric"):
+            coupled_hmc.validate_marginal_inputs(
+                jnp.asarray([[1.0, 0.5], [0.4, 1.0]]), 0.1, 4
+            )
+        with self.assertRaisesRegex(ValueError, "positive definite"):
+            coupled_hmc.validate_marginal_inputs(
+                jnp.asarray([[1.0, 2.0], [2.0, 1.0]]), 0.1, 4
+            )
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            coupled_hmc.validate_marginal_inputs(jnp.asarray([1.0, -1.0]), 0.1, 4)
+        with self.assertRaisesRegex(ValueError, "orthonormal"):
+            coupled_hmc.validate_marginal_inputs(
+                metrics.LowRankInverseMassMatrix(
+                    jnp.ones((_DIM,)),
+                    jnp.ones((_DIM, _RANK)),
+                    jnp.asarray([2.0, 3.0]),
+                ),
+                0.1,
+                4,
+            )
+        with self.assertRaisesRegex(ValueError, "step_size.*positive"):
+            coupled_hmc.validate_marginal_inputs(good, -0.1, 4)
+        with self.assertRaisesRegex(ValueError, "num_integration_steps.*positive"):
+            coupled_hmc.validate_marginal_inputs(good, 0.1, 0)
+
+    def test_the_convenience_api_validates_and_build_kernel_does_not(self):
+        """Eager checks belong to the convenience API, not to the traced path.
+
+        ``build_kernel`` performs no eager numerical validation, which is what
+        makes it usable with traced metrics; the price is that admissibility
+        becomes the caller's responsibility there.
+        """
+        bad = jnp.asarray([[1.0, 0.5], [0.4, 1.0]])
+        fns = (_standard_normal_logdensity,) * 2
+        with self.assertRaisesRegex(ValueError, "exactly symmetric"):
+            coupled_hmc.as_top_level_api(fns, (0.1, 0.1), (bad, bad), (2, 2))
+        # Building a kernel does not inspect the metric numerically at all.
+        self.assertTrue(callable(coupled_hmc.build_kernel()))
+
+    # -- policy timing ------------------------------------------------------
+    def test_direction_policy_sees_only_the_incoming_states(self):
+        """``direction_fn`` is handed the pre-transition pair, nothing else."""
+        with _x64():
+            seen = {}
+
+            def recording_direction_fn(first, second, first_metric):
+                seen["first"] = first.position
+                seen["second"] = second.position
+                return coupled_hmc.whitened_difference(first, second, first_metric)
+
+            state = self._pair_state()
+            kernel = coupled_hmc.build_kernel(
+                coupling="reflection", direction_fn=recording_direction_fn
+            )
+            mass = jnp.ones((_DIM,), jnp.float64)
+            new_state, _ = kernel(
+                self.next_key(),
+                state,
+                (_standard_normal_logdensity,) * 2,
+                (0.2, 0.2),
+                (mass, mass),
+                (4, 4),
+            )
+            chex.assert_trees_all_equal(seen["first"], state.first.position)
+            chex.assert_trees_all_equal(seen["second"], state.second.position)
+            # And it is genuinely the pre-transition state, not the result.
+            self.assertFalse(
+                bool(jnp.allclose(seen["first"], new_state.first.position))
+            )
+
+    def test_synchronous_coupling_keeps_identical_states_identical(self):
+        """Two chains started at the same point never separate under sync."""
+        with _x64():
+            position = jnp.ones((_DIM,), jnp.float64)
+            state = coupled_hmc.init(
+                (position, position), (_standard_normal_logdensity,) * 2
+            )
+            kernel = coupled_hmc.build_kernel()
+            mass = jnp.ones((_DIM,), jnp.float64)
+            for _ in range(5):
+                state, info = kernel(
+                    self.next_key(),
+                    state,
+                    (_standard_normal_logdensity,) * 2,
+                    (0.3, 0.3),
+                    (mass, mass),
+                    (4, 4),
+                )
+                chex.assert_trees_all_equal(state.first.position, state.second.position)
+                chex.assert_trees_all_equal(
+                    info.reflection_unit, jnp.zeros((_DIM,), jnp.float64)
+                )
+
+    def test_reflection_of_identical_states_degenerates_to_synchronous(self):
+        """A zero position difference gives a zero direction, i.e. the identity."""
+        with _x64():
+            position = jnp.ones((_DIM,), jnp.float64)
+            state = coupled_hmc.init(
+                (position, position), (_standard_normal_logdensity,) * 2
+            )
+            kernel = coupled_hmc.build_kernel(coupling="reflection")
+            mass = jnp.ones((_DIM,), jnp.float64)
+            new_state, info = kernel(
+                self.next_key(),
+                state,
+                (_standard_normal_logdensity,) * 2,
+                (0.3, 0.3),
+                (mass, mass),
+                (4, 4),
+            )
+            chex.assert_trees_all_equal(
+                info.reflection_unit, jnp.zeros((_DIM,), jnp.float64)
+            )
+            chex.assert_trees_all_equal(
+                new_state.first.position, new_state.second.position
+            )
+
+    # -- transformations and protocol --------------------------------------
+    def test_jit_vmap_and_scan(self):
+        mass = jnp.ones((_DIM,))
+        algorithm = coupled_hmc.as_top_level_api(
+            (_standard_normal_logdensity, _tilted_logdensity),
+            (0.2, 0.2),
+            (mass, mass),
+            (4, 4),
+            coupling="reflection",
+        )
+        state = algorithm.init((jnp.ones((_DIM,)), -jnp.ones((_DIM,))))
+        key = self.next_key()
+
+        eager_state, eager_info = algorithm.step(key, state)
+        jitted_state, jitted_info = jax.jit(algorithm.step)(key, state)
+        chex.assert_trees_all_equal(eager_state, jitted_state)
+        chex.assert_trees_all_equal(eager_info, jitted_info)
+
+        def body(carry, step_key):
+            new_state, _ = algorithm.step(step_key, carry)
+            return new_state, new_state.first.position
+
+        keys = jax.random.split(self.next_key(), 20)
+        final, history = jax.jit(lambda s: jax.lax.scan(body, s, keys))(state)
+        self.assertEqual(history.shape, (20, _DIM))
+        self.assertTrue(bool(jnp.all(jnp.isfinite(final.first.position))))
+
+        def run_one(first_position, second_position, batch_key):
+            batch_state = algorithm.init((first_position, second_position))
+            return algorithm.step(batch_key, batch_state)[0].first.position
+
+        batched = jax.vmap(run_one)(
+            jnp.ones((3, _DIM)),
+            -jnp.ones((3, _DIM)),
+            jax.random.split(self.next_key(), 3),
+        )
+        self.assertEqual(batched.shape, (3, _DIM))
+
+    def test_conforms_to_the_sampling_algorithm_protocol(self):
+        mass = jnp.ones((_DIM,))
+        algorithm = coupled_hmc.as_top_level_api(
+            (_standard_normal_logdensity,) * 2, (0.2, 0.2), (mass, mass), (4, 4)
+        )
+        self.assertIsInstance(algorithm, SamplingAlgorithm)
+
+        state = algorithm.init((jnp.ones((_DIM,)), -jnp.ones((_DIM,))))
+        self.assertIsInstance(state, coupled_hmc.CoupledHMCState)
+
+        new_state, info = algorithm.step(self.next_key(), state)
+        self.assertIsInstance(new_state, coupled_hmc.CoupledHMCState)
+        self.assertIsInstance(info, coupled_hmc.CoupledHMCInfo)
+        # The pair really is a pytree, so the generic runner drives it.
+        final, history = run_inference_algorithm(
+            self.next_key(),
+            algorithm,
+            num_steps=10,
+            initial_position=(jnp.ones((_DIM,)), -jnp.ones((_DIM,))),
+        )
+        self.assertIsInstance(final, coupled_hmc.CoupledHMCState)
+        self.assertEqual(history[0].first.position.shape, (10, _DIM))
+
+    def test_pytree_positions_are_supported(self):
+        with _x64():
+            position = {
+                "a": jnp.ones((2,), jnp.float64),
+                "b": jnp.zeros((2,), jnp.float64),
+            }
+            other = jax.tree.map(lambda leaf: leaf - 1.0, position)
+            mass = jnp.ones((4,), jnp.float64)
+            algorithm = coupled_hmc.as_top_level_api(
+                (_standard_normal_logdensity,) * 2,
+                (0.2, 0.2),
+                (mass, mass),
+                (4, 4),
+                coupling="reflection",
+            )
+            state = algorithm.init((position, other))
+            new_state, info = algorithm.step(self.next_key(), state)
+            chex.assert_trees_all_equal_structs(new_state.first.position, position)
+            self.assertEqual(info.common_normal.shape, (4,))
+
+    def test_heterogeneous_marginals_run(self):
+        """Different targets, metrics, step sizes and integration counts."""
+        with _x64():
+            payloads = _metric_payloads(jnp.float64)
+            algorithm = coupled_hmc.as_top_level_api(
+                (_standard_normal_logdensity, _tilted_logdensity),
+                (0.07, 0.19),
+                (payloads["dense"], payloads["low_rank"]),
+                (3, 6),
+                coupling="reflection",
+            )
+            state = algorithm.init(
+                (
+                    jnp.ones((_DIM,), jnp.float64),
+                    -jnp.ones((_DIM,), jnp.float64),
+                )
+            )
+            new_state, info = algorithm.step(self.next_key(), state)
+            self.assertEqual(info.first.num_integration_steps, 3)
+            self.assertEqual(info.second.num_integration_steps, 6)
+            self.assertTrue(bool(jnp.all(jnp.isfinite(new_state.first.position))))
+            self.assertTrue(bool(jnp.all(jnp.isfinite(new_state.second.position))))
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -29,6 +29,7 @@ import jax.numpy as jnp
 import numpy as np
 from absl.testing import absltest, parameterized
 
+import blackjax
 from blackjax.base import SamplingAlgorithm
 from blackjax.mcmc import coupled_hmc, integrators, metrics, trajectory
 from blackjax.mcmc.hmc import HMCState, flip_momentum
@@ -925,6 +926,120 @@ class CoupledHMCContractTest(BlackJAXTest):
             coupled_hmc.validate_marginal_inputs(good, -0.1, 4)
         with self.assertRaisesRegex(ValueError, "num_integration_steps.*positive"):
             coupled_hmc.validate_marginal_inputs(good, 0.1, 0)
+
+    def test_warmup_output_is_accepted_without_hand_casting(self):
+        """A real ``window_adaptation`` payload must drive the pair directly.
+
+        Warmup returns ``step_size`` as a zero-dimensional JAX array, so a
+        validator that insisted on a Python float would force every caller to
+        cast ordinary BlackJAX output before use.
+        """
+        warmup = blackjax.window_adaptation(
+            blackjax.hmc, _standard_normal_logdensity, num_integration_steps=5
+        )
+        (_, parameters), _ = warmup.run(
+            self.next_key(), jnp.ones((_DIM,)), num_steps=120
+        )
+        step_size = parameters["step_size"]
+        inverse_mass_matrix = parameters["inverse_mass_matrix"]
+        # Precondition for this test to mean anything: it is not a plain float.
+        self.assertFalse(isinstance(step_size, float))
+        self.assertEqual(jnp.ndim(step_size), 0)
+
+        algorithm = coupled_hmc.as_top_level_api(
+            (_standard_normal_logdensity,) * 2,
+            (step_size, step_size),
+            (inverse_mass_matrix, inverse_mass_matrix),
+            (5, 5),
+        )
+        state = algorithm.init((jnp.ones((_DIM,)), -jnp.ones((_DIM,))))
+        new_state, _ = algorithm.step(self.next_key(), state)
+        self.assertTrue(bool(jnp.all(jnp.isfinite(new_state.first.position))))
+
+    @parameterized.named_parameters(
+        {"testcase_name": "python_float", "value": 0.1},
+        {"testcase_name": "python_int", "value": 1},
+        {"testcase_name": "numpy_float32", "value": np.float32(0.1)},
+        {"testcase_name": "numpy_float64", "value": np.float64(0.1)},
+        {"testcase_name": "jax_scalar_f32", "value": jnp.asarray(0.1, jnp.float32)},
+    )
+    def test_step_size_accepts_ordinary_scalar_forms(self, value):
+        coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), value, 4)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "bool", "value": True, "error": TypeError},
+        {"testcase_name": "numpy_bool", "value": np.bool_(True), "error": TypeError},
+        {"testcase_name": "complex", "value": 1 + 2j, "error": TypeError},
+        {
+            "testcase_name": "nonscalar",
+            "value": jnp.asarray([0.1, 0.2]),
+            "error": ValueError,
+        },
+        {"testcase_name": "nan", "value": float("nan"), "error": ValueError},
+        {"testcase_name": "inf", "value": float("inf"), "error": ValueError},
+    )
+    def test_step_size_refuses_inadmissible_scalar_forms(self, value, error):
+        """Accepting array forms must not also let bad values through."""
+        with self.assertRaises(error):
+            coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), value, 4)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "python_int", "value": 4},
+        {"testcase_name": "numpy_int32", "value": np.int32(4)},
+        {"testcase_name": "jax_scalar_i32", "value": jnp.asarray(4, jnp.int32)},
+    )
+    def test_integration_count_accepts_integer_scalar_forms(self, value):
+        """The count contract: any concrete integer scalar, matching the engine.
+
+        All three forms already run through ``static_integration`` unchanged,
+        so the validator must not be stricter than the machinery it guards.
+        """
+        coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), 0.1, value)
+        _, step = coupled_hmc._build_prescribed_marginal(
+            _standard_normal_logdensity,
+            jnp.ones((_DIM,)),
+            0.1,
+            value,
+            integrators.velocity_verlet,
+            1000.0,
+        )
+        position = jnp.ones((_DIM,))
+        state = HMCState(
+            position,
+            _standard_normal_logdensity(position),
+            jax.grad(_standard_normal_logdensity)(position),
+        )
+        _, info = step(state, jnp.zeros((_DIM,)), jnp.asarray(0.5, position.dtype))
+        self.assertEqual(int(info.num_integration_steps), 4)
+
+    @parameterized.named_parameters(
+        {"testcase_name": "bool", "value": True, "error": TypeError},
+        {"testcase_name": "float", "value": 4.0, "error": TypeError},
+        {
+            "testcase_name": "jax_float_scalar",
+            "value": jnp.asarray(4.0, jnp.float32),
+            "error": TypeError,
+        },
+        {
+            "testcase_name": "nonscalar",
+            "value": jnp.asarray([4, 5]),
+            "error": ValueError,
+        },
+    )
+    def test_integration_count_refuses_inadmissible_forms(self, value, error):
+        """A floating count is refused, never silently truncated."""
+        with self.assertRaises(error):
+            coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), 0.1, value)
+
+    def test_eager_validation_refuses_a_tracer(self):
+        """Eager checks cannot read a traced value, and say so rather than pass."""
+
+        def under_jit(value):
+            coupled_hmc.validate_marginal_inputs(jnp.ones((_DIM,)), value, 4)
+            return value
+
+        with self.assertRaisesRegex(TypeError, "must be concrete"):
+            jax.jit(under_jit)(jnp.asarray(0.1))
 
     def test_the_convenience_api_validates_and_build_kernel_does_not(self):
         """Eager checks belong to the convenience API, not to the traced path.

--- a/tests/mcmc/test_trajectory.py
+++ b/tests/mcmc/test_trajectory.py
@@ -6,7 +6,6 @@ import numpy as np
 from absl.testing import absltest, parameterized
 
 import blackjax.mcmc.dynamic_hmc as dynamic_hmc
-import blackjax.mcmc.hmc as hmc
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
 import blackjax.mcmc.proposal as proposal
@@ -318,58 +317,6 @@ class TrajectoryTest(chex.TestCase):
         _, unique_counts = np.unique(infos.num_integration_steps, return_counts=True)
 
         np.testing.assert_allclose(unique_counts / num_iter, unique_probs, rtol=1e-1)
-
-
-class StaticIntegrationReversibilityTest(chex.TestCase):
-    """Reversibility of the endpoint map, which is what detailed balance needs.
-
-    Integrating forward, flipping the momentum, integrating the same number of
-    steps and flipping again must return the starting state. If it does not,
-    the Metropolis correction is applied to a proposal that is not its own
-    inverse and the chain targets the wrong distribution -- with no error, no
-    NaN, and a perfectly healthy-looking acceptance rate.
-
-    The accuracy and energy-conservation tests elsewhere do not cover this: all
-    of them are symmetric under a sign error, so a flip applied in the wrong
-    place, or a reverse leg integrated with the wrong direction, changes
-    neither the analytic agreement nor the conserved energy. Comparing the scan
-    and fori implementations against each other does not cover it either, since
-    a shared directional bug passes.
-    """
-
-    def test_endpoint_map_is_an_involution(self):
-        with jax.enable_x64():
-
-            def logdensity_fn(x):
-                scales = jnp.arange(1, x.size + 1, dtype=x.dtype)
-                return -0.5 * jnp.sum((x / scales) ** 2) + jnp.sum(0.3 * x)
-
-            dimension, step_size, num_steps = 4, 0.09, 5
-            metric = metrics.default_metric(jnp.ones((dimension,), jnp.float64))
-            integrator = integrators.velocity_verlet(
-                logdensity_fn, metric.kinetic_energy
-            )
-            build = trajectory.static_integration(integrator)
-
-            key_position, key_momentum = jax.random.split(jax.random.key(20260907))
-            position = jax.random.normal(key_position, (dimension,), jnp.float64)
-            momentum = jax.random.normal(key_momentum, (dimension,), jnp.float64)
-            start = integrators.IntegratorState(
-                position,
-                momentum,
-                logdensity_fn(position),
-                jax.grad(logdensity_fn)(position),
-            )
-
-            end = hmc.flip_momentum(build(start, step_size, num_steps))
-            back = hmc.flip_momentum(build(end, step_size, num_steps))
-
-            # The trajectory must actually move, or the round trip is trivial.
-            self.assertFalse(
-                bool(jnp.allclose(end.position, start.position, atol=1e-6))
-            )
-            chex.assert_trees_all_close(back.position, start.position, atol=1e-10)
-            chex.assert_trees_all_close(back.momentum, start.momentum, atol=1e-10)
 
 
 if __name__ == "__main__":

--- a/tests/mcmc/test_trajectory.py
+++ b/tests/mcmc/test_trajectory.py
@@ -6,6 +6,7 @@ import numpy as np
 from absl.testing import absltest, parameterized
 
 import blackjax.mcmc.dynamic_hmc as dynamic_hmc
+import blackjax.mcmc.hmc as hmc
 import blackjax.mcmc.integrators as integrators
 import blackjax.mcmc.metrics as metrics
 import blackjax.mcmc.proposal as proposal
@@ -317,6 +318,58 @@ class TrajectoryTest(chex.TestCase):
         _, unique_counts = np.unique(infos.num_integration_steps, return_counts=True)
 
         np.testing.assert_allclose(unique_counts / num_iter, unique_probs, rtol=1e-1)
+
+
+class StaticIntegrationReversibilityTest(chex.TestCase):
+    """Reversibility of the endpoint map, which is what detailed balance needs.
+
+    Integrating forward, flipping the momentum, integrating the same number of
+    steps and flipping again must return the starting state. If it does not,
+    the Metropolis correction is applied to a proposal that is not its own
+    inverse and the chain targets the wrong distribution -- with no error, no
+    NaN, and a perfectly healthy-looking acceptance rate.
+
+    The accuracy and energy-conservation tests elsewhere do not cover this: all
+    of them are symmetric under a sign error, so a flip applied in the wrong
+    place, or a reverse leg integrated with the wrong direction, changes
+    neither the analytic agreement nor the conserved energy. Comparing the scan
+    and fori implementations against each other does not cover it either, since
+    a shared directional bug passes.
+    """
+
+    def test_endpoint_map_is_an_involution(self):
+        with jax.enable_x64():
+
+            def logdensity_fn(x):
+                scales = jnp.arange(1, x.size + 1, dtype=x.dtype)
+                return -0.5 * jnp.sum((x / scales) ** 2) + jnp.sum(0.3 * x)
+
+            dimension, step_size, num_steps = 4, 0.09, 5
+            metric = metrics.default_metric(jnp.ones((dimension,), jnp.float64))
+            integrator = integrators.velocity_verlet(
+                logdensity_fn, metric.kinetic_energy
+            )
+            build = trajectory.static_integration(integrator)
+
+            key_position, key_momentum = jax.random.split(jax.random.key(20260907))
+            position = jax.random.normal(key_position, (dimension,), jnp.float64)
+            momentum = jax.random.normal(key_momentum, (dimension,), jnp.float64)
+            start = integrators.IntegratorState(
+                position,
+                momentum,
+                logdensity_fn(position),
+                jax.grad(logdensity_fn)(position),
+            )
+
+            end = hmc.flip_momentum(build(start, step_size, num_steps))
+            back = hmc.flip_momentum(build(end, step_size, num_steps))
+
+            # The trajectory must actually move, or the round trip is trivial.
+            self.assertFalse(
+                bool(jnp.allclose(end.position, start.position, atol=1e-6))
+            )
+            chex.assert_trees_all_close(back.position, start.position, atol=1e-10)
+            chex.assert_trees_all_close(back.momentum, start.momentum, atol=1e-10)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What this adds

`blackjax.mcmc.coupled_hmc` — two ordinary HMC chains advanced from one shared standard
normal and one shared Metropolis uniform.

Independent review of the mathematics and of test integrity has been carried out and its
findings acted on; see *Testing*. That is a statement about review having happened, not a
correctness guarantee — the scope section below is the binding description of what is and
is not claimed.

## Scope, stated narrowly

The module provides a **coupling of the random inputs**. It does not claim, implement or
test any of: invariance of the pair for the product of the two targets; that the chains
meet (exactly, maximally, or at all); unbiasedness of any estimator built from the pair;
or improved sampling efficiency in any sense.

The one property asserted, and tested, is:

> Coupling changes only the joint law of the two marginals' random inputs. It never
> changes either marginal's transition function, its Metropolis decision rule, or its
> cached log-density and gradient.

## Design

Three ideas do the work.

**The momentum draw can be externalised exactly.** `Metric.scale(position, z,
inv=False, trans=False)` is precisely the map `Metric.sample_momentum` applies to a
standard normal, for the diagonal, dense and low-rank Euclidean metrics. Handing each
marginal a caller-chosen `z` therefore leaves its momentum law untouched. Callable
(Riemannian) metrics and pre-built `Metric` objects are refused rather than assumed
valid, since that agreement was only established for the three array-shaped kinds.

**The Metropolis test already accepts a non-key first argument.** `hmc_proposal` forwards
whatever it is given to `sample_proposal`; `ghmc` already relies on this with
`nonreversible_slice_sampling`. A private uniform-comparison selector lets both marginals
share one variate while each compares it against **its own** acceptance probability, so a
shared uniform is not a shared decision. `proposal.py` is unchanged.

**Reflection is correct for any past-measurable direction.** `z' = z - 2e(eᵀz)` is an
orthogonal reflection, so it preserves `N(0, I)` exactly for any unit `e` not depending
on `z`. That is all reflection buys here: marginal correctness, not contraction. The
default direction is the position difference whitened by the first marginal's metric,
`e ∝ A⁻¹(x₁ - x₂)`, which is `scale(…, inv=True, trans=True)`. With differing metrics it
is first-metric-based, with no property claimed for the pair.

`coupling` and `direction_fn` are fixed when the kernel is built; the kernel evaluates
`direction_fn` on the incoming states and supplies it no innovations. Keeping that
callable pure is the caller's part of the contract, as for any kernel.

### API

`init` / `build_kernel` / `as_top_level_api`, `CoupledHMCState(first, second)` as two
complete `HMCState`s, and `CoupledHMCInfo` carrying both complete `HMCInfo`s plus the
shared normal, the reflection unit and the shared uniform.

Every per-marginal parameter is an **explicit `(first, second)` pair**, including when
both marginals share a value. Nothing is broadcast: positions, metrics and step sizes may
themselves legitimately be tuples, so inferring a pair from a bare value would be
ambiguous exactly where the mistake is most costly. The two marginals may use different
targets, metrics, step sizes and integration counts; their positions must share a pytree
structure, leaf shapes and one floating dtype.

There is deliberately **no top-level `blackjax.coupled_hmc`** while the API settles;
reach it at `blackjax.mcmc.coupled_hmc`.

### Relation to `blackjax.hmc`

Each marginal applies the same *mathematical* Metropolis rule. It realises that rule with
a uniform comparison where `static_binomial_sampling` uses `jax.random.bernoulli`, so the
two agree as distributions and **not** draw-for-draw. The tests assert the acceptance
*probability* matches to 1e-14 and deliberately assert no draw parity.

### Input handling

Eager numerical validation lives in `validate_marginal_inputs`, called from
`as_top_level_api`; the traced kernel keeps only static type and shape checks and does no
NumPy conversion. Passing that check covers the arguments given, and says nothing about
traced values appearing later under `jit`/`vmap` — the docstrings say so rather than
implying a guarantee. `build_kernel` is the documented path with no eager validation.

Scalars accept the forms BlackJAX actually produces — `window_adaptation` returns
`step_size` as a 0-d JAX array — while still refusing booleans, complex values,
non-scalars, non-finite values and tracers. A floating integration count is refused, not
truncated.

Prescribed innovations are inspected **as given**, before any conversion, and the rule
depends on whether the value declares a dtype:

- An input that **declares** a dtype — a NumPy or JAX array — must match the position's
  **effective** dtype and is refused otherwise, never converted. Casting can narrow: a
  float64 uniform below one becomes exactly `1.0` in float32, turning a certain acceptance
  into a rejection; one in range becomes a *different* float32, so the Metropolis test
  would use a value the caller never supplied.
- A bare Python scalar **declares no dtype**, is weakly typed as elsewhere in JAX, and is
  adopted. For those the domain is checked on the value *after* conversion, which is where
  a bad Python float would otherwise pass.

"Effective dtype" is deliberate. A position is converted by `ravel_pytree` regardless, so
what its leaves become is what matters, and a position mixing float64 and float32 leaves
is accepted under JAX's default configuration because both become float32. An innovation
is compared against an acceptance probability, so what it *declares* is what matters
there. The two checks use opposite notions on purpose and each says which.

A uniform outside `[0, 1)` is refused rather than clipped, so caller error cannot
masquerade as an ordinary rejection. **These are eager checks**: they read values and so
run only when a value is concrete. Under `jit`/`vmap` they are documented preconditions,
not checks, and `build_kernel` performs no eager numerical validation at all.

## Testing

`tests/mcmc/test_coupled_hmc.py` — **84 passed** at this head, within a full-suite CI run
of **1876 passed, 10 skipped, 53 subtests passed**.

The uncoupled reference is rebuilt from `static_integration`, `flip_momentum`,
`hmc_energy` and `safe_energy_diff` rather than by calling the module's own helper again,
then compared field by field on state **and** every `HMCInfo` field, for both marginals,
under differing targets, metrics, step sizes and integration counts.

Also covered: the momentum-law identity across the three metric kinds and over pytree
positions; reflection as a norm-preserving involution and its effect on the standard
normal, and that it negates the component along the unit while leaving the orthogonal
complement unchanged; the whitening convention checked by autodiff on the library's own
kinetic energy; zero, tiny, huge and non-finite directions; the uniform endpoints `u=0`,
`u` just below 1, `p=0`, `p=1`; per-leaf shape and effective-dtype agreement across the
pair; refusal of narrowed, mismatched, mis-dimensioned or out-of-domain inputs; `jit`,
`vmap`, `scan`, the `SamplingAlgorithm` protocol and `run_inference_algorithm` through the
convenience API.

The accepting **and** rejecting branches are both compared against the reference, at a
uniform derived from the reference's own acceptance probabilities, with those
probabilities asserted strictly interior so the case cannot silently stop discriminating.
A rejection is checked on the returned state, not only on the `is_accepted` flag.

### CI at this head

All jobs pass at `a56b0cb9a`: the test suite on Python 3.11, 3.12 and 3.13, both style
checks, multi-device (`shard_map`), build, and the benchmark job.

### Still not established

- **No performance measurement of any kind was made.** The benchmark job passing is not a
  measurement of this module; nothing here was benchmarked.
- A marginal moment check cannot validate the **coupling policy**. Which direction the pair
  reflects along is a joint-policy property: any unit vector independent of the fresh `z`
  leaves both marginal laws intact, so a wrong direction would be invisible to any
  marginal test. That contract is covered by direct assertions on the policy instead.
- Statistical checks made during review support the moments and configurations they
  measured, at their own pins, and are not proofs of invariance.

`black`, `isort` and `flake8` pass on both files at the versions this repo pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dqi7bhWMaFkyQuEDkxgKn7

