### PR TITLE
Fix nightly + main CI: LAPS silent NaN death, and three float-boundary test defects

### DIFF
--- a/blackjax/adaptation/laps_burn_in.py
+++ b/blackjax/adaptation/laps_burn_in.py
@@ -66,6 +66,14 @@ def build_kernel(logdensity_fn, ndims, microcanonical=True):
         # no_nans(new_state) was always True after the kernel's own revert, so
         # the "nans" diagnostic and the eps_factor 0.5 halving safety in
         # Adaptation.update() (:332-334) were dead code.
+        #
+        # D1 fix (LAPS nightly regression): until mclmc.handle_nans also checked
+        # kinetic_change / energy_change, info.nonans was blind to a NaN
+        # kinetic_change that left position, momentum and logdensity all finite
+        # (see mclmc.py:handle_nans). That NaN passed this gate silently, poisoned
+        # the ECA `lax.psum` ensemble average, and produced a permanently
+        # non-finite step size (see the D2 fix on the multiplicative update
+        # below). info.nonans now covers that route too.
         nonans = info.nonans
         new_state = nan_reject(nonans, state, new_state)
 
@@ -351,10 +359,27 @@ class Adaptation:
             "observables": Etheta["observables"],
         }
 
+        # D2 fix (LAPS nightly regression): make "the adapted step size is always
+        # finite" an invariant of the update itself, not just of the nan_reject
+        # trigger above. The update is multiplicative (step_size * eps_factor), so
+        # a single non-finite eps_factor -- from this trigger or from any other
+        # route this function does not explicitly guard -- is otherwise absorbing:
+        # once step_size is NaN it stays NaN for every remaining burn-in
+        # iteration, and LAPS silently returns a frozen, un-equilibrated ensemble
+        # with no error and no warning. Falling back to the previous step size
+        # (finite, by induction from the finite initial state) lets the chain
+        # survive a poisoned iteration instead of being permanently killed by it.
+        step_size_candidate = adaptation_state.step_size * eps_factor
+        step_size_new = jnp.where(
+            jnp.isfinite(step_size_candidate),
+            step_size_candidate,
+            adaptation_state.step_size,
+        )
+
         adaptation_state_new = AdaptationState(
             L,
             inverse_mass_matrix,
-            adaptation_state.step_size * eps_factor,  # set the stepsize directly
+            step_size_new,  # set the stepsize directly
             adaptation_state.step_count + 1,
             EEVPD,
             EEVPD_wanted,

--- a/blackjax/adaptation/laps_burn_in.py
+++ b/blackjax/adaptation/laps_burn_in.py
@@ -66,14 +66,6 @@ def build_kernel(logdensity_fn, ndims, microcanonical=True):
         # no_nans(new_state) was always True after the kernel's own revert, so
         # the "nans" diagnostic and the eps_factor 0.5 halving safety in
         # Adaptation.update() (:332-334) were dead code.
-        #
-        # D1 fix (LAPS nightly regression): until mclmc.handle_nans also checked
-        # kinetic_change / energy_change, info.nonans was blind to a NaN
-        # kinetic_change that left position, momentum and logdensity all finite
-        # (see mclmc.py:handle_nans). That NaN passed this gate silently, poisoned
-        # the ECA `lax.psum` ensemble average, and produced a permanently
-        # non-finite step size (see the D2 fix on the multiplicative update
-        # below). info.nonans now covers that route too.
         nonans = info.nonans
         new_state = nan_reject(nonans, state, new_state)
 
@@ -359,23 +351,12 @@ class Adaptation:
             "observables": Etheta["observables"],
         }
 
-        # D2 fix (LAPS nightly regression): make "the adapted step size is always
-        # finite" an invariant of the update itself, not just of the nan_reject
-        # trigger above. The update is multiplicative (step_size * eps_factor), so
-        # a single non-finite eps_factor -- from this trigger or from any other
-        # route this function does not explicitly guard -- is otherwise absorbing:
-        # once step_size is NaN it stays NaN for every remaining burn-in
-        # iteration, and LAPS silently returns a frozen, un-equilibrated ensemble
-        # with no error and no warning. Falling back to the previous step size
-        # (finite, by induction from the finite initial state) lets the chain
-        # survive a poisoned iteration instead of being permanently killed by it.
-        step_size_candidate = adaptation_state.step_size * eps_factor
+        # D2 (#1035): multiplicative update is absorbing on a non-finite factor; fall back to the last finite step size.
         step_size_new = jnp.where(
-            jnp.isfinite(step_size_candidate),
-            step_size_candidate,
+            jnp.isfinite(adaptation_state.step_size * eps_factor),
+            adaptation_state.step_size * eps_factor,
             adaptation_state.step_size,
         )
-
         adaptation_state_new = AdaptationState(
             L,
             inverse_mass_matrix,

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -227,11 +227,25 @@ def handle_nans(previous_state, next_state, info, key):
     # at moderate overshoot) are correctly detected and reverted.  Pre-fix, case-2
     # left info.nonans=True while the state carried a NaN logdensity, silently
     # corrupting subsequent energy_change computations and blocking step-size shrinkage.
+    #
+    # D1 fix (LAPS nightly regression): also check kinetic_change / energy_change.
+    # `momentum_proj` in the isokinetic integrator is a dot product of two unit
+    # vectors that can round marginally below -1 in float32, driving the argument of
+    # `jnp.log(1 + momentum_proj + (1 - momentum_proj) * zeta**2)` negative and
+    # producing a NaN kinetic_change while position, momentum and logdensity all stay
+    # finite. Pre-fix this route left info.nonans=True: a single poisoned chain's NaN
+    # silently propagated through ECA's `lax.psum` ensemble average and, downstream,
+    # made the LAPS-adapted step size non-finite forever (see laps_burn_in.py).
     nonans = jnp.logical_and(
         jnp.logical_and(
             isfinite_pytree(next_state.position), isfinite_pytree(next_state.momentum)
         ),
-        jnp.isfinite(next_state.logdensity),
+        jnp.logical_and(
+            jnp.isfinite(next_state.logdensity),
+            jnp.logical_and(
+                jnp.isfinite(info.kinetic_change), jnp.isfinite(info.energy_change)
+            ),
+        ),
     )
 
     state, info = jax.lax.cond(

--- a/blackjax/mcmc/mclmc.py
+++ b/blackjax/mcmc/mclmc.py
@@ -227,25 +227,14 @@ def handle_nans(previous_state, next_state, info, key):
     # at moderate overshoot) are correctly detected and reverted.  Pre-fix, case-2
     # left info.nonans=True while the state carried a NaN logdensity, silently
     # corrupting subsequent energy_change computations and blocking step-size shrinkage.
-    #
-    # D1 fix (LAPS nightly regression): also check kinetic_change / energy_change.
-    # `momentum_proj` in the isokinetic integrator is a dot product of two unit
-    # vectors that can round marginally below -1 in float32, driving the argument of
-    # `jnp.log(1 + momentum_proj + (1 - momentum_proj) * zeta**2)` negative and
-    # producing a NaN kinetic_change while position, momentum and logdensity all stay
-    # finite. Pre-fix this route left info.nonans=True: a single poisoned chain's NaN
-    # silently propagated through ECA's `lax.psum` ensemble average and, downstream,
-    # made the LAPS-adapted step size non-finite forever (see laps_burn_in.py).
+    # D1 (#1035): also require finite kinetic/energy change, else a NaN there silently poisons ECA's ensemble psum average.
     nonans = jnp.logical_and(
         jnp.logical_and(
             isfinite_pytree(next_state.position), isfinite_pytree(next_state.momentum)
         ),
-        jnp.logical_and(
-            jnp.isfinite(next_state.logdensity),
-            jnp.logical_and(
-                jnp.isfinite(info.kinetic_change), jnp.isfinite(info.energy_change)
-            ),
-        ),
+        jnp.isfinite(next_state.logdensity)
+        & jnp.isfinite(info.kinetic_change)
+        & jnp.isfinite(info.energy_change),
     )
 
     state, info = jax.lax.cond(

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -60,6 +60,13 @@ _CONTROL_SEED = 20260907
 _REFERENCE_SEED = 11
 _REFERENCE_STEP_SIZES = (0.75, 0.90)
 
+# `test_jit_vmap_and_scan`'s decision-margin control needs an interior
+# acceptance probability for BOTH marginals of its own fixture (standard
+# normal vs. tilted, mass 1, step 0.2, 4 leapfrog steps, positions +-1). Both
+# `_CONTROL_SEED` and `_REFERENCE_SEED` saturate at least one marginal to
+# exactly 1.0 there, so this fixture gets its own seed, found by scanning.
+_JIT_MARGIN_SEED = 10248
+
 
 def _standard_normal_logdensity(x):
     flat, _ = jax.flatten_util.ravel_pytree(x)
@@ -1450,16 +1457,107 @@ class CoupledHMCContractTest(BlackJAXTest):
         jitted_state, jitted_info = jax.jit(algorithm.step)(key, state)
         # Floating results are compared with a tolerance: XLA may fuse or
         # reassociate under `jit`, so bitwise agreement with the eager path is
-        # not a contract this module can promise. The DECISIONS and the
-        # structure are exact, because those must not drift.
-        chex.assert_trees_all_close(eager_state, jitted_state, atol=1e-12)
-        self.assertEqual(
-            bool(eager_info.first.is_accepted), bool(jitted_info.first.is_accepted)
+        # not a contract this module can promise. `atol=1e-12` on the STATE
+        # was already too tight for that: a 300,000-seed sweep of this
+        # fixture found the accepted position differing by up to 2.861e-6
+        # (float32) between the two paths, so this `key`'s date-seeded draw
+        # tripped it on roughly a third of simulated days. `atol=1e-4` is
+        # ~35x that measured gap.
+        #
+        # The same drift reaches the accept/reject DECISION itself, since it
+        # is a `<` comparison against exactly the float that may move: that
+        # same sweep found the acceptance rate differing by up to 3.815e-6
+        # for the second marginal, with no natural draw among them flipping
+        # either decision; an adversarial probe -- a uniform placed inside
+        # one such gap by construction, not drawn -- confirmed the gap really
+        # does flip `is_accepted` between the two paths. So the probability
+        # is compared with a tolerance (atol=1e-4, ~26x that measured gap)
+        # instead of asserting the boolean at `key`'s essentially arbitrary
+        # point, and decision coverage is restored below at a uniform held
+        # deliberately far from `p_accept` instead.
+        chex.assert_trees_all_close(eager_state, jitted_state, atol=1e-4)
+        chex.assert_trees_all_close(
+            eager_info.first.acceptance_rate,
+            jitted_info.first.acceptance_rate,
+            atol=1e-4,
         )
-        self.assertEqual(
-            bool(eager_info.second.is_accepted), bool(jitted_info.second.is_accepted)
+        chex.assert_trees_all_close(
+            eager_info.second.acceptance_rate,
+            jitted_info.second.acceptance_rate,
+            atol=1e-4,
         )
         chex.assert_trees_all_equal_structs(eager_state, jitted_state)
+        chex.assert_trees_all_equal_structs(eager_info, jitted_info)
+
+        # Decision coverage, without the knife edge: exercise accept/reject
+        # through the same prescribed-pair machinery `algorithm.step` is built
+        # from (`_build_prescribed_pair`), but with an explicit uniform held
+        # comfortably away from `p_accept` on either side, rather than at
+        # `key`'s arbitrary draw. `_JIT_MARGIN_SEED` is a fixed control (see
+        # its definition) chosen so both marginals' `p_accept` are interior
+        # here; the interiority is asserted rather than trusted.
+        margin_step = coupled_hmc._build_prescribed_pair(
+            (_standard_normal_logdensity, _tilted_logdensity),
+            (mass, mass),
+            (0.2, 0.2),
+            (4, 4),
+            integrators.velocity_verlet,
+            1000.0,
+            "reflection",
+            coupled_hmc.whitened_difference,
+        )
+        margin_noise = jax.random.normal(jax.random.key(_JIT_MARGIN_SEED), (_DIM,))
+        # `acceptance_rate` does not depend on the uniform supplied, so this
+        # placeholder call only reads off `p_accept` for both marginals.
+        _, rate_probe_info = margin_step(state, margin_noise, jnp.asarray(0.5))
+        first_p_accept = float(rate_probe_info.first.acceptance_rate)
+        second_p_accept = float(rate_probe_info.second.acceptance_rate)
+        for label, probability in (
+            ("first", first_p_accept),
+            ("second", second_p_accept),
+        ):
+            self.assertGreater(
+                probability, 0.0, f"{label} p_accept is 0, no accepting uniform exists"
+            )
+            self.assertLess(
+                probability,
+                1.0,
+                f"{label} p_accept rounded to 1, no rejecting uniform exists -- "
+                "choose a different `_JIT_MARGIN_SEED`",
+            )
+        highest = max(first_p_accept, second_p_accept)
+        # `uniform = 0` accepts both marginals with a margin of a whole
+        # probability; `uniform = 0.5 * (highest + 1.0)` rejects both with a
+        # margin of `0.5 * (1 - highest)` -- see the `reflect_reject` fixture
+        # above for why the rejecting case is built from `highest` and not
+        # pinned to either marginal's own probability directly.
+        for uniform, expect_accepted in (
+            (jnp.asarray(0.0), True),
+            (jnp.asarray(0.5 * (highest + 1.0)), False),
+        ):
+            eager_margin_state, eager_margin_info = margin_step(
+                state, margin_noise, uniform
+            )
+            jitted_margin_state, jitted_margin_info = jax.jit(margin_step)(
+                state, margin_noise, uniform
+            )
+            for name, info in (
+                ("eager", eager_margin_info),
+                ("jitted", jitted_margin_info),
+            ):
+                self.assertEqual(
+                    bool(info.first.is_accepted),
+                    expect_accepted,
+                    f"{name} first marginal at uniform={float(uniform)!r}",
+                )
+                self.assertEqual(
+                    bool(info.second.is_accepted),
+                    expect_accepted,
+                    f"{name} second marginal at uniform={float(uniform)!r}",
+                )
+            chex.assert_trees_all_close(
+                eager_margin_state, jitted_margin_state, atol=1e-12
+            )
 
         def body(carry, step_key):
             new_state, _ = algorithm.step(step_key, carry)

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -536,9 +536,30 @@ class CoupledHMCContractTest(BlackJAXTest):
                     "than skipping or clipping this case",
                 )
             highest = max(float(probe_first), float(probe_second))
-            # Acceptance is `uniform < p_accept`, so `uniform = highest` rejects
-            # both marginals and `uniform = 0` accepts both.
-            uniform = jnp.asarray(0.0 if accept else highest, jnp.float64)
+            # Acceptance is `uniform < p_accept`. `uniform = 0` accepts both
+            # with a margin of a whole probability (both probes are strictly
+            # > 0, asserted above), so the accepting case is safe as written.
+            #
+            # The rejecting case must NOT use `uniform = highest` verbatim:
+            # `highest` is the ORACLE's own recomputation of the higher
+            # marginal's probability, not the module's. The module computes
+            # `log_p_accept` via its own composition of the same primitives
+            # (`_build_prescribed_pair` builds and runs both marginals
+            # together, rather than the oracle's one-at-a-time recomputation
+            # in `_oracle_marginal`), so the two can disagree in the last
+            # ULP even in float64 on one fixed JAX version -- a sweep of 51
+            # independently-drawn reference fixtures found the module's own
+            # acceptance rate for the higher marginal exceeding `highest` by
+            # exactly one ULP (e.g. 0.8137129940550802 vs
+            # 0.8137129940550795) in 3 of them, which flips that marginal to
+            # "accepted" when `uniform` sits exactly on the oracle's value.
+            # The midpoint of `(highest, 1.0)` rejects both marginals with a
+            # margin of `0.5 * (1.0 - highest)` -- order 0.1 here, many
+            # orders of magnitude past any ULP-level disagreement -- while
+            # `uniform = 0` already has an equally wide margin on the
+            # accepting side, so both branches are now robust by construction
+            # rather than by landing on the correct side of a knife edge.
+            uniform = jnp.asarray(0.0 if accept else 0.5 * (highest + 1.0), jnp.float64)
 
             new_state, info = step(state, noise, uniform)
             # Confirm this case exercises the branch it is named for.

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -1460,9 +1460,23 @@ class CoupledHMCContractTest(BlackJAXTest):
         # not a contract this module can promise. `atol=1e-12` on the STATE
         # was already too tight for that: a 300,000-seed sweep of this
         # fixture found the accepted position differing by up to 2.861e-6
-        # (float32) between the two paths, so this `key`'s date-seeded draw
-        # tripped it on roughly a third of simulated days. `atol=1e-4` is
-        # ~35x that measured gap.
+        # (float32) between the two paths -- comfortably smaller than the
+        # state values themselves (roughly 0.3 to 11 over that same sweep,
+        # median ~1.9), so this is drift, not a real divergence.
+        # `chex.assert_trees_all_close` combines `atol` with a default
+        # `rtol=1e-6` (fails when `|actual - desired| > atol + rtol *
+        # |desired|`), so the two knobs interact: at `atol=1e-12` alone ~33%
+        # of the sweep's simulated days exceeded it, but the `rtol` term
+        # (about 1e-6 times an O(1) state value) rescued most of those,
+        # leaving 13/200 (6.5%) simulated days that failed the actual
+        # (combined) assertion -- `self.next_key()`'s date-seeded draw is one
+        # such day roughly one day in fifteen, which is what was actually
+        # breaking CI (main Tests run 34185840275 on pinned JAX failed at
+        # exactly this line). `atol=1e-4` is ~35x the measured 2.861e-6 gap
+        # and ~800 float32 ULP; perturbing the jitted state by 1e-2 (two
+        # orders above this atol) still trips the assertion, confirming the
+        # loosened check still catches a genuine divergence rather than
+        # merely tolerating drift.
         #
         # The same drift reaches the accept/reject DECISION itself, since it
         # is a `<` comparison against exactly the float that may move: that

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -833,7 +833,25 @@ class CoupledHMCContractTest(BlackJAXTest):
         {"testcase_name": "u_just_below_one", "uniform": None},
     )
     def test_certain_acceptance_accepts_at_both_uniform_endpoints(self, uniform):
-        """``p_accept == 1`` accepts for every admissible uniform in [0, 1)."""
+        """``p_accept == 1`` accepts for every admissible uniform in [0, 1).
+
+        A *small* step size does not make this hold: the leapfrog's energy
+        error is ``O(step_size**2)`` from truncation alone, not from
+        floating-point rounding, so with ``step_size = 1e-8`` the error sits
+        right at ~1e-16 with a sign that a seed sweep showed is essentially a
+        coin flip -- a prior version of this test drew its momentum from
+        ``self.next_key()`` (date-seeded) and, checked across 200 synthetic
+        "days", failed on 128 of them because `p_accept` rounded to fractionally
+        *below* 1 as often as not. `p_accept == 1` must instead hold BY
+        CONSTRUCTION: start at ``position = momentum = 0``. The standard
+        normal's gradient there is exactly ``0``, so every leapfrog half-step
+        multiplies a zero gradient into a zero update and the trajectory
+        stays bit-for-bit at the origin for any step size or step count.
+        Both endpoints' energies are then the same float64 value evaluated
+        twice, so their difference is exactly ``0.0`` -- not merely small --
+        and `p_accept` clips to exactly `1.0` regardless of JAX version or
+        operation ordering.
+        """
         with _x64():
             if uniform is None:
                 uniform = float(jnp.nextafter(jnp.float64(1.0), jnp.float64(0.0)))
@@ -844,7 +862,6 @@ class CoupledHMCContractTest(BlackJAXTest):
                 _standard_normal_logdensity(position),
                 jax.grad(_standard_normal_logdensity)(position),
             )
-            # A vanishing step size makes the energy error ~0, so p_accept == 1.
             _, step = coupled_hmc._build_prescribed_marginal(
                 _standard_normal_logdensity,
                 mass,
@@ -853,9 +870,15 @@ class CoupledHMCContractTest(BlackJAXTest):
                 integrators.velocity_verlet,
                 1000.0,
             )
-            noise = jax.random.normal(self.next_key(), (_DIM,), jnp.float64)
+            # Zero momentum, not a fresh draw: see the docstring above for
+            # why this is what pins `p_accept` at exactly 1.0.
+            noise = jnp.zeros((_DIM,), jnp.float64)
             _, info = step(state, noise, jnp.asarray(uniform, jnp.float64))
-            np.testing.assert_allclose(float(info.acceptance_rate), 1.0, rtol=1e-12)
+            self.assertEqual(
+                float(info.acceptance_rate),
+                1.0,
+                "p_accept must be bit-exact 1.0 at a stationary point, not merely close",
+            )
             self.assertTrue(bool(info.is_accepted))
 
     def test_certain_rejection_rejects_at_the_zero_uniform(self):

--- a/tests/mcmc/test_coupled_hmc.py
+++ b/tests/mcmc/test_coupled_hmc.py
@@ -60,11 +60,8 @@ _CONTROL_SEED = 20260907
 _REFERENCE_SEED = 11
 _REFERENCE_STEP_SIZES = (0.75, 0.90)
 
-# `test_jit_vmap_and_scan`'s decision-margin control needs an interior
-# acceptance probability for BOTH marginals of its own fixture (standard
-# normal vs. tilted, mass 1, step 0.2, 4 leapfrog steps, positions +-1). Both
-# `_CONTROL_SEED` and `_REFERENCE_SEED` saturate at least one marginal to
-# exactly 1.0 there, so this fixture gets its own seed, found by scanning.
+# `test_jit_vmap_and_scan`'s margin control needs both marginals interior;
+# `_CONTROL_SEED` and `_REFERENCE_SEED` saturate one to 1.0 on that fixture.
 _JIT_MARGIN_SEED = 10248
 
 
@@ -543,29 +540,8 @@ class CoupledHMCContractTest(BlackJAXTest):
                     "than skipping or clipping this case",
                 )
             highest = max(float(probe_first), float(probe_second))
-            # Acceptance is `uniform < p_accept`. `uniform = 0` accepts both
-            # with a margin of a whole probability (both probes are strictly
-            # > 0, asserted above), so the accepting case is safe as written.
-            #
-            # The rejecting case must NOT use `uniform = highest` verbatim:
-            # `highest` is the ORACLE's own recomputation of the higher
-            # marginal's probability, not the module's. The module computes
-            # `log_p_accept` via its own composition of the same primitives
-            # (`_build_prescribed_pair` builds and runs both marginals
-            # together, rather than the oracle's one-at-a-time recomputation
-            # in `_oracle_marginal`), so the two can disagree in the last
-            # ULP even in float64 on one fixed JAX version -- a sweep of 51
-            # independently-drawn reference fixtures found the module's own
-            # acceptance rate for the higher marginal exceeding `highest` by
-            # exactly one ULP (e.g. 0.8137129940550802 vs
-            # 0.8137129940550795) in 3 of them, which flips that marginal to
-            # "accepted" when `uniform` sits exactly on the oracle's value.
-            # The midpoint of `(highest, 1.0)` rejects both marginals with a
-            # margin of `0.5 * (1.0 - highest)` -- order 0.1 here, many
-            # orders of magnitude past any ULP-level disagreement -- while
-            # `uniform = 0` already has an equally wide margin on the
-            # accepting side, so both branches are now robust by construction
-            # rather than by landing on the correct side of a knife edge.
+            # Reject with a margin, not at `highest`: oracle and module p_accept
+            # can disagree by 1 ULP, making `uniform = highest` a coin flip.
             uniform = jnp.asarray(0.0 if accept else 0.5 * (highest + 1.0), jnp.float64)
 
             new_state, info = step(state, noise, uniform)
@@ -863,22 +839,9 @@ class CoupledHMCContractTest(BlackJAXTest):
     def test_certain_acceptance_accepts_at_both_uniform_endpoints(self, uniform):
         """``p_accept == 1`` accepts for every admissible uniform in [0, 1).
 
-        A *small* step size does not make this hold: the leapfrog's energy
-        error is ``O(step_size**2)`` from truncation alone, not from
-        floating-point rounding, so with ``step_size = 1e-8`` the error sits
-        right at ~1e-16 with a sign that a seed sweep showed is essentially a
-        coin flip -- a prior version of this test drew its momentum from
-        ``self.next_key()`` (date-seeded) and, checked across 200 synthetic
-        "days", failed on 128 of them because `p_accept` rounded to fractionally
-        *below* 1 as often as not. `p_accept == 1` must instead hold BY
-        CONSTRUCTION: start at ``position = momentum = 0``. The standard
-        normal's gradient there is exactly ``0``, so every leapfrog half-step
-        multiplies a zero gradient into a zero update and the trajectory
-        stays bit-for-bit at the origin for any step size or step count.
-        Both endpoints' energies are then the same float64 value evaluated
-        twice, so their difference is exactly ``0.0`` -- not merely small --
-        and `p_accept` clips to exactly `1.0` regardless of JAX version or
-        operation ordering.
+        Pinned at a stationary point (position = momentum = 0, energy
+        difference exactly 0.0); a small step size alone left ~1e-16 sign
+        noise that failed 128/200 seeded days.
         """
         with _x64():
             if uniform is None:
@@ -898,9 +861,7 @@ class CoupledHMCContractTest(BlackJAXTest):
                 integrators.velocity_verlet,
                 1000.0,
             )
-            # Zero momentum, not a fresh draw: see the docstring above for
-            # why this is what pins `p_accept` at exactly 1.0.
-            noise = jnp.zeros((_DIM,), jnp.float64)
+            noise = jnp.zeros((_DIM,), jnp.float64)  # see docstring
             _, info = step(state, noise, jnp.asarray(uniform, jnp.float64))
             self.assertEqual(
                 float(info.acceptance_rate),
@@ -1455,40 +1416,7 @@ class CoupledHMCContractTest(BlackJAXTest):
 
         eager_state, eager_info = algorithm.step(key, state)
         jitted_state, jitted_info = jax.jit(algorithm.step)(key, state)
-        # Floating results are compared with a tolerance: XLA may fuse or
-        # reassociate under `jit`, so bitwise agreement with the eager path is
-        # not a contract this module can promise. `atol=1e-12` on the STATE
-        # was already too tight for that: a 300,000-seed sweep of this
-        # fixture found the accepted position differing by up to 2.861e-6
-        # (float32) between the two paths -- comfortably smaller than the
-        # state values themselves (roughly 0.3 to 11 over that same sweep,
-        # median ~1.9), so this is drift, not a real divergence.
-        # `chex.assert_trees_all_close` combines `atol` with a default
-        # `rtol=1e-6` (fails when `|actual - desired| > atol + rtol *
-        # |desired|`), so the two knobs interact: at `atol=1e-12` alone ~33%
-        # of the sweep's simulated days exceeded it, but the `rtol` term
-        # (about 1e-6 times an O(1) state value) rescued most of those,
-        # leaving 13/200 (6.5%) simulated days that failed the actual
-        # (combined) assertion -- `self.next_key()`'s date-seeded draw is one
-        # such day roughly one day in fifteen, which is what was actually
-        # breaking CI (main Tests run 34185840275 on pinned JAX failed at
-        # exactly this line). `atol=1e-4` is ~35x the measured 2.861e-6 gap
-        # and ~800 float32 ULP; perturbing the jitted state by 1e-2 (two
-        # orders above this atol) still trips the assertion, confirming the
-        # loosened check still catches a genuine divergence rather than
-        # merely tolerating drift.
-        #
-        # The same drift reaches the accept/reject DECISION itself, since it
-        # is a `<` comparison against exactly the float that may move: that
-        # same sweep found the acceptance rate differing by up to 3.815e-6
-        # for the second marginal, with no natural draw among them flipping
-        # either decision; an adversarial probe -- a uniform placed inside
-        # one such gap by construction, not drawn -- confirmed the gap really
-        # does flip `is_accepted` between the two paths. So the probability
-        # is compared with a tolerance (atol=1e-4, ~26x that measured gap)
-        # instead of asserting the boolean at `key`'s essentially arbitrary
-        # point, and decision coverage is restored below at a uniform held
-        # deliberately far from `p_accept` instead.
+        # atol=1e-4: ~35x measured float32 eager/jit drift (state 2.86e-6, rate 3.82e-6).
         chex.assert_trees_all_close(eager_state, jitted_state, atol=1e-4)
         chex.assert_trees_all_close(
             eager_info.first.acceptance_rate,
@@ -1503,13 +1431,8 @@ class CoupledHMCContractTest(BlackJAXTest):
         chex.assert_trees_all_equal_structs(eager_state, jitted_state)
         chex.assert_trees_all_equal_structs(eager_info, jitted_info)
 
-        # Decision coverage, without the knife edge: exercise accept/reject
-        # through the same prescribed-pair machinery `algorithm.step` is built
-        # from (`_build_prescribed_pair`), but with an explicit uniform held
-        # comfortably away from `p_accept` on either side, rather than at
-        # `key`'s arbitrary draw. `_JIT_MARGIN_SEED` is a fixed control (see
-        # its definition) chosen so both marginals' `p_accept` are interior
-        # here; the interiority is asserted rather than trusted.
+        # Decisions exercised through the same machinery, but with the uniform
+        # held far from p_accept. Interiority is asserted, not trusted.
         margin_step = coupled_hmc._build_prescribed_pair(
             (_standard_normal_logdensity, _tilted_logdensity),
             (mass, mass),
@@ -1521,8 +1444,7 @@ class CoupledHMCContractTest(BlackJAXTest):
             coupled_hmc.whitened_difference,
         )
         margin_noise = jax.random.normal(jax.random.key(_JIT_MARGIN_SEED), (_DIM,))
-        # `acceptance_rate` does not depend on the uniform supplied, so this
-        # placeholder call only reads off `p_accept` for both marginals.
+        # acceptance_rate is independent of the uniform; this only reads p_accept.
         _, rate_probe_info = margin_step(state, margin_noise, jnp.asarray(0.5))
         first_p_accept = float(rate_probe_info.first.acceptance_rate)
         second_p_accept = float(rate_probe_info.second.acceptance_rate)
@@ -1540,11 +1462,7 @@ class CoupledHMCContractTest(BlackJAXTest):
                 "choose a different `_JIT_MARGIN_SEED`",
             )
         highest = max(first_p_accept, second_p_accept)
-        # `uniform = 0` accepts both marginals with a margin of a whole
-        # probability; `uniform = 0.5 * (highest + 1.0)` rejects both with a
-        # margin of `0.5 * (1 - highest)` -- see the `reflect_reject` fixture
-        # above for why the rejecting case is built from `highest` and not
-        # pinned to either marginal's own probability directly.
+        # Same margin construction as reflect_reject above.
         for uniform, expect_accepted in (
             (jnp.asarray(0.0), True),
             (jnp.asarray(0.5 * (highest + 1.0)), False),

--- a/tests/mcmc/test_laps_nan_survival.py
+++ b/tests/mcmc/test_laps_nan_survival.py
@@ -11,25 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Regression tests for the LAPS nightly NaN-death defect (two-piece fix).
+"""Regression tests for the LAPS silent NaN death (#1035).
 
-D1 (blackjax/mcmc/mclmc.py, handle_nans): a NaN kinetic_change / energy_change
-paired with an otherwise-finite proposed state (position, momentum,
-logdensity) used to pass the kernel's own NaN gate silently. Root cause:
-`momentum_proj` in the isokinetic integrator is a dot product of two unit
-vectors that can round marginally below -1 in float32, driving
-`jnp.log(1 + momentum_proj + (1 - momentum_proj) * zeta**2)` negative. In an
-ECA ensemble (LAPS burn-in), one such chain contaminates every chain's summary
-statistics via `lax.psum`.
-
-D2 (blackjax/adaptation/laps_burn_in.py, Adaptation.update): the adapted step
-size is updated multiplicatively (`step_size * eps_factor`), so a single
-non-finite `eps_factor` -- from D1 or from any other undetected route -- is
-absorbing: once step_size is NaN it stays NaN for the rest of burn-in, and
-LAPS silently returns a frozen, un-equilibrated ensemble with no error and no
-warning.
-
-Both tests below fail on pre-fix `main` and pass after the fix.
+D1: the NaN gate must cover kinetic/energy change, not just state.
+D2: a non-finite eps_factor must not permanently kill the step size.
 """
 import jax
 import jax.numpy as jnp
@@ -50,22 +35,11 @@ def _finite_state(dim=_DIM):
     )
 
 
-# ---------------------------------------------------------------------------
-# D1 -- the NaN gate must also cover kinetic_change / energy_change
-# ---------------------------------------------------------------------------
-
-
 def test_handle_nans_catches_nan_kinetic_change_with_finite_state():
-    """A NaN kinetic_change/energy_change with an otherwise-finite proposed
-    state must be flagged and reverted, exactly like a NaN position or a NaN
-    logdensity. Pre-D1, `info.nonans` looked only at position/momentum/
-    logdensity, so this route passed the gate silently (nonans=True) and a
-    single such chain could poison an ECA ensemble average with no warning.
-    """
+    """A NaN kinetic/energy change with an otherwise-finite state must be
+    flagged and reverted; pre-D1 the gate never looked past position,
+    momentum and logdensity, so this route passed silently (nonans=True)."""
     previous_state = _finite_state()
-    # The proposed state itself is entirely finite -- only the energy
-    # accounting is broken, exactly as measured in the LAPS nightly trace
-    # (kinetic_change=NaN while position/momentum/logdensity stayed finite).
     next_state = _finite_state()
     info = MCLMCInfo(
         logdensity=next_state.logdensity,
@@ -74,51 +48,11 @@ def test_handle_nans_catches_nan_kinetic_change_with_finite_state():
         nonans=True,
     )
 
-    new_state, new_info = handle_nans(
-        previous_state, next_state, info, jax.random.key(0)
-    )
+    _, new_info = handle_nans(previous_state, next_state, info, jax.random.key(0))
 
-    assert not bool(new_info.nonans), (
-        "a NaN kinetic_change/energy_change must be flagged even when "
-        "position, momentum and logdensity are all finite"
-    )
-    assert jnp.isfinite(new_info.energy_change), "reverted energy_change must be finite"
-    assert jnp.isfinite(
-        new_info.kinetic_change
-    ), "reverted kinetic_change must be finite"
-    assert jnp.array_equal(
-        new_state.position, previous_state.position
-    ), "a flagged step must revert position to the previous state"
-
-
-def test_handle_nans_healthy_state_unaffected():
-    """Control: a fully finite proposed step (including kinetic/energy
-    change) is unaffected by the D1 change -- proves the extended gate is a
-    strict-superset check, not a behavior change on healthy steps.
-    """
-    previous_state = _finite_state()
-    next_state = _finite_state()
-    info = MCLMCInfo(
-        logdensity=next_state.logdensity,
-        kinetic_change=jnp.array(0.1),
-        energy_change=jnp.array(0.05),
-        nonans=True,
-    )
-
-    new_state, new_info = handle_nans(
-        previous_state, next_state, info, jax.random.key(0)
-    )
-
-    assert bool(new_info.nonans)
-    assert new_info.energy_change == info.energy_change
-    assert new_info.kinetic_change == info.kinetic_change
-    assert jnp.array_equal(new_state.position, next_state.position)
-
-
-# ---------------------------------------------------------------------------
-# D2 -- the adapted step size must stay finite even if some other route
-# produces a non-finite eps_factor
-# ---------------------------------------------------------------------------
+    assert not bool(new_info.nonans)
+    assert jnp.isfinite(new_info.energy_change)
+    assert jnp.isfinite(new_info.kinetic_change)
 
 
 def _adaptation_state(step_size, ndims=_DIM):
@@ -144,51 +78,25 @@ def _etheta(ndims=_DIM, E=0.0, Esq=0.0, rejection_rate_nans=0.0):
         "E": jnp.asarray(E),
         "Esq": jnp.asarray(Esq),
         "rejection_rate_nans": jnp.asarray(rejection_rate_nans),
-        # Non-zero so contract_history's r = (avg_sq - sq_avg) / sq_avg does
-        # not divide 0/0 -- keeps the "healthy" control path itself finite so
-        # it exercises the same eps_factor arithmetic as a real run.
-        "observables_for_bias": jnp.full((ndims,), 2.0),
+        "observables_for_bias": jnp.full(
+            (ndims,), 2.0
+        ),  # non-zero: avoids 0/0 in contract_history
         "observables": jnp.zeros(()),
         "entropy": jnp.zeros(()),
     }
 
 
 def test_step_size_survives_undetected_nan_route():
-    """D2 must stand on its own: even when `rejection_rate_nans` is 0 (no
-    chain was flagged -- simulating a route D1 does not cover), a NaN
-    summary statistic that drives `eps_factor` non-finite must not poison the
-    step size. This is the invariant that lets LAPS survive a poisoned
-    iteration instead of freezing for the rest of its budget.
-    """
+    """D2 must stand on its own: even with rejection_rate_nans=0 (a route D1
+    does not itself close), a NaN E/Esq driving eps_factor non-finite must
+    fall back to the previous step size rather than corrupt it forever."""
     adap_state, adaptation = _adaptation_state(step_size=0.05)
-    # E/Esq are NaN (as ECA's lax.psum would produce from one poisoned chain)
-    # while rejection_rate_nans reports clean -- the D1 failure mode, tested
-    # here in isolation from D1's own fix.
     etheta = _etheta(E=jnp.nan, Esq=jnp.nan, rejection_rate_nans=0.0)
 
     new_state, _ = adaptation.update(adap_state, etheta)
 
-    assert jnp.isfinite(
-        new_state.step_size
-    ), f"step size must stay finite, got {float(new_state.step_size)}"
-    assert new_state.step_size == jnp.float32(0.05), (
-        "on an undetected non-finite route, step size should fall back to "
-        "the previous (finite) value rather than being corrupted, got "
-        f"{float(new_state.step_size)}"
-    )
-
-
-def test_step_size_healthy_update_unaffected():
-    """Control: a normal, fully-finite update produces a finite, moved step
-    size -- proves the D2 fallback changes nothing on a healthy iteration.
-    """
-    adap_state, adaptation = _adaptation_state(step_size=0.05)
-    etheta = _etheta(E=0.1, Esq=0.02, rejection_rate_nans=0.0)
-
-    new_state, _ = adaptation.update(adap_state, etheta)
-
     assert jnp.isfinite(new_state.step_size)
-    assert float(new_state.step_size) != 0.05  # the update actually moved it
+    assert new_state.step_size == jnp.float32(0.05)
 
 
 def test_step_size_still_halves_on_reported_nan():

--- a/tests/mcmc/test_laps_nan_survival.py
+++ b/tests/mcmc/test_laps_nan_survival.py
@@ -1,0 +1,202 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for the LAPS nightly NaN-death defect (two-piece fix).
+
+D1 (blackjax/mcmc/mclmc.py, handle_nans): a NaN kinetic_change / energy_change
+paired with an otherwise-finite proposed state (position, momentum,
+logdensity) used to pass the kernel's own NaN gate silently. Root cause:
+`momentum_proj` in the isokinetic integrator is a dot product of two unit
+vectors that can round marginally below -1 in float32, driving
+`jnp.log(1 + momentum_proj + (1 - momentum_proj) * zeta**2)` negative. In an
+ECA ensemble (LAPS burn-in), one such chain contaminates every chain's summary
+statistics via `lax.psum`.
+
+D2 (blackjax/adaptation/laps_burn_in.py, Adaptation.update): the adapted step
+size is updated multiplicatively (`step_size * eps_factor`), so a single
+non-finite `eps_factor` -- from D1 or from any other undetected route -- is
+absorbing: once step_size is NaN it stays NaN for the rest of burn-in, and
+LAPS silently returns a frozen, un-equilibrated ensemble with no error and no
+warning.
+
+Both tests below fail on pre-fix `main` and pass after the fix.
+"""
+import jax
+import jax.numpy as jnp
+
+from blackjax.adaptation.laps_burn_in import Adaptation, AdaptationState
+from blackjax.mcmc.integrators import IntegratorState
+from blackjax.mcmc.mclmc import MCLMCInfo, handle_nans
+
+_DIM = 2
+
+
+def _finite_state(dim=_DIM):
+    return IntegratorState(
+        position=jnp.zeros(dim),
+        momentum=jnp.ones(dim) / jnp.sqrt(dim),
+        logdensity=jnp.array(-1.0),
+        logdensity_grad=jnp.zeros(dim),
+    )
+
+
+# ---------------------------------------------------------------------------
+# D1 -- the NaN gate must also cover kinetic_change / energy_change
+# ---------------------------------------------------------------------------
+
+
+def test_handle_nans_catches_nan_kinetic_change_with_finite_state():
+    """A NaN kinetic_change/energy_change with an otherwise-finite proposed
+    state must be flagged and reverted, exactly like a NaN position or a NaN
+    logdensity. Pre-D1, `info.nonans` looked only at position/momentum/
+    logdensity, so this route passed the gate silently (nonans=True) and a
+    single such chain could poison an ECA ensemble average with no warning.
+    """
+    previous_state = _finite_state()
+    # The proposed state itself is entirely finite -- only the energy
+    # accounting is broken, exactly as measured in the LAPS nightly trace
+    # (kinetic_change=NaN while position/momentum/logdensity stayed finite).
+    next_state = _finite_state()
+    info = MCLMCInfo(
+        logdensity=next_state.logdensity,
+        kinetic_change=jnp.nan,
+        energy_change=jnp.nan,
+        nonans=True,
+    )
+
+    new_state, new_info = handle_nans(
+        previous_state, next_state, info, jax.random.key(0)
+    )
+
+    assert not bool(new_info.nonans), (
+        "a NaN kinetic_change/energy_change must be flagged even when "
+        "position, momentum and logdensity are all finite"
+    )
+    assert jnp.isfinite(new_info.energy_change), "reverted energy_change must be finite"
+    assert jnp.isfinite(
+        new_info.kinetic_change
+    ), "reverted kinetic_change must be finite"
+    assert jnp.array_equal(
+        new_state.position, previous_state.position
+    ), "a flagged step must revert position to the previous state"
+
+
+def test_handle_nans_healthy_state_unaffected():
+    """Control: a fully finite proposed step (including kinetic/energy
+    change) is unaffected by the D1 change -- proves the extended gate is a
+    strict-superset check, not a behavior change on healthy steps.
+    """
+    previous_state = _finite_state()
+    next_state = _finite_state()
+    info = MCLMCInfo(
+        logdensity=next_state.logdensity,
+        kinetic_change=jnp.array(0.1),
+        energy_change=jnp.array(0.05),
+        nonans=True,
+    )
+
+    new_state, new_info = handle_nans(
+        previous_state, next_state, info, jax.random.key(0)
+    )
+
+    assert bool(new_info.nonans)
+    assert new_info.energy_change == info.energy_change
+    assert new_info.kinetic_change == info.kinetic_change
+    assert jnp.array_equal(new_state.position, next_state.position)
+
+
+# ---------------------------------------------------------------------------
+# D2 -- the adapted step size must stay finite even if some other route
+# produces a non-finite eps_factor
+# ---------------------------------------------------------------------------
+
+
+def _adaptation_state(step_size, ndims=_DIM):
+    adaptation = Adaptation(ndims=ndims, microcanonical=True)
+    state = AdaptationState(
+        L=jnp.inf,
+        inverse_mass_matrix=jnp.ones(ndims),
+        step_size=step_size,
+        step_count=0,
+        EEVPD=1e-3,
+        EEVPD_wanted=1e-3,
+        history=adaptation.initial_state.history,
+    )
+    return state, adaptation
+
+
+def _etheta(ndims=_DIM, E=0.0, Esq=0.0, rejection_rate_nans=0.0):
+    return {
+        "equipartition_diagonal": jnp.zeros(ndims),
+        "equipartition_fullrank": jnp.zeros((100, ndims)),
+        "x": jnp.zeros(ndims),
+        "xsq": jnp.ones(ndims),
+        "E": jnp.asarray(E),
+        "Esq": jnp.asarray(Esq),
+        "rejection_rate_nans": jnp.asarray(rejection_rate_nans),
+        # Non-zero so contract_history's r = (avg_sq - sq_avg) / sq_avg does
+        # not divide 0/0 -- keeps the "healthy" control path itself finite so
+        # it exercises the same eps_factor arithmetic as a real run.
+        "observables_for_bias": jnp.full((ndims,), 2.0),
+        "observables": jnp.zeros(()),
+        "entropy": jnp.zeros(()),
+    }
+
+
+def test_step_size_survives_undetected_nan_route():
+    """D2 must stand on its own: even when `rejection_rate_nans` is 0 (no
+    chain was flagged -- simulating a route D1 does not cover), a NaN
+    summary statistic that drives `eps_factor` non-finite must not poison the
+    step size. This is the invariant that lets LAPS survive a poisoned
+    iteration instead of freezing for the rest of its budget.
+    """
+    adap_state, adaptation = _adaptation_state(step_size=0.05)
+    # E/Esq are NaN (as ECA's lax.psum would produce from one poisoned chain)
+    # while rejection_rate_nans reports clean -- the D1 failure mode, tested
+    # here in isolation from D1's own fix.
+    etheta = _etheta(E=jnp.nan, Esq=jnp.nan, rejection_rate_nans=0.0)
+
+    new_state, _ = adaptation.update(adap_state, etheta)
+
+    assert jnp.isfinite(
+        new_state.step_size
+    ), f"step size must stay finite, got {float(new_state.step_size)}"
+    assert new_state.step_size == jnp.float32(0.05), (
+        "on an undetected non-finite route, step size should fall back to "
+        "the previous (finite) value rather than being corrupted, got "
+        f"{float(new_state.step_size)}"
+    )
+
+
+def test_step_size_healthy_update_unaffected():
+    """Control: a normal, fully-finite update produces a finite, moved step
+    size -- proves the D2 fallback changes nothing on a healthy iteration.
+    """
+    adap_state, adaptation = _adaptation_state(step_size=0.05)
+    etheta = _etheta(E=0.1, Esq=0.02, rejection_rate_nans=0.0)
+
+    new_state, _ = adaptation.update(adap_state, etheta)
+
+    assert jnp.isfinite(new_state.step_size)
+    assert float(new_state.step_size) != 0.05  # the update actually moved it
+
+
+def test_step_size_still_halves_on_reported_nan():
+    """Control: the pre-existing eps_factor=0.5 safety (rejection_rate_nans
+    > 0) is untouched by the D2 fallback."""
+    adap_state, adaptation = _adaptation_state(step_size=100.0)
+    etheta = _etheta(rejection_rate_nans=1.0)
+
+    new_state, _ = adaptation.update(adap_state, etheta)
+
+    assert jnp.isclose(new_state.step_size, 50.0, rtol=1e-5)

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -788,6 +788,13 @@ class LinearRegressionTest(chex.TestCase):
         # meaning nothing.
         for phase in ("phase_1", "phase_2"):
             step_sizes = np.asarray(info[phase]["step_size"])
+            # Precomputed into a plain variable rather than nested inline in the
+            # f-string below: the pinned flake8 6.0.0 / pycodestyle 2.10.0 (see
+            # .pre-commit-config.yaml) misreads a semicolon inside a multi-brace
+            # f-string as a statement separator (E702) under CPython's PEP 701
+            # f-string tokenizer (landed in 3.12, so this reproduces on CI's own
+            # Python versions -- not merely a newer-interpreter artifact). Do not
+            # inline this back into the f-string.
             first_bad_iter = int(np.argmax(~np.isfinite(step_sizes)))
             msg = (
                 f"{phase}: adapted step size became non-finite at iteration "
@@ -813,6 +820,12 @@ class LinearRegressionTest(chex.TestCase):
         np.testing.assert_array_less(0.5, sd_ratio)
 
         equilibrated = np.mean(np.all(np.abs(z_scores) < 6.0, axis=1))
+        # Deliberately not f"{equilibrated:.0%}": the pinned flake8 6.0.0 /
+        # pycodestyle 2.10.0 misparses the ':' of an f-string percent-format
+        # spec as "missing whitespace after ':'" (E231) under CPython's PEP 701
+        # f-string tokenizer. Reproduces on 3.11/3.12/3.13 (CI's own matrix),
+        # not just newer interpreters -- confirmed independently twice. If you
+        # "simplify" this back to a format spec, CI's lint job will fail.
         equilibrated_pct = round(100 * equilibrated)
         assert equilibrated >= 0.9, (
             f"only {equilibrated_pct}% of chains are within 6 posterior sd of "

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -769,49 +769,30 @@ class LinearRegressionTest(chex.TestCase):
             superchain_size=1,
         )
 
-        # ``final_state`` is the ENSEMBLE at the final step -- one draw per chain,
-        # not a time series -- so the checks below are over 100 draws.
+        # ``final_state`` is the ensemble at the final step: one draw per chain.
         ensemble = np.asarray(final_state.position)
 
-        # Reference posterior for this fixed dataset, from an independent 4-chain
-        # NUTS run (1000 warmup + 5000 draws per chain, no divergences, R-hat
-        # 1.00003, ESS ~1.6e4): log_scale ~ (0.0325, sd 0.0224); coefs ~ (3.0135,
-        # sd 0.0335). With 1000 observations the posterior is extremely tight, so a
-        # converged ensemble is a narrow cloud around these values.
+        # Reference posterior: independent 4-chain NUTS, R-hat 1.00003, ESS ~1.6e4. See #1035.
         posterior_mean = np.array([0.0325, 3.0135])
         posterior_sd = np.array([0.0224, 0.0335])
 
-        # Check the adaptation stayed alive before interpreting any draws. If the
-        # adapted step size ever becomes non-finite, every subsequent proposal is
-        # rejected and LAPS returns a frozen, un-equilibrated ensemble -- with no
-        # error and no NaN in the positions -- so the draws look plausible while
-        # meaning nothing.
+        # A non-finite step size means the rest of the budget ran as no-ops; gate on it first.
         for phase in ("phase_1", "phase_2"):
             step_sizes = np.asarray(info[phase]["step_size"])
-            # Precomputed into a plain variable rather than nested inline in the
-            # f-string below: the pinned flake8 6.0.0 / pycodestyle 2.10.0 (see
-            # .pre-commit-config.yaml) misreads a semicolon inside a multi-brace
-            # f-string as a statement separator (E702) under CPython's PEP 701
-            # f-string tokenizer (landed in 3.12, so this reproduces on CI's own
-            # Python versions -- not merely a newer-interpreter artifact). Do not
-            # inline this back into the f-string.
-            first_bad_iter = int(np.argmax(~np.isfinite(step_sizes)))
-            msg = (
-                f"{phase}: adapted step size became non-finite at iteration "
-                f"{first_bad_iter} of {step_sizes.size}, "
-                "the rest of the budget ran as no-ops"
+            first_bad_iter = int(
+                np.argmax(~np.isfinite(step_sizes))
+            )  # not inlined: pycodestyle 2.10.0 E702 on PEP 701 f-strings (3.12+)
+            assert np.all(np.isfinite(step_sizes)), (
+                f"{phase}: step size became non-finite at iteration "
+                f"{first_bad_iter} of {step_sizes.size}"
             )
-            assert np.all(np.isfinite(step_sizes)), msg
         mean_acceptance = float(np.mean(np.asarray(info["phase_2"]["acc_prob"])))
         assert (
             mean_acceptance > 0.01
         ), f"adjusted phase accepted nothing (mean acceptance {mean_acceptance})"
 
-        # The ensemble must look like a sample from that posterior: right location,
-        # right dispersion, and no chain left behind. Location is checked on the
-        # median so that one stray chain cannot carry the verdict, and dispersion is
-        # checked on both sides so that an ensemble which never moved (the initial
-        # draws have sd 1.0) fails just as loudly as one that scattered.
+        # Median location (robust to one stray chain) and two-sided dispersion
+        # (an ensemble that never moved has sd 1.0, not ~0.02).
         z_scores = (ensemble - posterior_mean) / posterior_sd
         np.testing.assert_array_less(np.abs(np.median(z_scores, axis=0)), 6.0)
 
@@ -820,17 +801,11 @@ class LinearRegressionTest(chex.TestCase):
         np.testing.assert_array_less(0.5, sd_ratio)
 
         equilibrated = np.mean(np.all(np.abs(z_scores) < 6.0, axis=1))
-        # Deliberately not f"{equilibrated:.0%}": the pinned flake8 6.0.0 /
-        # pycodestyle 2.10.0 misparses the ':' of an f-string percent-format
-        # spec as "missing whitespace after ':'" (E231) under CPython's PEP 701
-        # f-string tokenizer. Reproduces on 3.11/3.12/3.13 (CI's own matrix),
-        # not just newer interpreters -- confirmed independently twice. If you
-        # "simplify" this back to a format spec, CI's lint job will fail.
+        # not f"{x:.0%}": pycodestyle 2.10.0 flags E231 on PEP 701 f-strings
         equilibrated_pct = round(100 * equilibrated)
-        assert equilibrated >= 0.9, (
-            f"only {equilibrated_pct}% of chains are within 6 posterior sd of "
-            "the posterior mean in both coordinates"
-        )
+        assert (
+            equilibrated >= 0.9
+        ), f"only {equilibrated_pct}% of chains are within 6 posterior sd"
 
     @parameterized.named_parameters(
         {"testcase_name": "typed_key", "use_typed_key": True},

--- a/tests/mcmc/test_sampling.py
+++ b/tests/mcmc/test_sampling.py
@@ -769,14 +769,55 @@ class LinearRegressionTest(chex.TestCase):
             superchain_size=1,
         )
 
-        scale_samples = np.exp(final_state.position[:, 0])
-        coefs_samples = final_state.position[:, 1]
+        # ``final_state`` is the ENSEMBLE at the final step -- one draw per chain,
+        # not a time series -- so the checks below are over 100 draws.
+        ensemble = np.asarray(final_state.position)
 
-        print(np.mean(scale_samples))
-        print(np.mean(coefs_samples))
+        # Reference posterior for this fixed dataset, from an independent 4-chain
+        # NUTS run (1000 warmup + 5000 draws per chain, no divergences, R-hat
+        # 1.00003, ESS ~1.6e4): log_scale ~ (0.0325, sd 0.0224); coefs ~ (3.0135,
+        # sd 0.0335). With 1000 observations the posterior is extremely tight, so a
+        # converged ensemble is a narrow cloud around these values.
+        posterior_mean = np.array([0.0325, 3.0135])
+        posterior_sd = np.array([0.0224, 0.0335])
 
-        np.testing.assert_allclose(np.mean(scale_samples), 1.0, atol=1e-1)
-        np.testing.assert_allclose(np.mean(coefs_samples), 3.0, atol=1e-1)
+        # Check the adaptation stayed alive before interpreting any draws. If the
+        # adapted step size ever becomes non-finite, every subsequent proposal is
+        # rejected and LAPS returns a frozen, un-equilibrated ensemble -- with no
+        # error and no NaN in the positions -- so the draws look plausible while
+        # meaning nothing.
+        for phase in ("phase_1", "phase_2"):
+            step_sizes = np.asarray(info[phase]["step_size"])
+            first_bad_iter = int(np.argmax(~np.isfinite(step_sizes)))
+            msg = (
+                f"{phase}: adapted step size became non-finite at iteration "
+                f"{first_bad_iter} of {step_sizes.size}, "
+                "the rest of the budget ran as no-ops"
+            )
+            assert np.all(np.isfinite(step_sizes)), msg
+        mean_acceptance = float(np.mean(np.asarray(info["phase_2"]["acc_prob"])))
+        assert (
+            mean_acceptance > 0.01
+        ), f"adjusted phase accepted nothing (mean acceptance {mean_acceptance})"
+
+        # The ensemble must look like a sample from that posterior: right location,
+        # right dispersion, and no chain left behind. Location is checked on the
+        # median so that one stray chain cannot carry the verdict, and dispersion is
+        # checked on both sides so that an ensemble which never moved (the initial
+        # draws have sd 1.0) fails just as loudly as one that scattered.
+        z_scores = (ensemble - posterior_mean) / posterior_sd
+        np.testing.assert_array_less(np.abs(np.median(z_scores, axis=0)), 6.0)
+
+        sd_ratio = ensemble.std(axis=0) / posterior_sd
+        np.testing.assert_array_less(sd_ratio, 2.0)
+        np.testing.assert_array_less(0.5, sd_ratio)
+
+        equilibrated = np.mean(np.all(np.abs(z_scores) < 6.0, axis=1))
+        equilibrated_pct = round(100 * equilibrated)
+        assert equilibrated >= 0.9, (
+            f"only {equilibrated_pct}% of chains are within 6 posterior sd of "
+            "the posterior mean in both coordinates"
+        )
 
     @parameterized.named_parameters(
         {"testcase_name": "typed_key", "use_typed_key": True},


### PR DESCRIPTION
Fixes the JAX Nightly workflow (red since 2026-09-04) and the main Tests workflow (red since #1034). Two unrelated defects. Closes #1035.

## 1. LAPS silently returned a frozen ensemble (~13-18% of runs)

One chain in 100 produces a NaN `kinetic_change` with position, momentum and logdensity all finite, so it passes the kernel's NaN gate. ECA's `lax.psum` spreads it to all 100 chains, and because the step-size update is *multiplicative*, the resulting NaN is absorbing (`NaN * 0.5 = NaN`). The rest of burn-in and all of phase 2 then run as no-ops, and `laps()` returns finite positions and raises nothing.

Not a JAX regression: a **+1 ULP perturbation of `y_data`** at the test's own seed, on pinned JAX, reproduces the nightly value exactly.

| | before | after | truth |
|---|---|---|---|
| `mean(exp(log_scale))` | 1.963126 | 1.033710 | 1.033311 |
| `mean(coefs)` | 1.48013 | 3.01084 | 3.013491 |
| non-finite step size | 11/60 | **0/60** | — |

- **D1** (`mclmc.py`) — the NaN gate also requires `isfinite(kinetic_change)` and `isfinite(energy_change)`. `isfinite` not `isnan`: `zeta` underflows to exactly `0.0` on ~0.9% of momentum updates, so `log(0) = -inf` is a real second route.
- **D2** (`laps_burn_in.py`) — a non-finite step-size factor falls back to the last finite value, so no route to a NaN step size is absorbing.

Isolated by a four-arm sweep: base 11/60, D1-only 0/60, D2-only 0/60, both 0/60. Either alone fixes every observed route; kept together as defence in depth. Healthy runs are bit-identical (`np.array_equal` on the full ensemble and the 1000-element step-size trace).

Root cause is one arithmetic event: `momentum_proj = -(1 + 2^-23)`, one float32 ulp below `-1`, in `integrators.py:470-473`. The source-level fix is **#1038** — deliberately not done here, because the obvious clamp leaves up to 19 nats of silent error. These guards are the backstop and should land either way.

## 2. `test_laps`'s assertion could not fail

It asserted `mean(exp(log_scale)) ~ 1.0` at `atol=1e-1` against a true posterior mean of **1.0333**, leaving ~30 standard errors of slack — it could only fail on an outlier, which is why it missed this defect for as long as it existed.

Replaced with a liveness gate (step size finite, phase-2 acceptance > 0) plus median-location and two-sided-dispersion checks against the reference posterior. The dispersion check is load-bearing: initial draws are `N(0, 1)`, so location alone passes a sampler that never ran.

Known limits: it starts failing at ~12% systematic scale bias where the old one failed at ~8%; and after D2 the `phase_1` half of the step-size gate is a tautology (`phase_2` is not). Both recorded in the review, neither reopens the targeted defect.

## 3. Three `coupled_hmc` tests compared floats across a decision boundary

These broke `main`, not just nightly — `BlackJAXTest` seeds from `datetime.date.today()`, so a different subset failed each day.

- `marginals_match_an_independent_reference`: `uniform = highest` sat exactly on the *oracle's* `p_accept`, which can differ from the module's by 1 ULP (3/51 fixtures). Now rejects at a margin.
- `certain_acceptance`: assumed a small step size makes `p_accept == 1`; truncation error is `O(step^2)` with arbitrary sign, failing 128/200 days. Now exact by construction. (Coverage caveat: **#1037**.)
- `jit_vmap_and_scan`: two defects. The dominant one was `atol=1e-12` on the state — too tight for float32, and what CI actually hit (run 34185840275); failed 13/200 days. Tolerances now justified against measured drift, with decision coverage kept off the knife edge.

## Verification

Every hardened assertion carries a mutation control proving it still fails on an injected defect. Reviewed by a two-arm adversarial pass (math/numerics, test-integrity), each reproducing from a clean checkout in its own worktree: full suite 1992 passed / 11 skipped / 0 failed, pre-commit clean, 8/8 CI checks green on 3.11/3.12/3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
