### PR TITLE
Reduce telemetry test setup duplication and shorten coupling docs

### DIFF
--- a/blackjax/adaptation/meta/_telemetry.py
+++ b/blackjax/adaptation/meta/_telemetry.py
@@ -13,40 +13,30 @@
 # limitations under the License.
 """Opt-in observation of metric-publication decisions at slow-window boundaries.
 
-The meta-adaptation controller's ``final()`` computes candidate metrics, the
-escalation predicates and the number of draws it consumed, then resets its
-buffers and returns only the new state.  Everything except the deployed metric
-is discarded, so a caller watching the adaptation info stream sees the
-*outcome* of a publication decision but none of its *inputs*.
-
-This module adds a read-only record of those inputs.  It changes no threshold,
-no predicate, no ordering and no published metric: with telemetry disabled
-nothing here is constructed or traced.
+The controller's ``final()`` computes candidates, predicates, and draw counts,
+then resets its buffers; the adaptation info stream otherwise exposes only the
+deployed metric.  This module records those inputs read-only.  It changes no
+threshold, predicate, ordering, or published metric, and telemetry-disabled
+runs construct or trace nothing here.
 
 Two masks, and what they do *not* mean
 --------------------------------------
-The controller's escalation decision is a JAX expression such as
-``~has_escalated & r2_gate & s_gap_gate & deadline_ok``.  ``&`` is eager:
-**every** predicate is computed on **every** window, including after escalation
-and including when a sibling conjunct is false.  There is no short-circuit, and
-a failed conjunct does not prevent its siblings from being evaluated.  Some of
-those same predicates additionally govern the multi-chain deferral latch, which
-is *not* gated on ``has_escalated`` and can therefore fire post-escalation.
+The escalation expression (for example,
+``~has_escalated & r2_gate & s_gap_gate & deadline_ok``) uses eager ``&``:
+every predicate is computed every window, including after escalation and when
+siblings are false.  Some also govern the multi-chain deferral latch, which is
+not gated on ``has_escalated``.
 
-Reporting "was this computed?" would thus be uninformative — the answer is
-always yes.  The two masks are defined instead as:
+Thus the masks report predicate truth and applicability, not computation:
 
 ``gate_predicate_true``
-    Raw truth of each named predicate this window, exactly as the controller
-    computed it.  Always populated, including after escalation, so that the
-    deferral latch and the branch decisions remain reconstructable.
+    Raw truth of each named predicate this window, always populated so branch
+    decisions and the deferral latch remain reconstructable.
 
 ``escalation_gate_applicable``
-    Whether the predicate bears on a **new** escalation decision this window.
-    Clear once the controller has escalated (the ``~has_escalated`` conjunct
-    makes a new escalation impossible regardless of the others), and clear for
-    a predicate whose inputs are not yet available — the S_gap stability test
-    needs the previous window's S_gap, which the first window does not have.
+    Whether the predicate bears on a **new** escalation decision.  Clear after
+    escalation and when inputs are unavailable (the first S_gap stability test
+    lacks a previous-window S_gap).
 
 **The two are not nested.** A raw predicate can be true while its applicability
 is zero; that is the normal post-escalation state and is not a contradiction.
@@ -66,10 +56,6 @@ Read :data:`SCHEMA_VERSION` from the module; do not hard-code it here or
 anywhere else.  Consumers must check it and refuse a version they do not know
 rather than inferring meaning from raw mask bits.  Bit positions are never
 reused across versions.
-
-(This paragraph previously restated the number and went stale against the
-constant across a bump.  Naming it once, in the constant, is the only way that
-cannot happen again.)
 
 Units
 -----
@@ -174,51 +160,26 @@ BRANCH_BOTH: int = _DETECTION_BRANCH_BOTH
 class CandidateSummary(NamedTuple):
     """Compact description of one candidate inverse mass matrix.
 
-    Emitted for every candidate the controller builds, including the ones it
-    does not deploy — before escalation those are computed and discarded, which
-    is the single most important thing this module preserves.
-
-    After escalation the picture is different and the record reflects it: the
-    historical route deploys a *freshly computed* candidate each window, so a
-    candidate summary post-escalation generally describes the metric that was
-    just published rather than one that was thrown away.
+    Emitted for every candidate, including candidates computed but not deployed
+    before escalation.  On the multi-chain path, both freshly computed
+    candidates remain recorded; history selects one route for deployment.
 
     Attributes
     ----------
     effective_rank
-        Count of ``|lam - 1| > 1e-6``, the same convention
-        :func:`~blackjax.adaptation.meta.verdict.extract_meta_verdict` uses.
+        Count of ``|lam - 1| > 1e-6``, matching the verdict convention.
     logdet
-        ``2*sum(log sigma) + sum(log lam)``, exact for this parameterisation
-        (``U`` has orthonormal columns, so the non-unit eigenvalues are ``lam``).
+        ``2*sum(log sigma) + sum(log lam)`` under the documented
+        :func:`_logdet` invariant: active ``lam != 1`` columns of ``U`` are
+        orthonormal (including T's one-active-column case).
     lam_max, lam_min, sigma_gm
         Eigenvalue extremes and the geometric mean of the diagonal scaling.
-
-        On the multi-chain path ``sigma_gm`` is necessarily EQUAL between
-        ``candidate_w`` and ``candidate_t``, for the same reason
-        ``sigma_log_ratio_rms_vs_deployed`` is: both candidates are built from
-        the same ``sigma_lr``.  The scalars that do differ between them are
-        ``logdet``, ``effective_rank`` and ``lam_max`` — and note that even
-        together those are summaries, not a metric identity test.
+        Only ``sigma_gm`` is shared by W and T on the multi-chain path; their
+        eigenvalue summaries can differ.
     sigma_log_ratio_rms_vs_deployed
-        ``rms(log(this sigma) - log(deployed sigma))``.
-
-        **This compares diagonal scalings only, and on the multi-chain path it
-        cannot tell the two candidates apart.**  ``candidate_w`` and
-        ``candidate_t`` are built from the same ``sigma_lr``, so both report the
-        identical value in every window — zero once either has been deployed,
-        and a common non-zero value against the pre-escalation diagonal metric.
-        Reading a zero here as "*this* candidate is the deployed one" is wrong:
-        it means *a* candidate sharing this sigma was deployed.
-
-        What separates W from T lives in ``U`` and ``lam``, not in sigma.
-        ``effective_rank`` and the ``lam`` extremes distinguish *some* cases,
-        but they are scalar summaries and cannot certify that two metrics are
-        equal or that they differ — two metrics can share a rank and an
-        eigenvalue range while pointing in different directions.  Orientation
-        is only answerable from the full factors, under ``full_matrices=True``
-        and a declared comparison convention.  This field is a diagonal-scale
-        comparison, not a candidate-identity test.
+        RMS log-scale difference from the deployed metric.  This compares only
+        diagonal scaling; W and T share the same value, so candidate identity
+        requires full factors under a declared comparison convention.
     full
         The full factors, or ``None`` unless ``full_matrices=True``.
     """
@@ -233,18 +194,16 @@ class CandidateSummary(NamedTuple):
 
 
 class SingleChainDetail(NamedTuple):
-    """Fields specific to :func:`~blackjax.adaptation.meta.builders.build_meta_adaptation_core`.
+    """Fields specific to the single-chain meta-adaptation core.
 
     Attributes
     ----------
     detection_rank
-        ``k_new``, chosen from the whitened-residual spectrum.  A detection
-        quantity: distinct from the candidate's and the deployed metric's
-        effective ranks, and distinct again from the stored nominal
-        ``escalation_rank_stored`` on the parent record.
+        ``k_new`` from the whitened-residual spectrum; distinct from candidate,
+        deployed, and stored nominal escalation ranks.
     s_gap, s_gap_prev, s_gap_relative_change
-        The stability test's inputs.  ``s_gap_prev`` is NaN in the first window,
-        which is why ``sc_s_gap_stability`` is inapplicable there.
+        Stability inputs; ``s_gap_prev`` is NaN in the first window, making
+        ``sc_s_gap_stability`` inapplicable there.
     candidate
         The single low-rank candidate this controller builds.
     """
@@ -257,75 +216,47 @@ class SingleChainDetail(NamedTuple):
 
 
 class MultiChainDetail(NamedTuple):
-    """Fields specific to :func:`~blackjax.adaptation.meta.builders.build_multi_chain_meta_core`.
+    """Fields specific to the multi-chain meta-adaptation core.
 
-    Three branch fields, because three different questions have three different
-    answers and the controller keeps them apart:
+    Branch fields intentionally answer different questions:
 
     ``branch_fired_this_window``
         What escalated *now*: ``NONE`` / W / T / ``BOTH``.
     ``detection_branch_history``
-        The controller's carried ``detection_branch``, which holds the last
-        *firing* window's branch and is unchanged in windows where nothing
-        fires.  This carried value — not the current one — selects which
-        escalated metric is deployed.
-
-        It and ``branch_fired_this_window`` necessarily leave ``NONE`` in the
-        same window, since the carry is only ever written when a branch fires;
-        they diverge only afterwards, once a later window fires nothing.
+        Carried last firing branch, unchanged when nothing fires; this selects
+        the escalated metric and can diverge from the current branch.
     ``deployed_metric_route``
-        What the kernel will actually use: ``ROUTE_DIAGONAL`` before escalation,
-        else ``ROUTE_W``/``ROUTE_T``.  ``BOTH`` firing deploys the W metric.
-
-        This *is* derivable, from ``has_escalated`` and
-        ``detection_branch_history``, by reapplying the controller's own routing
-        rule (``BOTH`` and ``W`` both route to W).  It is carried anyway so that
-        reading the record never requires reimplementing that rule — the same
-        trade the unit fields make.  Do not read it as information held nowhere
-        else; see the module docstring's list of what genuinely is.
+        Metric used by the kernel: diagonal before escalation, then W or T;
+        BOTH routes to W.  It is carried to avoid reimplementing this rule.
 
     Attributes
     ----------
     branch_first_set_at_window
-        ``window_index`` at which ``detection_branch`` first left ``NONE``,
-        stamped on that transition only and unchanged afterwards; ``-1`` until
-        it happens.
+        First window where ``detection_branch`` left ``NONE``; ``-1`` before.
     t_detection_rank
-        ``k_new``, the **between-chain** detection rank.  Note that the
-        controller stores this into ``escalation_rank`` even when the W branch
-        is what fired, so ``escalation_rank_stored`` can describe a different
-        branch than the one that escalated.  Reported, not corrected.
+        Between-chain ``k_new``.  The controller stores it as
+        ``escalation_rank`` even when W fires, so the stored rank can describe a
+        different branch; the record reports it unchanged.
     r2_routed
-        The GAIN-overridden R² the T branch and the verdict use.  Distinct from
-        the parent record's raw ``r2_raw``, which is what the W branch uses;
-        the two can disagree, and the override exists precisely because the raw
-        value is meaningless at ``k << d``.
+        GAIN-overridden R² used by T and the verdict, distinct from raw
+        ``r2_raw`` used by W; they can disagree, especially when ``k << d``.
     is_converging, is_unimodal, any_mode_flag
-        The three separate observations behind the three-way unimodality rule.
+        Separate observations behind the three-way unimodality rule.
     t_unimodality_resolved
-        Its resolved outcome: ``is_converging | (is_unimodal & ~any_mode_flag)``.
-
-        Carried rather than left to the consumer because the obvious derivation
-        is wrong: ``is_converging`` is an **override**, not a fourth conjunct,
-        and writing ``is_unimodal & ~any_mode_flag`` alone fails silently on
-        exactly the converging-chains case the three-way rule was added for.
-        This is a policy and it can change.  Equal to the ``t_unimodality`` gate
-        bit by construction — if you find both, there is no difference to hunt
-        for.
+        Resolved outcome ``is_converging | (is_unimodal & ~any_mode_flag)``;
+        convergence is an override, not a fourth conjunct.  This policy can
+        change and equals the ``t_unimodality`` gate bit by construction.
     t_contraction_stat, unimodality_gap_ratio
         The numerics behind those observations.
     unimodality_flag_count
-        Consecutive flagged windows; deferral needs this to reach
-        ``_MC_UNIMODALITY_CONFIRM_WINDOWS``.
+        Consecutive flagged windows; deferral waits for the confirmation limit.
     deferred_to_ensemble
-        The deferral latch.  Non-monotone, and *not* gated on ``has_escalated``,
-        so it can fire after escalation.
+        Deferral latch; non-monotone and not gated on ``has_escalated``.
     chain_collinearity_f1, within_lam1, chain_consistency_psi, r1_top
-        Detector signals as measured this window.
+        Detector signals measured this window.
     candidate_w, candidate_t
-        **Both** candidates.  They are built before routing and are not
-        interchangeable: W is the full Fisher-LR on per-chain-centred pooled
-        buffers, T is a rank-1 geometric-mean slow-direction correction.
+        Both candidates, built before routing: W is full Fisher-LR on pooled
+        per-chain-centred buffers; T is a rank-1 geometric-mean correction.
     """
 
     branch_fired_this_window: Array

--- a/blackjax/mcmc/coupled_hmc.py
+++ b/blackjax/mcmc/coupled_hmc.py
@@ -11,45 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Two HMC chains advanced from a shared source of randomness.
+"""Two HMC marginals coupled only through their random inputs.
 
-This module runs two ordinary HMC marginals side by side and couples them
-*only through their random inputs*: the standard normal that becomes each
-momentum, and the single uniform that drives each Metropolis test.
-
-.. warning::
-
-    The scope of what is implemented here is deliberately narrow.  This
-    module provides a **coupling of the random inputs**.  It makes no claim
-    that the pair is invariant for the product of the two targets, that the
-    chains meet (exactly, maximally, or at all), that any estimator built
-    from the pair is unbiased, or that coupling improves sampling efficiency
-    in any sense.  None of those properties is implemented or tested.
+The pair consists of ordinary HMC transitions with one shared normal
+innovation and one shared uniform variate.  Each marginal keeps its own
+transition, acceptance probability, decision, and cached state.  This module
+does not claim product-target invariance, meeting, unbiased estimators, or an
+efficiency improvement.
 
 The contract
 ------------
 
-The one property this module does assert, and test, is:
-
-    Coupling changes only the *joint law* of the two marginals' random
-    inputs.  It never changes either marginal's transition function, its
-    Metropolis decision rule, or its cached log-density and gradient.
-
-Concretely, given the same ``(state, standard_normal, uniform)`` triple, each
-marginal here performs exactly the transition an uncoupled HMC marginal built
-from the same target, metric, step size and integration count would perform,
-and returns exactly the same state and info.  The two marginals share a
-uniform but each compares it against **its own** acceptance probability, so a
-shared uniform is emphatically *not* a shared decision.  Each marginal carries
-its own ``logdensity``/``logdensity_grad`` cache.
+Given the same ``(state, standard_normal, uniform)`` triple and per-marginal
+parameters, each marginal performs the same transition as ordinary HMC.  A
+shared uniform is compared against each marginal's own acceptance probability;
+it is not a shared decision.
 
 Mathematical semantics
 ----------------------
 
-Write :math:`M` for a marginal's mass matrix and :math:`A` for the momentum
-square root BlackJAX uses, so that a momentum drawn as :math:`p = A z` with
-:math:`z \\sim N(0, I)` has covariance :math:`A A^\\top = M`.  Both couplings
-below draw a single :math:`z` and hand each marginal a transformed copy:
+Writing :math:`p = A z` for the momentum and :math:`A A^\\top = M` for its
+covariance, both couplings draw one :math:`z \\sim N(0,I)` and hand each
+marginal a transformed copy:
 
 ``synchronous``
     Both marginals receive the same :math:`z`.
@@ -61,55 +44,33 @@ below draw a single :math:`z` and hand each marginal a transformed copy:
 
         z' = z - 2 e (e^\\top z)
 
-    for a unit vector :math:`e`.  That map is an orthogonal reflection, so in
-    exact arithmetic it preserves :math:`N(0, I)` and the second marginal's
-    momentum law is unchanged **for any** unit :math:`e` that does not depend
-    on :math:`z`.  In floating point the normalisation of :math:`e` carries a
-    rounding error of a few units in the last place, so the preservation is
-    exact in the mathematics and accurate to that tolerance in the code.  That is the whole of what reflection buys here: marginal
-    correctness.  It is not a statement about contraction, meeting, or
-    coupling quality, and none is made.
+    For unit ``e`` independent of ``z``, this orthogonal reflection preserves
+    the normal law exactly in mathematics (floating-point normalization is
+    accurate to rounding).
 
-    ``e`` comes from ``direction_fn``, which is fixed when the kernel is
-    built and is applied to the *incoming* pair of states.  It is given the two
-    states and the first metric, and no innovations.  Note that this is a
-    statement about its arguments, not about ordering: the kernel draws ``z``
-    and the uniform first and only then runs the transition that evaluates
-    ``direction_fn``.  Supplying a ``direction_fn`` that is a pure function of
-    its arguments is the caller's part of the contract.  The default direction is the
+    ``e`` comes from ``direction_fn``, fixed at build time and applied to the
+    incoming states and first metric only; it receives no innovations and must
+    be pure in those arguments.  The default direction is the
     difference of the two positions whitened by the **first** marginal's
     metric, :math:`e \\propto A^{-1}(x_1 - x_2)`.  That particular choice is a
-    heuristic: it is the direction along which, to leading order, the two
-    chains' displacements respond oppositely, since the velocity
-    :math:`\\partial K / \\partial p` equals :math:`A^{-\\top} z` and hence
-    :math:`\\langle x_1 - x_2, \\partial K/\\partial p\\rangle = \\langle
-    A^{-1}(x_1 - x_2), z\\rangle`.  When the two marginals use *different*
-    metrics the default still uses the first marginal's metric only; it is
-    then a first-metric-based direction with no claimed property for the
-    pair.  A zero direction is the identity map, i.e. reflection degenerates
-    to synchronous coupling for that transition.
+    heuristic.  With different metrics it remains only a first-metric-based
+    direction with no claimed property for the pair, and a zero direction is
+    the identity.
 
 Relation to ``blackjax.hmc``
 ----------------------------
 
-Each marginal applies the same *mathematical* Metropolis rule as ordinary
-HMC: accept with probability :math:`\\min(1, e^{\\Delta})`.  It realises that
-rule by comparing a supplied uniform against the acceptance probability,
-whereas :func:`~blackjax.mcmc.proposal.static_binomial_sampling` realises it
-with :func:`jax.random.bernoulli`.  The two agree as distributions and do
-**not** agree draw-for-draw: feeding the same key to this kernel and to
-``blackjax.hmc`` will not reproduce the same accept/reject sequence, and no
-such parity is claimed or tested.
+Each marginal accepts with probability :math:`\\min(1,e^{\\Delta})`, comparing
+the supplied uniform directly.  This is distributionally equivalent to
+ordinary HMC's Bernoulli implementation, but not draw-for-draw equivalent.
 
 Usage
 -----
 
-There is deliberately no top-level ``blackjax.coupled_hmc``; reach this
-module at ``blackjax.mcmc.coupled_hmc``.  Every per-marginal parameter is
-passed as an explicit ``(first, second)`` pair -- including when both
-marginals share a value, which is written ``(value, value)``.  Nothing is
-broadcast or inferred, because positions, metrics and step sizes may
-themselves legitimately be tuples.
+There is no top-level ``blackjax.coupled_hmc``; use
+``blackjax.mcmc.coupled_hmc``.  Every per-marginal argument is an explicit
+``(first, second)`` pair, including shared values as ``(value, value)``;
+nothing is broadcast or inferred.
 
 .. code::
 
@@ -150,14 +111,10 @@ __all__ = [
 
 
 class CoupledHMCState(NamedTuple):
-    """State of a pair of coupled HMC chains.
+    """Pair of HMC states, each with its own caches.
 
-    The two marginals are held as two complete, independent
-    :class:`~blackjax.mcmc.hmc.HMCState` values, so each carries its own
-    position and its own cached ``logdensity``/``logdensity_grad``.  Keeping
-    them separate makes crossing the two caches an obvious error rather than
-    a silent one -- it does not make it impossible, so the test suite checks
-    it explicitly.
+    Each marginal retains its own position and cached
+    ``logdensity``/``logdensity_grad``.
 
     first
         State of the first marginal chain.
@@ -171,30 +128,23 @@ class CoupledHMCState(NamedTuple):
 
 
 class CoupledHMCInfo(NamedTuple):
-    """Additional information on a coupled HMC transition.
+    """Per-marginal transition information and the shared random inputs.
 
-    Both marginals' complete :class:`~blackjax.mcmc.hmc.HMCInfo` objects are
-    preserved untouched, so every per-chain diagnostic (momentum, acceptance
-    rate, acceptance decision, divergence flag, energy, proposal, integration
-    count) stays separately visible.  The remaining three fields describe the
-    shared randomness itself.
+    ``first`` and ``second`` retain complete, separate HMC diagnostics.
 
     first
         Transition information for the first marginal.
     second
         Transition information for the second marginal.
     common_normal
-        The flat standard normal vector handed to the first marginal.  The
-        second marginal receives this vector under the coupling map, i.e.
-        unchanged for ``"synchronous"`` and reflected for ``"reflection"``.
+        Standard normal handed to the first marginal; the second receives its
+        synchronous or reflected image.
     reflection_unit
-        The unit vector used by the reflection, in the same flat coordinates
-        as ``common_normal``.  Exactly zero under synchronous coupling, and
-        exactly zero for a reflection whose direction was zero (both denote
-        the identity map).
+        Reflection direction in the same coordinates, or exactly zero for
+        synchronous/identity coupling.
     uniform
-        The single uniform variate shared by both Metropolis tests.  Each
-        marginal compares it against its own acceptance probability.
+        Uniform shared by both tests; each marginal compares it with its own
+        acceptance probability.
 
     """
 
@@ -213,14 +163,9 @@ class CoupledHMCInfo(NamedTuple):
 def _as_pair(value, name: str) -> tuple:
     """Require an explicit two-element pair.
 
-    Nothing is broadcast: a value shared by both marginals must be written
-    ``(value, value)``.  Positions, metrics and step sizes can themselves be
-    tuples, so inferring a pair from a bare value would be ambiguous exactly
-    where the mistake is most costly -- and the cost is silent.  A bare dense
-    ``(d, d)`` inverse mass matrix, if it were unpacked as a pair, would index
-    to its first two ROWS: the first marginal would run with row 0 as a
-    *diagonal* metric and the second with row 1.  The shapes are plausible, the
-    run completes, and the results are wrong with nothing raised anywhere.
+    Nothing is broadcast: shared values must be written ``(value, value)``.
+    Inferring pairs is ambiguous because positions and metrics can themselves
+    be tuples, so a bare value raises ``TypeError``.
     """
     if isinstance(value, tuple) and len(value) == 2:
         return value
@@ -233,18 +178,11 @@ def _as_pair(value, name: str) -> tuple:
 
 
 def _check_metric_kind(inverse_mass_matrix):
-    """Reject metric inputs this module does not support, without tracing.
+    """Accept fixed Euclidean diagonal, dense, or low-rank metrics only.
 
-    Only the three array-shaped Euclidean metric payloads are accepted: a
-    one-dimensional diagonal, a two-dimensional dense matrix, and a
-    :class:`~blackjax.mcmc.metrics.LowRankInverseMassMatrix`.  A callable
-    (Riemannian) metric and a pre-built :class:`~blackjax.mcmc.metrics.Metric`
-    are refused rather than assumed valid: the coupling maps momenta through
-    ``Metric.scale``, and that this reproduces ``Metric.sample_momentum``
-    cannot be verified for an opaque or position-dependent metric.
-
-    This is a static type check only.  It performs no array conversion and is
-    safe on tracers; the numerical checks live in
+    Callable/Riemannian and pre-built ``Metric`` inputs are rejected because
+    their momentum scaling cannot be verified.  This static check does no
+    conversion or tracing; numerical checks are in
     :func:`validate_marginal_inputs`.
     """
     if isinstance(inverse_mass_matrix, metrics.LowRankInverseMassMatrix):
@@ -265,23 +203,9 @@ def _check_metric_kind(inverse_mass_matrix):
 def _flat_position(position: ArrayLikeTree) -> tuple[Array, Callable]:
     """Flatten a position, requiring one nonempty real floating dtype.
 
-    The dtype compared here is the **effective** one -- what the leaf becomes
-    once JAX has it, via ``jnp.asarray`` -- not the dtype the caller's object
-    declares.  That is deliberate and is the opposite choice from
-    :func:`_check_innovations`, so the difference is worth stating.
-
-    A position is the thing everything else is measured against, and
-    ``ravel_pytree`` will convert its leaves regardless, so what matters is the
-    dtype they end up with.  Under JAX's default configuration a float64 leaf
-    becomes float32, and a position mixing float64 and float32 leaves is
-    therefore accepted: after conversion they genuinely agree, and there is no
-    later step at which they could disagree.
-
-    An innovation is a different case.  There the caller supplies a value that
-    is compared against an acceptance probability, so narrowing it silently
-    changes the number the Metropolis test uses.  :func:`_check_innovations`
-    consequently inspects the *declared* dtype and refuses a mismatch instead
-    of converting.  Neither function promises both notions at once.
+    This uses the effective dtype after ``jnp.asarray`` rather than the
+    declared dtype (the opposite of :func:`_check_innovations`, which protects
+    supplied Metropolis innovations from silent narrowing).
     """
     leaves = jax.tree.leaves(position)
     if not leaves:
@@ -300,10 +224,9 @@ def _flat_position(position: ArrayLikeTree) -> tuple[Array, Callable]:
 def _check_paired_positions(first_position, second_position) -> None:
     """Require identical tree structure, leaf shapes and dtype across the pair.
 
-    The dtype compared is the **effective** one, see :func:`_flat_position`, so
-    this guarantee is configuration-relative: under JAX's default settings two
-    positions declaring float64 and float32 agree here, because both become
-    float32.  It is not a promise that their declared dtypes match.
+    Dtype means effective dtype after conversion, as in
+    :func:`_flat_position`; declared dtypes need not match under default JAX
+    narrowing.
     """
     first_structure = jax.tree.structure(first_position)
     second_structure = jax.tree.structure(second_position)
@@ -390,18 +313,11 @@ def _metric_dimension(inverse_mass_matrix):
 def _check_innovations(standard_normal, uniform, flat_position) -> None:
     """Require prescribed innovations to match the position shape and dtype.
 
-    The inputs are inspected **as given**, before any conversion.  That
-    ordering is the whole point: ``jnp.asarray`` narrows a float64 input to
-    float32 under JAX's default configuration, so converting first and
-    comparing dtypes afterwards compares two values that already agree and
-    checks nothing.
-
-    Narrowing is not cosmetic: a float64 uniform below one becomes exactly
-    ``1.0`` in float32 and then rejects a certain acceptance, and one in range
-    becomes a *different* float32, so the test would use a value the caller
-    never gave.  An array declaring a dtype must match the position exactly; a
-    bare Python scalar declares none, is weakly typed and is adopted, so its
-    domain is checked after conversion instead.
+    Inputs are inspected before conversion: strong array dtypes must match
+    exactly (no silent narrowing), while weak Python or JAX scalar arrays adopt
+    the position dtype.  For concrete values, shapes, finiteness, and the
+    uniform's ``[0, 1)`` domain are checked; traced values remain the kernel's
+    responsibility.
     """
     if _declared_shape(standard_normal) != flat_position.shape:
         raise ValueError(
@@ -447,13 +363,7 @@ def _check_innovations(standard_normal, uniform, flat_position) -> None:
 
 
 def _concrete_real_scalar(value, name: str) -> float:
-    """Read a concrete real scalar, accepting the array forms BlackJAX produces.
-
-    Warmup returns a step size as a zero-dimensional JAX array, so requiring a
-    Python float would force callers to hand-cast routine BlackJAX output.
-    Booleans, complex values, non-scalars, non-finite values and tracers are
-    still refused.
-    """
+    """Read a concrete finite real scalar; reject tracers and non-scalars."""
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
             f"`{name}` must be concrete here -- a traced value cannot be checked "
@@ -477,14 +387,7 @@ def _concrete_real_scalar(value, name: str) -> float:
 
 
 def _concrete_integer_scalar(value, name: str) -> int:
-    """Read a concrete integer scalar, accepting NumPy and JAX scalar forms.
-
-    A floating value is refused here rather than left to fail later. Nothing
-    truncates it -- ``fori_loop`` rejects a float bound -- but it does so with a
-    message about loop bound types that never names the parameter, and only
-    once a trajectory is being built. This is a diagnostic improvement, not a
-    correctness guard.
-    """
+    """Read a concrete integer scalar without truncating floating inputs."""
     if isinstance(value, jax.core.Tracer):
         raise TypeError(
             f"`{name}` must be concrete here -- a traced value cannot be checked "
@@ -501,19 +404,11 @@ def _concrete_integer_scalar(value, name: str) -> int:
 
 
 def validate_marginal_inputs(inverse_mass_matrix, step_size, num_integration_steps):
-    """Eagerly validate one marginal's concrete metric and integration settings.
+    """Eagerly validate one marginal's concrete metric and settings.
 
-    These are host-side numerical checks on *concrete* values: they use NumPy
-    and cannot run on tracers, so they are performed once when an algorithm is
-    constructed and are deliberately absent from the traced kernel.
-
-    .. important::
-
-        Passing this check says the values supplied *now* are admissible.  It
-        says nothing about values that appear later inside a jitted or
-        vmapped computation, which are never seen by this function.  A caller
-        who builds a kernel with :func:`build_kernel` and feeds it traced
-        metrics is responsible for their admissibility.
+    Checks use NumPy on concrete host values and are absent from the traced
+    kernel.  Passing them validates only the values supplied now; callers using
+    traced values through :func:`build_kernel` retain responsibility for them.
 
     Raises
     ------
@@ -689,22 +584,10 @@ def _build_prescribed_marginal(
 
 
 def _reflection_unit(direction: Array) -> Array:
-    """Normalise a direction robustly; a zero direction gives the identity.
+    """Normalize after scaling by the maximum absolute entry.
 
-    The direction is first divided by its largest absolute entry, so a
-    direction whose norm would overflow or underflow in the working dtype is
-    still normalised correctly.  This is load-bearing rather than defensive, and
-    the failure it prevents is silent.  At float32 -- BlackJAX's default -- a
-    difference like ``[1e20, -2e20, 5e19, 3e20]`` has a norm that overflows, so
-    a naive ``d / norm(d)`` yields exactly zero: the reflection would quietly
-    become the identity and the pair would report ``reflection_unit = 0`` while
-    running synchronous coupling under a reflection label.  The mirrored
-    underflow case yields infinities.  Both are reachable for a diverging chain.
-    A direction that is exactly zero is returned as zero, which makes the
-    reflection the identity map -- that case is intended and documented.
-
-    A direction containing a non-finite entry propagates as non-finite rather
-    than silently producing a plausible-looking unit vector.
+    A zero direction remains zero (identity reflection); non-finite entries
+    propagate rather than becoming a plausible unit vector.
     """
     maximum = jnp.max(jnp.abs(direction))
     scaled = direction / jnp.where(maximum == 0, 1, maximum)
@@ -722,16 +605,10 @@ def whitened_difference(
     second_state: hmc.HMCState,
     first_metric: metrics.Metric,
 ) -> Array:
-    """Default reflection direction: the position difference, whitened.
+    """Return the first-metric-whitened position difference in flat space.
 
-    Returns :math:`A^{-1}(x_1 - x_2)` in flat coordinates, where :math:`A` is
-    the first marginal's momentum square root.  ``Metric.scale`` with
-    ``inv=True, trans=True`` is exactly that inverse map.
-
-    Only the first marginal's metric is used.  When the two marginals carry
-    different metrics this is therefore a first-metric-based direction, and no
-    property is claimed for the pair.  A policy needing the second metric can
-    close over it.
+    Only the first metric is used; a policy needing the second can close over
+    it.  No property is claimed for pairs with different metrics.
     """
     delta = jax.tree.map(
         lambda a, b: a - b, first_state.position, second_state.position
@@ -750,19 +627,11 @@ def _build_prescribed_pair(
     coupling: str,
     direction_fn: Callable | None,
 ):
-    """Build the coupled transition whose randomness is supplied, not drawn.
+    """Build the deterministic core with prescribed ``(z, u)`` inputs.
 
-    Returns ``step(state, standard_normal, uniform) -> (CoupledHMCState,
-    CoupledHMCInfo)``.  This is the deterministic core of the kernel: given
-    the pair of incoming states and one ``(z, u)`` pair it is an ordinary pure
-    function, which is what makes the coupling separately checkable without
-    also reasoning about key splitting.  It is internal to this module.
-
-    This function passes ``direction_fn`` nothing but the incoming states and
-    the first metric -- the innovations it receives are not among its
-    arguments, though they do already exist by the time it is called. Whether
-    the returned direction is genuinely free of them is a contract the caller
-    keeps, since a callable may close over anything.
+    It returns ``step(state, standard_normal, uniform)`` and passes
+    ``direction_fn`` only incoming states and the first metric.  Purity of that
+    callable remains the caller's responsibility.
     """
     logdensity_fns = _as_pair(logdensity_fn, "logdensity_fn")
     step_sizes = _as_pair(step_size, "step_size")
@@ -837,7 +706,7 @@ def _build_prescribed_pair(
 
 
 def init(position: Position, logdensity_fn: Sequence[Callable]) -> CoupledHMCState:
-    """Initialise a coupled pair.
+    """Initialize a coupled pair from explicit position and log-density pairs.
 
     Parameters
     ----------
@@ -872,15 +741,11 @@ def build_kernel(
     built, and not at call time.  ``direction_fn`` is applied to the pair of
     incoming states and the first metric, and is supplied no innovations.
 
-    It is worth being exact about what that does and does not say, because an
-    earlier version of this docstring overstated it.  The kernel draws ``z``
-    and the uniform *before* running the transition in which ``direction_fn``
-    is evaluated, so the guarantee is **not** one of ordering.  It is that the
-    innovations are not among the arguments handed over.  A ``direction_fn``
-    that closes over innovations, or draws its own randomness, breaks the
-    reflection's marginal correctness and nothing here can detect it. Keeping
-    it a pure function of the arguments it is given is the caller's part of the
-    contract -- the same purity convention every BlackJAX kernel assumes.
+    The kernel draws ``z`` and the uniform before the transition evaluates
+    ``direction_fn``; the contract concerns its arguments, not ordering.  A
+    callable that closes over innovations or draws randomness breaks reflection
+    marginal correctness and cannot be detected here, so callers must keep it
+    pure in the supplied arguments.
 
     Parameters
     ----------

--- a/tests/adaptation/test_meta_telemetry.py
+++ b/tests/adaptation/test_meta_telemetry.py
@@ -600,39 +600,30 @@ class SingleChainCandidateTest(chex.TestCase):
         draws, grads = _make_isotropic_buffer(_D, 40)
         return core.final(_fill_state_from_buffer(state, draws, grads)).publication
 
-    def test_withheld_candidate_is_still_reported(self):
+    def test_default_record_reports_candidate_and_controller_summaries(self):
         record = self._record()
         self.assertFalse(bool(record.escalated_now))
         candidate = record.single_chain.candidate
         for name in ("logdet", "lam_max", "sigma_gm"):
             self.assertTrue(np.isfinite(np.asarray(getattr(candidate, name))), msg=name)
         self.assertGreater(float(candidate.lam_max), 0.0)
-
-    def test_the_three_ranks_are_reported_separately(self):
-        record = self._record()
         self.assertGreaterEqual(int(record.single_chain.detection_rank), 0)
         self.assertGreaterEqual(int(record.single_chain.candidate.effective_rank), 0)
         self.assertEqual(int(record.deployed_effective_rank), 0)  # not escalated
         self.assertGreaterEqual(int(record.escalation_rank_stored), 0)
-
-    def test_in_force_and_deployed_metrics_are_both_reported(self):
-        record = self._record()
         self.assertTrue(np.isfinite(np.asarray(record.in_force_logdet)))
         self.assertTrue(np.isfinite(np.asarray(record.deployed_logdet)))
-
-    def test_full_matrices_absent_by_default_present_when_asked(self):
-        self.assertIsNone(self._record().single_chain.candidate.full)
-        self.assertIsNone(self._record().deployed_full)
-        full = self._record(full_matrices=True)
-        self.assertIsNotNone(full.single_chain.candidate.full)
-        self.assertEqual(full.single_chain.candidate.full.sigma.shape, (_D,))
-
-    def test_epsilons_are_nan_when_final_is_called_without_the_host(self):
-        """The core cannot see the step size; it must not invent one."""
-        record = self._record()
         self.assertTrue(np.isnan(np.asarray(record.epsilon_in_force)))
         self.assertTrue(np.isnan(np.asarray(record.epsilon_next_window)))
         self.assertEqual(int(record.warmup_step_index), -1)
+
+    def test_full_matrices_absent_by_default_present_when_asked(self):
+        compact = self._record()
+        self.assertIsNone(compact.single_chain.candidate.full)
+        self.assertIsNone(compact.deployed_full)
+        full = self._record(full_matrices=True)
+        self.assertIsNotNone(full.single_chain.candidate.full)
+        self.assertEqual(full.single_chain.candidate.full.sigma.shape, (_D,))
 
 
 class MultiChainBranchTest(chex.TestCase):
@@ -665,9 +656,8 @@ class MultiChainBranchTest(chex.TestCase):
         self.assertEqual(int(record.multi_chain.detection_branch_history), BRANCH_NONE)
         self.assertEqual(int(record.multi_chain.branch_first_set_at_window), -1)
 
-    def test_both_candidates_are_reported_before_escalation(self):
-        """W and T candidates are built before routing and are not the same."""
-        record = _mc_record(_make_mc_isotropic)
+        # Both candidates are built before routing, even when neither is
+        # deployed, and their low-rank summaries must remain distinguishable.
         detail = record.multi_chain
         for candidate in (detail.candidate_w, detail.candidate_t):
             self.assertTrue(np.isfinite(np.asarray(candidate.logdet)))
@@ -677,7 +667,6 @@ class MultiChainBranchTest(chex.TestCase):
 
     def test_raw_and_routed_r2_are_separate_and_can_disagree(self):
         """The W branch uses the raw R2; the T branch uses the routed one."""
-        core = _mc_core(telemetry=True)
         warmup = staged_adaptation(
             blackjax.nuts,
             _logdensity_fn,
@@ -699,7 +688,22 @@ class MultiChainBranchTest(chex.TestCase):
             disagreements,
             msg="expected at least one window where raw and routed R2 differ",
         )
-        del core
+        # The raw and routed values must disagree in the same window as their
+        # own gate bits: raw R2 passes W while routed R2 is NaN and fails T.
+        split = [
+            e
+            for e in chronology
+            if e["gates_true"]["w_r2_raw"] != e["gates_true"]["t_r2_routed"]
+        ]
+        self.assertNotEmpty(
+            split,
+            msg="expected a window where the raw and routed R2 gates disagree",
+        )
+        for entry in split:
+            self.assertTrue(entry["gates_true"]["w_r2_raw"])
+            self.assertFalse(entry["gates_true"]["t_r2_routed"])
+            self.assertTrue(np.isnan(entry["multi_chain.r2_routed"]))
+            self.assertFalse(np.isnan(entry["r2_raw"]))
 
 
 class MultiChainEscalationSequenceTest(chex.TestCase):
@@ -814,42 +818,6 @@ class MultiChainEscalationSequenceTest(chex.TestCase):
         self.assertTrue(bool(detail.t_unimodality_resolved))
         self.assertLess(float(detail.t_contraction_stat), -2.365)
 
-    def test_r2_gate_bits_are_pinned_to_their_own_predicates(self):
-        """w_r2_raw is the raw R2 gate; t_r2_routed is the GAIN-overridden one.
-
-        In the hand-built fixtures both R2 values are 1.0, so the two gates are
-        numerically identical and swapping the bits would pass.  A real run
-        reaches windows where the routed value is NaN while the raw value is
-        finite and above threshold -- there the two bits must disagree, which
-        pins each to its own predicate.
-        """
-        warmup = staged_adaptation(
-            blackjax.nuts,
-            _logdensity_fn,
-            metric="auto",
-            max_grad_budget=16_000,
-            n_chains=_MC_M,
-            metric_telemetry=True,
-            adaptation_info_fn=publication_adapt_info_fn(),
-        )
-        x0 = jax.random.normal(jax.random.key(1), (_MC_M, _D))
-        _, records = warmup.run(jax.random.key(0), x0)
-        split = [
-            e
-            for e in extract_publication_chronology(records)
-            if e["gates_true"]["w_r2_raw"] != e["gates_true"]["t_r2_routed"]
-        ]
-        self.assertNotEmpty(
-            split,
-            msg="expected a window where the raw and routed R2 gates disagree",
-        )
-        for entry in split:
-            # raw finite and passing, routed NaN and therefore failing
-            self.assertTrue(entry["gates_true"]["w_r2_raw"])
-            self.assertFalse(entry["gates_true"]["t_r2_routed"])
-            self.assertTrue(np.isnan(entry["multi_chain.r2_routed"]))
-            self.assertFalse(np.isnan(entry["r2_raw"]))
-
     def test_stored_escalation_rank_is_the_t_detection_rank_even_when_w_fires(self):
         """Reported, not corrected: the controller stores k_new regardless.
 
@@ -875,25 +843,21 @@ class PayloadAndSchemaTest(chex.TestCase):
         state = _fill_state_from_buffer(core.init(_D), draws, grads)
         return core.final(state).publication
 
-    def test_compact_record_leaves_are_all_scalar(self):
-        for leaf in jax.tree.leaves(self._record()):
-            self.assertEqual(jnp.asarray(leaf).shape, ())
-
-    def test_compact_record_carries_no_buffers(self):
+    def test_compact_record_is_scalar_bounded_and_measured(self):
         record = self._record()
+        for leaf in jax.tree.leaves(record):
+            self.assertEqual(jnp.asarray(leaf).shape, ())
         total = sum(int(jnp.asarray(x).size) for x in jax.tree.leaves(record))
         self.assertEqual(total, len(jax.tree.leaves(record)))
-
-    def test_record_nbytes_reports_actual_leaf_bytes(self):
-        record = self._record()
         expected = sum(int(jnp.asarray(x).nbytes) for x in jax.tree.leaves(record))
         self.assertEqual(record_nbytes(record), expected)
         self.assertLess(record_nbytes(record), 1024)
 
     def test_full_matrices_cost_is_why_they_are_opt_in(self):
+        compact = self._record()
         self.assertGreater(
             record_nbytes(self._record(full_matrices=True)),
-            record_nbytes(self._record()),
+            record_nbytes(compact),
         )
 
     def test_exactly_one_detail_subrecord_is_populated(self):


### PR DESCRIPTION
## Summary

- Shorten the telemetry and coupled-HMC docstrings while retaining units, routing, dtype/validation boundaries, and numerical limitations. Library executable statements are unchanged.
- Consolidate identical telemetry records and merge two identical eight-chain warmups into one test. Keep all assertions, seeds, configurations, escalation preconditions, and tolerances; add no caches, skips, or coverage machinery.
- Net reduction: **240 lines across three files**.

## Verification

At `a90ae74bbd2dfad5d77712d4ef0883cbda8c0630`:

- Full pinned pre-commit hook set passed.
- Six focused telemetry cases passed.
- Full `tests/` gate, CPU, Python 3.12.3, JAX/jaxlib 0.10.0, two workers, coverage enabled: **2000 passed + 53 subtests, zero failures/skips, 1623.80s (27m04s)**. The horseshoe benchmark body ran and passed.
- Statement coverage remains **7729/7998 = 96.64%** (97% rounded), exactly matching the baseline totals. This is not branch-coverage evidence.
- Independent source checks verified unchanged executable library AST and preservation of all 183 telemetry assertion expressions, including their setup and guards.

The full command was `uv run --no-sync pytest -n 2 -vv --benchmark-disable --cov=blackjax --cov-report=xml --cov-report=term --durations=50 --junitxml=<report> -ra tests`, with CPU/unbuffered output and a 24G cap. The imported source paths and hashes matched the committed worktree. Existing optional oracle packages were retained; this local environment is not identical to the hosted CI install.

## Runtime scope

The clean-main baseline at `112dae7b4c98d3f358c7402c5793cb09f063733a` passed **2007 tests + 53 subtests in 1487.40s (24m47s)** under the same local dependency versions, worker count and coverage command. Both runs are below 35 minutes on this host, but the final run was slower. **No measured speedup or hosted-CI runtime guarantee is claimed.** Seven separate test items were consolidated, not seven checks discarded. The removed duplicate warmup item took 3.131s in the baseline; that is not a measured end-to-end saving.

No controller, sampler, diagnostic, schema, threshold, dependency, or CI-policy change.

Generated with Codex; reviewed by two independent source-review lenses and the coordinating lead.
